### PR TITLE
Write intermediate 'as roll' results to binary files instead of the DB

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Spine Project consortium <spine_info@vtt.fi>"]
 version = "0.6.9"
 
 [deps]
+Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"
 Cbc = "9961bab8-2fa3-5c5a-9d89-47fab24efd76"
 Clp = "e2554f3b-3117-50c0-817c-e040a3ddf72d"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"

--- a/Project.toml
+++ b/Project.toml
@@ -18,5 +18,5 @@ Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 SpineInterface = "0cda1612-498a-11e9-3c92-77fa82595a4f"
 
 [compat]
-SpineInterface = "0.9.0"
+SpineInterface = "0.9.2"
 julia = "^1.2"

--- a/docs/src/library.md
+++ b/docs/src/library.md
@@ -19,6 +19,7 @@ Depth = 3
 
 ```@docs
 run_spineopt
+write_report_from_intermediate_results
 generate_forced_availability_factor
 ```
 

--- a/src/SpineOpt.jl
+++ b/src/SpineOpt.jl
@@ -39,8 +39,9 @@ export prepare_spineopt
 export refresh_model!
 export run_spineopt_kernel!
 export output_value
-export write_report
 export collect_output_values
+export write_report
+export write_report_from_intermediate_results
 export generate_forced_availability_factor
 export forced_availability_factor_time_series
 

--- a/src/SpineOpt.jl
+++ b/src/SpineOpt.jl
@@ -27,6 +27,7 @@ using JSON
 using Printf
 using Requires
 using JuMP
+using Arrow
 import DataStructures: OrderedDict
 import Dates: CompoundPeriod
 import LinearAlgebra: BLAS.gemm, LAPACK.getri!, LAPACK.getrf!

