### PR TITLE
Avoid division by zero in lodf constraint with outages

### DIFF
--- a/src/constraints/constraint_connection_flow_lodf.jl
+++ b/src/constraints/constraint_connection_flow_lodf.jl
@@ -34,12 +34,11 @@ function add_constraint_connection_flow_lodf!(m::Model)
     m.ext[:spineopt].constraints[:connection_flow_lodf] = Dict(
         (connection_contingency=conn_cont, connection_monitored=conn_mon, stochastic_path=s, t=t) => @constraint(
             m,
-            -1
+            - connection_minimum_emergency_capacity(m, conn_mon, s, t)
             <=
-            connection_post_contingency_flow(m, connection_flow, conn_cont, conn_mon, s, t, expr_sum)
-            / connection_minimum_emergency_capacity(m, conn_mon, s, t)
+            + connection_post_contingency_flow(m, connection_flow, conn_cont, conn_mon, s, t, expr_sum)
             <=
-            +1
+            + connection_minimum_emergency_capacity(m, conn_mon, s, t)
         )
         for (conn_cont, conn_mon, s, t) in constraint_connection_flow_lodf_indices(m)
     )

--- a/test/constraints/constraint_connection.jl
+++ b/test/constraints/constraint_connection.jl
@@ -535,7 +535,8 @@
         conn_mon = connection(:connection_ab)
         n_mon_to = node(:node_b)
         expected_con = @build_constraint(
-            -1 <=
+            -conn_emergency_cap_ab
+            <=
             (
                 + var_connection_flow[conn_mon, n_mon_to, d_to, s_parent, t2h]
                 - var_connection_flow[conn_mon, n_mon_to, d_from, s_parent, t2h]
@@ -545,8 +546,9 @@
                     - var_connection_flow[conn_cont, n_cont_to, d_from, s_parent, t1h1]
                     - var_connection_flow[conn_cont, n_cont_to, d_from, s_child, t1h2]
                 )
-            ) / conn_emergency_cap_ab <=
-            +1
+            )
+            <=
+            conn_emergency_cap_ab
         )
         observed_con = constraint_object(constraint[conn_cont, conn_mon, [s_parent, s_child], t2h])
         @test _is_constraint_equal(observed_con, expected_con)
@@ -554,7 +556,8 @@
         conn_mon = connection(:connection_bc)
         n_mon_to = node(:node_c)
         expected_con = @build_constraint(
-            -1 <=
+            -conn_emergency_cap_bc
+            <=
             (
                 + var_connection_flow[conn_mon, n_mon_to, d_to, s_parent, t1h1]
                 - var_connection_flow[conn_mon, n_mon_to, d_from, s_parent, t1h1]
@@ -562,14 +565,16 @@
                     + var_connection_flow[conn_cont, n_cont_to, d_to, s_parent, t1h1]
                     - var_connection_flow[conn_cont, n_cont_to, d_from, s_parent, t1h1]
                 )
-            ) / conn_emergency_cap_bc <=
-            +1
+            )
+            <=
+            conn_emergency_cap_bc
         )
         observed_con = constraint_object(constraint[conn_cont, conn_mon, [s_parent], t1h1])
         @test _is_constraint_equal(observed_con, expected_con)
         # connection_bc -- t1h2
         expected_con = @build_constraint(
-            -1 <=
+            -conn_emergency_cap_bc
+            <=
             (
                 + var_connection_flow[conn_mon, n_mon_to, d_to, s_child, t1h2]
                 - var_connection_flow[conn_mon, n_mon_to, d_from, s_child, t1h2]
@@ -577,8 +582,9 @@
                     + var_connection_flow[conn_cont, n_cont_to, d_to, s_child, t1h2]
                     - var_connection_flow[conn_cont, n_cont_to, d_from, s_child, t1h2]
                 )
-            ) / conn_emergency_cap_bc <=
-            +1
+            )
+            <=
+            conn_emergency_cap_bc
         )
         observed_con = constraint_object(constraint[conn_cont, conn_mon, [s_child], t1h2])
         @test _is_constraint_equal(observed_con, expected_con)


### PR DESCRIPTION
The lodf constraint now looks like -1 <= post_cont_flow / min_emergency_cap <= 1 
​This PR rewrites it as: -min_emergency_cap <= post_cont_flow <= min_emergency_cap

This way whenever min_emergency_cap is zero we don't have a problem but we rather just constrain the post contingency flow to zero.

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted nicely
- [x] Unit tests pass