--- a/src/data_structure/preprocess_data_structure.jl
+++ b/src/data_structure/preprocess_data_structure.jl
@@ -366,10 +366,12 @@ function _ptdf_unfiltered_values()
     )
     Dict(
         (conn, n) => Dict(
-            :ptdf_unfiltered => indexed_parameter_value(
-                Dict(
-                    ind => get(ptdf_by_ind, ind, ptdf_by_ind[:nothing])[i, j]
-                    for (ind, val) in indexed_values(connection_availability_factor(connection=conn))
+            :ptdf_unfiltered => parameter_value(
+                collect_indexed_values(
+                    Dict(
+                        ind => get(ptdf_by_ind, ind, ptdf_by_ind[:nothing])[i, j]
+                        for (ind, val) in indexed_values(connection_availability_factor(connection=conn))
+                    )
                 )
             )
         )

--- a/src/objective/total_costs.jl
+++ b/src/objective/total_costs.jl
@@ -24,29 +24,31 @@ Expression corresponding to the sume of all cost terms for given model, and up u
 """
 total_costs(m, t_range) = sum(eval(term)(m, t_range) for term in objective_terms(m))
 
+const invest_terms = [:unit_investment_costs, :connection_investment_costs, :storage_investment_costs]
+const op_terms = [
+    :variable_om_costs,
+    :fixed_om_costs,
+    :taxes,
+    :fuel_costs,
+    :start_up_costs,
+    :shut_down_costs,
+    :objective_penalties,
+    :connection_flow_costs,
+    :renewable_curtailment_costs,
+    :res_proc_costs,
+    :ramp_costs,
+    :units_on_costs,
+]
+const all_objective_terms = [op_terms; invest_terms]
+
 function objective_terms(m)
     # FIXME: this could just be Benders defining the objective function itself
     # if we have a decomposed structure, master problem costs (investments) should not be included
-    invest_terms = [:unit_investment_costs, :connection_investment_costs, :storage_investment_costs]
-    op_terms = [
-        :variable_om_costs,
-        :fixed_om_costs,
-        :taxes,
-        :fuel_costs,
-        :start_up_costs,
-        :shut_down_costs,
-        :objective_penalties,
-        :connection_flow_costs,
-        :renewable_curtailment_costs,
-        :res_proc_costs,
-        :ramp_costs,
-        :units_on_costs,
-    ]
     if model_type(model=m.ext[:spineopt].instance) in (:spineopt_standard, :spineopt_mga)
         if m.ext[:spineopt].is_subproblem
             op_terms
         else
-            [op_terms; invest_terms]
+            all_objective_terms
         end
     elseif model_type(model=m.ext[:spineopt].instance) == :spineopt_benders_master
         invest_terms

--- a/src/run_spineopt.jl
+++ b/src/run_spineopt.jl
@@ -413,7 +413,11 @@ struct SpineOptExt
     objective_lower_bound::Float64
     objective_upper_bound::Float64
     benders_gap::Float64
+    arrow_results_folder::String
+    arrow_results::Dict
     function SpineOptExt(instance, lp_solver, is_subproblem)
+        arrow_results_folder = tempname(; cleanup=false)
+        mkpath(arrow_results_folder)
         new(
             instance,
             lp_solver,
@@ -431,6 +435,8 @@ struct SpineOptExt
             0.0,
             0.0,
             0.0,
+            arrow_results_folder,
+            Dict()
         )
     end
 end

--- a/src/run_spineopt_standard.jl
+++ b/src/run_spineopt_standard.jl
@@ -656,10 +656,10 @@ function _write_intermediate_results(m)
         @info """
         Intermediate results are being written to $(m.ext[:spineopt].intermediate_results_folder).
 
-        In case your run terminates unexpectedly - before these results can be written to the output DB -
-        you can rescue them by running
+        These results will be cleared automatically when written to the DB.
+        However if your run fails before this can happen, you can write them manually by running
 
-            write_report_from_intermediate_results("$(m.ext[:spineopt].intermediate_results_folder)", url_out)
+            write_report_from_intermediate_results(raw"$(m.ext[:spineopt].intermediate_results_folder)", url_out)
 
         """
         open(file_path, "w") do f

--- a/src/run_spineopt_standard.jl
+++ b/src/run_spineopt_standard.jl
@@ -57,7 +57,7 @@ function rerun_spineopt!(
         showerror(stdout, err, catch_backtrace())
         m
     finally
-        _write_report_from_arrow_results(m, url_out; alternative=alternative, log_level=log_level)
+        write_report_from_intermediate_results(m, url_out; alternative=alternative, log_level=log_level)
     end
 end
 
@@ -119,7 +119,8 @@ function _add_variables!(m; add_user_variables=m -> nothing, log_level=3)
 end
 
 """
-Initialize all variables in the given model to the values computed by the corresponding `initial_value` parameter, if any.
+Initialize all variables in the given model to the values computed by the corresponding `initial_value` parameter,
+if any.
 """
 function _init_variables!(m::Model)
     for (name, definition) in m.ext[:spineopt].variables_definition
@@ -287,7 +288,7 @@ function run_spineopt_kernel!(
         @log log_level 1 "\nWindow $k: $(current_window(m))"
         optimize_model!(m; log_level=log_level, calculate_duals=calculate_duals) || break
         if write_as_roll > 0 && k % write_as_roll == 0
-            _write_arrow_results(m)                
+            _write_intermediate_results(m)                
             _dump_resume_data(m, k, resume_file_path)
             _clear_results!(m)
         end
@@ -297,7 +298,7 @@ function run_spineopt_kernel!(
         update_model!(m; update_constraints=update_constraints, log_level=log_level, update_names=update_names)
         k += 1
     end
-    _write_arrow_results(m)
+    _write_intermediate_results(m)
     m
 end
 
@@ -636,33 +637,101 @@ end
 _entity_name(entity::ObjectLike) = entity.name
 _entity_name(entities::Vector{T}) where {T<:ObjectLike} = [entity.name for entity in entities]
 
-function _write_arrow_results(m)
+function _write_intermediate_results(m)
     values = collect_output_values(m)
-    for ((out, overwrite), by_entity) in values
+    tables = []
+    for ((output_name, overwrite), by_entity) in values
         table = [
             ((; (class => _entity_name(ent) for (class, ent) in pairs(entity))...), index, value)
             for (entity, val) in by_entity
             for (index, value) in indexed_values(val)
         ]
         isempty(table) && continue
-        file_path = joinpath(m.ext[:spineopt].arrow_results_folder, string(out.name, overwrite))
-        m.ext[:spineopt].arrow_results[out.name, overwrite] = file_path
+        file_path = joinpath(m.ext[:spineopt].intermediate_results_folder, string(output_name, overwrite))
+        push!(tables, (file_path, table))
+    end
+    isempty(tables) && return
+    file_path = joinpath(m.ext[:spineopt].intermediate_results_folder, ".report_name_keys_by_url")
+    if !isfile(file_path)
+        @info """
+        Intermediate results are being written to $(m.ext[:spineopt].intermediate_results_folder).
+
+        In case your run terminates unexpectedly - before these results can be written to the output DB -
+        you can rescue them by running
+
+            write_report_from_intermediate_results("$(m.ext[:spineopt].intermediate_results_folder)", url_out)
+
+        """
+        open(file_path, "w") do f
+            JSON.print(f, m.ext[:spineopt].report_name_keys_by_url)
+        end
+    end
+    for (file_path, table) in tables
         Arrow.append(file_path, table)
     end
 end
 
-function _write_report_from_arrow_results(m, default_url; alternative="", log_level=3)
+function _output_keys(report_name_keys_by_url)
+    unique(
+        key
+        for report_name_keys in values(report_name_keys_by_url)
+        for (_rpt_name, keys) in report_name_keys
+        for key in keys
+    )
+end
+
+"""
+    write_report_from_intermediate_results(intermediate_results_folder, default_url; <keyword arguments>)
+
+Collect results generated on a previous, unsuccessful SpineOpt run from `intermediate_results_folder`, and
+write the corresponding report(s) to `url_out`.
+A new Spine database is created at `url_out` if one doesn't exist.
+
+# Arguments
+
+- `alternative::String=""`: if non empty, write results to the given alternative in the output DB.
+
+- `log_level::Int=3`: an integer to control the log level.
+"""
+function write_report_from_intermediate_results(
+    x::Union{Model,AbstractString}, default_url; alternative="", log_level=3
+)
+    intermediate_results_folder = _intermediate_results_folder(x)
+    report_name_keys_by_url = _report_name_keys_by_url(x)
+    values = _collect_values_from_intermediate_results(intermediate_results_folder, report_name_keys_by_url)
+    isempty(values) || write_report(
+        report_name_keys_by_url, default_url, values; alternative=alternative, log_level=log_level
+    )
+    _clear_intermediate_results(x)
+    @info "cleared intermediate results from $intermediate_results_folder - already in the DB"
+end
+
+_intermediate_results_folder(m::Model) = m.ext[:spineopt].intermediate_results_folder
+_intermediate_results_folder(intermediate_results_folder::AbstractString) = intermediate_results_folder
+
+_report_name_keys_by_url(m::Model) = m.ext[:spineopt].report_name_keys_by_url
+function _report_name_keys_by_url(intermediate_results_folder::AbstractString)
+    JSON.parsefile(joinpath(intermediate_results_folder, ".report_name_keys_by_url"))
+end
+
+function _collect_values_from_intermediate_results(intermediate_results_folder, report_name_keys_by_url)
     values = Dict()
-    for ((output_name, overwrite), file_path) in m.ext[:spineopt].arrow_results
+    for (output_name, overwrite) in _output_keys(report_name_keys_by_url)
+        file_path = joinpath(intermediate_results_folder, string(output_name, overwrite))
+        isfile(file_path) || continue
         table = Arrow.Table(file_path)
         by_entity = Dict()
         for (entity, index, value) in zip(table...)
             push!(get!(by_entity, entity, Dict{typeof(index),Any}()), index => value)
         end
-        values[output(output_name), overwrite] = Dict(entity => indexed_value(vals) for (entity, vals) in by_entity)
+        values[output_name, overwrite] = Dict(entity => collect_indexed_values(vals) for (entity, vals) in by_entity)
     end
-    isempty(values) || write_report(m, default_url, values; alternative=alternative, log_level=log_level)
-    rm(m.ext[:spineopt].arrow_results_folder; force=true, recursive=true)
+    values
+end
+
+_clear_intermediate_results(m::Model) = _clear_intermediate_results(m.ext[:spineopt].intermediate_results_folder)
+function _clear_intermediate_results(intermediate_results_folder::AbstractString)
+    rm(intermediate_results_folder; force=true, recursive=true)
 end
 
 """
@@ -679,32 +748,31 @@ Write report from given model into a db.
 - `alternative::String`: an alternative to pass to `SpineInterface.write_parameters`.
 """
 function write_report(m, default_url, output_value=output_value; alternative="", log_level=3)
-    default_url === nothing && return false
+    default_url === nothing && return
     values = collect_output_values(m, output_value)
     write_report(m, default_url, values; alternative=alternative, log_level=log_level)
 end
 function write_report(m, default_url, values::Dict; alternative="", log_level=3)
-    report_values_by_url = Dict()
-    for rpt in model__report(model=m.ext[:spineopt].instance)
-        vals = Dict()
-        for out in report__output(report=rpt)
-            overwrite = overwrite_results_on_rolling(report=rpt, output=out)
-            name = out.name in keys(m.ext[:spineopt].objective_terms) ? Symbol("objective_", out.name) : out.name
-            value = get(values, (out, overwrite), nothing)
-            value === nothing && continue
-            vals[name] = Dict(_flatten_stochastic_path(ent) => val for (ent, val) in value)
-        end
-        output_url = output_db_url(report=rpt, _strict=false)
+    write_report(
+        m.ext[:spineopt].report_name_keys_by_url, default_url, values, alternative=alternative, log_level=log_level
+    )
+end
+function write_report(report_name_keys_by_url::Dict, default_url, values::Dict; alternative="", log_level=3)
+    for (output_url, report_name_keys) in report_name_keys_by_url
         url = output_url !== nothing ? output_url : default_url
-        push!(get!(report_values_by_url, url, []), (rpt, vals))
-    end
-    for (url, report_values) in report_values_by_url
         actual_url = run_request(url, "get_db_url")
-        @timelog log_level 2 "Writing report to $actual_url..." for (rpt, vals) in report_values
-            write_parameters(vals, url; report=string(rpt.name), alternative=alternative, on_conflict="merge")
+        @timelog log_level 2 "Writing report to $actual_url..." for (report_name, keys) in report_name_keys
+            vals = Dict()
+            for (output_name, overwrite) in keys
+                value = get(values, (output_name, overwrite), nothing)
+                value === nothing && continue
+                output_name = output_name in all_objective_terms ? Symbol("objective_", output_name) : output_name
+                vals[output_name] = Dict(_flatten_stochastic_path(ent) => val for (ent, val) in value)
+            end
+            @show vals
+            write_parameters(vals, url; report=string(report_name), alternative=alternative, on_conflict="merge")
         end
     end
-    true
 end
 
 """
@@ -720,15 +788,12 @@ parameter values.
 function collect_output_values(m, output_value=output_value)
     _wait_for_dual_solves(m)
     values = Dict()
-    for rpt in model__report(model=m.ext[:spineopt].instance)
-        for out in report__output(report=rpt)
-            by_entity = get(m.ext[:spineopt].outputs, out.name, nothing)
-            by_entity === nothing && continue
-            overwrite = overwrite_results_on_rolling(report=rpt, output=out)
-            key = (out, overwrite)
-            haskey(values, key) && continue
-            values[key] = _output_value_by_entity(by_entity, overwrite, output_value)
-        end
+    for (output_name, overwrite) in _output_keys(m.ext[:spineopt].report_name_keys_by_url)
+        by_entity = get(m.ext[:spineopt].outputs, output_name, nothing)
+        by_entity === nothing && continue
+        key = (output_name, overwrite)
+        haskey(values, key) && continue
+        values[key] = _output_value_by_entity(by_entity, overwrite, output_value)
     end
     values
 end

--- a/src/run_spineopt_standard.jl
+++ b/src/run_spineopt_standard.jl
@@ -42,17 +42,23 @@ function rerun_spineopt!(
         log_level=log_level,
         alternative_objective=alternative_objective
     )
-    run_spineopt_kernel!(
-        m,
-        url_out;
-        update_constraints=update_constraints,
-        log_level=log_level,
-        optimize=optimize,
-        update_names=update_names,
-        alternative=alternative,
-        write_as_roll=write_as_roll,
-        resume_file_path=resume_file_path,
-    )
+    try
+        run_spineopt_kernel!(
+            m;
+            update_constraints=update_constraints,
+            log_level=log_level,
+            optimize=optimize,
+            update_names=update_names,
+            alternative=alternative,
+            write_as_roll=write_as_roll,
+            resume_file_path=resume_file_path,
+        )
+    catch err
+        showerror(stdout, err, catch_backtrace())
+        m
+    finally
+        _write_report_from_arrow_results(m, url_out; alternative=alternative, log_level=log_level)
+    end
 end
 
 """
@@ -260,8 +266,7 @@ function _init_outputs!(m::Model)
 end
 
 function run_spineopt_kernel!(
-    m,
-    url_out::Union{String,Nothing};
+    m;
     update_constraints=m -> nothing,
     log_level=3,
     optimize=true,
@@ -282,10 +287,9 @@ function run_spineopt_kernel!(
         @log log_level 1 "\nWindow $k: $(current_window(m))"
         optimize_model!(m; log_level=log_level, calculate_duals=calculate_duals) || break
         if write_as_roll > 0 && k % write_as_roll == 0
-            if write_report(m, url_out; alternative=alternative, log_level=log_level)
-                _dump_resume_data(m, k, resume_file_path)
-                _clear_results!(m)
-            end
+            _write_arrow_results(m)                
+            _dump_resume_data(m, k, resume_file_path)
+            _clear_results!(m)
         end
         if @timelog log_level 2 "Rolling temporal structure...\n" !roll_temporal_structure!(m)
             @timelog log_level 2 " ... Rolling complete\n" break
@@ -293,7 +297,7 @@ function run_spineopt_kernel!(
         update_model!(m; update_constraints=update_constraints, log_level=log_level, update_names=update_names)
         k += 1
     end
-    write_report(m, url_out; alternative=alternative, log_level=log_level)
+    _write_arrow_results(m)
     m
 end
 
@@ -582,7 +586,6 @@ function _value_by_entity_non_aggregated(m, value::Dict, crop_to_window)
         t <= analysis_time && continue
         crop_to_window && start(t) >= end_(current_window(m)) && continue
         entity = _drop_key(ind, t_keys...)
-        entity = _flatten_stochastic_path(entity)
         by_analysis_time_non_aggr = get!(by_entity_non_aggr, entity, Dict{DateTime,Any}())
         by_time_slice_non_aggr = get!(by_analysis_time_non_aggr, analysis_time, Dict{TimeSlice,Any}())
         by_time_slice_non_aggr[t] = val
@@ -619,13 +622,6 @@ function _value_by_time_stamp_aggregated(by_time_slice_non_aggr, ::Nothing)
     Dict(start(t) => v for (t, v) in by_time_slice_non_aggr)
 end
 
-function _flatten_stochastic_path(entity::NamedTuple)
-    stoch_path = get(entity, :stochastic_path, nothing)
-    stoch_path === nothing && return entity
-    flat_stoch_path = (; Dict(Symbol(:stochastic_scenario, k) => scen for (k, scen) in enumerate(stoch_path))...)
-    (; _drop_key(entity, :stochastic_path)..., flat_stoch_path...)
-end
-
 function _compute_and_print_conflict!(m)
     compute_conflict!(m)    
     for (f, s) in list_of_constraint_types(m)
@@ -635,6 +631,38 @@ function _compute_and_print_conflict!(m)
             end
         end
     end
+end
+
+_entity_name(entity::ObjectLike) = entity.name
+_entity_name(entities::Vector{T}) where {T<:ObjectLike} = [entity.name for entity in entities]
+
+function _write_arrow_results(m)
+    values = collect_output_values(m)
+    for ((out, overwrite), by_entity) in values
+        table = [
+            ((; (class => _entity_name(ent) for (class, ent) in pairs(entity))...), index, value)
+            for (entity, val) in by_entity
+            for (index, value) in indexed_values(val)
+        ]
+        isempty(table) && continue
+        file_path = joinpath(m.ext[:spineopt].arrow_results_folder, string(out.name, overwrite))
+        m.ext[:spineopt].arrow_results[out.name, overwrite] = file_path
+        Arrow.append(file_path, table)
+    end
+end
+
+function _write_report_from_arrow_results(m, default_url; alternative="", log_level=3)
+    values = Dict()
+    for ((output_name, overwrite), file_path) in m.ext[:spineopt].arrow_results
+        table = Arrow.Table(file_path)
+        by_entity = Dict()
+        for (entity, index, value) in zip(table...)
+            push!(get!(by_entity, entity, Dict{typeof(index),Any}()), index => value)
+        end
+        values[output(output_name), overwrite] = Dict(entity => indexed_value(vals) for (entity, vals) in by_entity)
+    end
+    isempty(values) || write_report(m, default_url, values; alternative=alternative, log_level=log_level)
+    rm(m.ext[:spineopt].arrow_results_folder; force=true, recursive=true)
 end
 
 """
@@ -662,7 +690,9 @@ function write_report(m, default_url, values::Dict; alternative="", log_level=3)
         for out in report__output(report=rpt)
             overwrite = overwrite_results_on_rolling(report=rpt, output=out)
             name = out.name in keys(m.ext[:spineopt].objective_terms) ? Symbol("objective_", out.name) : out.name
-            vals[name] = values[out, overwrite]
+            value = get(values, (out, overwrite), nothing)
+            value === nothing && continue
+            vals[name] = Dict(_flatten_stochastic_path(ent) => val for (ent, val) in value)
         end
         output_url = output_db_url(report=rpt, _strict=false)
         url = output_url !== nothing ? output_url : default_url
@@ -756,6 +786,13 @@ function _output_value(by_analysis_time, overwrite_results_on_rolling::Val{false
             for by_time_stamp in values(by_analysis_time)
         ]
     )
+end
+
+function _flatten_stochastic_path(entity::NamedTuple)
+    stoch_path = get(entity, :stochastic_path, nothing)
+    stoch_path === nothing && return entity
+    flat_stoch_path = (; Dict(Symbol(:stochastic_scenario, k) => scen for (k, scen) in enumerate(stoch_path))...)
+    (; _drop_key(entity, :stochastic_path)..., flat_stoch_path...)
 end
 
 function _dump_resume_data(m::Model, k, ::Nothing) end

--- a/src/run_spineopt_standard.jl
+++ b/src/run_spineopt_standard.jl
@@ -769,7 +769,6 @@ function write_report(report_name_keys_by_url::Dict, default_url, values::Dict; 
                 output_name = output_name in all_objective_terms ? Symbol("objective_", output_name) : output_name
                 vals[output_name] = Dict(_flatten_stochastic_path(ent) => val for (ent, val) in value)
             end
-            @show vals
             write_parameters(vals, url; report=string(report_name), alternative=alternative, on_conflict="merge")
         end
     end

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -2,6 +2,7 @@
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
+Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 PyCall = "438e738f-606a-5dbb-bf0a-cddfbfd45ab0"
 SpineInterface = "0cda1612-498a-11e9-3c92-77fa82595a4f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/run_spineopt.jl
+++ b/test/run_spineopt.jl
@@ -17,7 +17,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #############################################################################
 
-using Logging
+import Logging: Warn
 
 module Y
 using SpineInterface
@@ -307,12 +307,7 @@ end
             object_parameter_values=object_parameter_values,
             relationship_parameter_values=relationship_parameter_values,
         )
-        test_logger = TestLogger()
-        with_logger(test_logger) do
-            run_spineopt(url_in, url_out; log_level=0)
-        end
-        @test test_logger.logs[1].message == "can't find any values for 'unknown_output'"
-        @test test_logger.logs[1].level == Warn
+        @test_logs min_level=Warn (:warn, "can't find any values for 'unknown_output'") run_spineopt(url_in, url_out; log_level=0)
     end
     @testset "write inputs" begin
         _load_test_data(url_in, test_data)

--- a/test/run_spineopt.jl
+++ b/test/run_spineopt.jl
@@ -17,6 +17,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #############################################################################
 
+using Logging
+
 module Y
 using SpineInterface
 end
@@ -305,7 +307,12 @@ end
             object_parameter_values=object_parameter_values,
             relationship_parameter_values=relationship_parameter_values,
         )
-        @test_logs (:warn, "can't find any values for 'unknown_output'") run_spineopt(url_in, url_out; log_level=0)
+        test_logger = TestLogger()
+        with_logger(test_logger) do
+            run_spineopt(url_in, url_out; log_level=0)
+        end
+        @test test_logger.logs[1].message == "can't find any values for 'unknown_output'"
+        @test test_logger.logs[1].level == Warn
     end
     @testset "write inputs" begin
         _load_test_data(url_in, test_data)


### PR DESCRIPTION
Only write to DB at the very end.

This might improve performance of results writing with write-as-roll, since appending to an arrow file should be faster than writing to a Spine DB. Why? Because writing time series or any indexed value to a Spine DB implies reading the value, merging the new data, and then writing the value again. As more and more data is added to the time series, this reading/merging/writing becomes more and more expensive (more data to deal with at each time).

With the arrow technique, we don't need to do the reading/merging part, just the writing. But at the end we need to read from the arrow file, compile and write the time series to the DB as one large chunk, which should be somewhat expensive. We'll see - I think it's good to merge this PR for experimentation with proper real-world models.

Note that I'm using the apache arrow format as binary format to store our intermediate results but any format should do. Arrow seems nice because of the swapping technique they use to handle files larger than the RAM.

Fixes #537 #467 

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted nicely
- [ ] Unit tests pass
