### PR TITLE
Collect constraint indices

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,5 +18,5 @@ Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 SpineInterface = "0cda1612-498a-11e9-3c92-77fa82595a4f"
 
 [compat]
-SpineInterface = "0.10.0"
+SpineInterface = "0.10.1"
 julia = "^1.2"

--- a/src/constraints/constraint_candidate_connection_flow_lb.jl
+++ b/src/constraints/constraint_candidate_connection_flow_lb.jl
@@ -67,7 +67,7 @@ function constraint_candidate_connection_flow_lb_indices(m::Model)
         (connection=conn, node=n, direction=d, stochastic_path=path, t=t)
         for (conn, n, d, s, t) in connection_flow_indices(m; connection=connection(is_candidate=true, has_ptdf=true))
         for t in t_lowest_resolution(time_slice(m; temporal_block=node__temporal_block(node=n)))
-        for path in active_stochastic_paths(s)
+        for path in active_stochastic_paths(m, s)
     )
 end
 

--- a/src/constraints/constraint_candidate_connection_flow_lb.jl
+++ b/src/constraints/constraint_candidate_connection_flow_lb.jl
@@ -67,7 +67,7 @@ function constraint_candidate_connection_flow_lb_indices(m::Model)
         (connection=conn, node=n, direction=d, stochastic_path=path, t=t)
         for (conn, n, d, s, t) in connection_flow_indices(m; connection=connection(is_candidate=true, has_ptdf=true))
         for t in t_lowest_resolution(time_slice(m; temporal_block=node__temporal_block(node=n)))
-        for path in active_stochastic_paths(s)  # FIXME?
+        for path in active_stochastic_paths(s)
     )
 end
 

--- a/src/constraints/constraint_candidate_connection_flow_ub.jl
+++ b/src/constraints/constraint_candidate_connection_flow_ub.jl
@@ -28,11 +28,9 @@ function add_constraint_candidate_connection_flow_ub!(m::Model)
     t0 = _analysis_time(m)
     m.ext[:spineopt].constraints[:candidate_connection_flow_ub] = Dict(
         (connection=conn, node=ng, direction=d, stochastic_path=s, t=t) => @constraint(
-            m,
-            connection_flow[conn, ng, d, s, t]
-            <=
-            connection_intact_flow[conn, ng, d, s, t]
-        ) for conn in connection(is_candidate=true, has_ptdf=true)
+            m, connection_flow[conn, ng, d, s, t] <= connection_intact_flow[conn, ng, d, s, t]
+        )
+        for conn in connection(is_candidate=true, has_ptdf=true)
         for (conn, ng, d, s, t) in connection_flow_indices(m; connection=conn)
     )
 end

--- a/src/constraints/constraint_common.jl
+++ b/src/constraints/constraint_common.jl
@@ -17,19 +17,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #############################################################################
 
-function _constraint_unit_flow_capacity_scenarios(m::Model, unit, node, direction, t)
-    (
-        s
-        for s in stochastic_scenario()
-        if !isempty(
-            unit_flow_indices(m; unit=unit, node=node, direction=direction, t=t, stochastic_scenario=s)
-        )
-        || !isempty(
-            units_on_indices(m; unit=unit, t=t_in_t(m; t_long=t), stochastic_scenario=s)
-        )
-    )
-end
-
 function t_lowest_resolution_path(indices)
     (
         (t, path)

--- a/src/constraints/constraint_common.jl
+++ b/src/constraints/constraint_common.jl
@@ -25,7 +25,8 @@ function t_lowest_resolution_path(indices)
     )
 end
 
-function past_units_on_indices(m, u, t0, s, t, min_time)
+function past_units_on_indices(m, u, s, t, min_time)
+    t0 = _analysis_time(m)
     units_on_indices(
         m;
         unit=u,

--- a/src/constraints/constraint_common.jl
+++ b/src/constraints/constraint_common.jl
@@ -27,7 +27,7 @@ function t_lowest_resolution_path(indices)
     end
     (
         (t, path)
-        for (t, scens) in t_lowest_resolution_sets(scens_by_t)
+        for (t, scens) in t_lowest_resolution_sets!(scens_by_t)
         for path in active_stochastic_paths(scens)
     )
 end

--- a/src/constraints/constraint_common.jl
+++ b/src/constraints/constraint_common.jl
@@ -21,7 +21,7 @@ function t_lowest_resolution_path(indices)
     scens_by_t = Dict()
     for x in indices
         scens = get!(scens_by_t, x.t) do
-            Set()
+            Set{Object}()
         end
         push!(scens, x.stochastic_scenario)
     end

--- a/src/constraints/constraint_common.jl
+++ b/src/constraints/constraint_common.jl
@@ -17,7 +17,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #############################################################################
 
-function t_lowest_resolution_path(indices)
+function t_lowest_resolution_path(m, indices)
     scens_by_t = Dict()
     for x in indices
         scens = get!(scens_by_t, x.t) do
@@ -28,7 +28,7 @@ function t_lowest_resolution_path(indices)
     (
         (t, path)
         for (t, scens) in t_lowest_resolution_sets!(scens_by_t)
-        for path in active_stochastic_paths(scens)
+        for path in active_stochastic_paths(m, scens)
     )
 end
 

--- a/src/constraints/constraint_common.jl
+++ b/src/constraints/constraint_common.jl
@@ -18,9 +18,16 @@
 #############################################################################
 
 function t_lowest_resolution_path(indices)
+    scens_by_t = Dict()
+    for x in indices
+        scens = get!(scens_by_t, x.t) do
+            Set()
+        end
+        push!(scens, x.stochastic_scenario)
+    end
     (
         (t, path)
-        for (t, scens) in t_lowest_resolution_sets(x.t => Set(x.stochastic_scenario) for x in indices)
+        for (t, scens) in t_lowest_resolution_sets(scens_by_t)
         for path in active_stochastic_paths(scens)
     )
 end

--- a/src/constraints/constraint_common.jl
+++ b/src/constraints/constraint_common.jl
@@ -24,3 +24,15 @@ function t_lowest_resolution_path(indices)
         for path in active_stochastic_paths(scens)
     )
 end
+
+function past_units_on_indices(m, u, t0, s, t, min_time)
+    units_on_indices(
+        m;
+        unit=u,
+        stochastic_scenario=s,
+        t=to_time_slice(
+            m; t=TimeSlice(end_(t) - min_time(unit=u, analysis_time=t0, stochastic_scenario=s, t=t), end_(t))
+        ),
+        temporal_block=anything
+    )    
+end

--- a/src/constraints/constraint_common.jl
+++ b/src/constraints/constraint_common.jl
@@ -29,3 +29,11 @@ function _constraint_unit_flow_capacity_scenarios(m::Model, unit, node, directio
         )
     )
 end
+
+function t_lowest_resolution_path(indices)
+    (
+        (t, path)
+        for (t, scens) in t_lowest_resolution_sets(x.t => Set(x.stochastic_scenario) for x in indices)
+        for path in active_stochastic_paths(scens)
+    )
+end

--- a/src/constraints/constraint_compression_ratio.jl
+++ b/src/constraints/constraint_compression_ratio.jl
@@ -28,42 +28,33 @@ function add_constraint_compression_ratio!(m::Model)
         (connection=conn, node1=n_orig, node2=n_dest, stochastic_path=s, t=t) => @constraint(
             m,
             + expr_sum(
-                node_pressure[n_dest, s, t] * duration(t) for (n_dest, s, t) in node_pressure_indices(
-                    m;
-                    node=n_dest,
-                    stochastic_scenario=s,
-                    t=t_in_t(m; t_long=t),
+                node_pressure[n_dest, s, t] * duration(t)
+                for (n_dest, s, t) in node_pressure_indices(
+                    m; node=n_dest, stochastic_scenario=s, t=t_in_t(m; t_long=t)
                 );
                 init=0,
             )
             <=
             compression_factor[
                 (connection=conn, node1=n_orig, node2=n_dest, stochastic_scenario=s, analysis_time=t0, t=t),
-            ] * expr_sum(
-                node_pressure[n_orig, s, t] * duration(t) for (n_orig, s, t) in node_pressure_indices(
-                    m;
-                    node=n_orig,
-                    stochastic_scenario=s,
-                    t=t_in_t(m; t_long=t),
+            ]
+            * expr_sum(
+                node_pressure[n_orig, s, t] * duration(t)
+                for (n_orig, s, t) in node_pressure_indices(
+                    m; node=n_orig, stochastic_scenario=s, t=t_in_t(m; t_long=t),
                 );
                 init=0,
             )
-        ) for (conn, n_orig, n_dest, s, t) in constraint_compression_ratio_indices(m)
+        )
+        for (conn, n_orig, n_dest, s, t) in constraint_compression_ratio_indices(m)
     )
 end
 
 function constraint_compression_ratio_indices(m::Model)
     unique(
         (connection=conn, node1=n1, node2=n2, stochastic_path=path, t=t)
-        for (conn, n1, n2) in indices(compression_factor) for t in t_lowest_resolution(
-            time_slice(m; temporal_block=node__temporal_block(node=Iterators.flatten((members(n1), members(n2))))),
-        ) for path in active_stochastic_paths(
-            collect(
-                s
-                for s in stochastic_scenario()
-                if !isempty(node_pressure_indices(m; node=[n1, n2], t=t, stochastic_scenario=s))
-            )
-        )
+        for (conn, n1, n2) in indices(compression_factor)
+        for (t, path) in t_lowest_resolution_path(node_pressure_indices(m; node=[n1, n2]))
     )
 end
 
@@ -73,7 +64,8 @@ end
 Form the stochastic indexing Array for the `:compression_ratio` constraint.
 
 Uses stochastic path indices of the `node_pressure` variables. Only the lowest resolution time slices are included,
-as the `:compression_factor` is used to constrain the "average compression ratio" of the `connection`. Keyword arguments can be used to filter the resulting
+as the `:compression_factor` is used to constrain the "average compression ratio" of the `connection`.
+Keyword arguments can be used to filter the resulting
 """
 function constraint_compression_ratio_indices_filtered(
     m::Model;

--- a/src/constraints/constraint_compression_ratio.jl
+++ b/src/constraints/constraint_compression_ratio.jl
@@ -54,7 +54,7 @@ function constraint_compression_ratio_indices(m::Model)
     unique(
         (connection=conn, node1=n1, node2=n2, stochastic_path=path, t=t)
         for (conn, n1, n2) in indices(compression_factor)
-        for (t, path) in t_lowest_resolution_path(node_pressure_indices(m; node=[n1, n2]))
+        for (t, path) in t_lowest_resolution_path(m, node_pressure_indices(m; node=[n1, n2]))
     )
 end
 

--- a/src/constraints/constraint_connection_flow_capacity.jl
+++ b/src/constraints/constraint_connection_flow_capacity.jl
@@ -105,20 +105,3 @@ function constraint_connection_flow_capacity_indices_filtered(
     f(ind) = _index_in(ind; connection=connection, node=node, direction=direction, stochastic_path=stochastic_path, t=t)
     filter(f, constraint_connection_flow_capacity_indices(m))
 end
-
-function _constraint_connection_flow_capacity_scenarios(m, connection, node, direction, t)
-    (
-        s
-        for s in stochastic_scenario()
-        if !isempty(
-            connection_flow_indices(
-                m; connection=connection, node=node, direction=direction, t=t, stochastic_scenario=s
-            )
-        )
-        || !isempty(
-            connections_invested_available_indices(
-                m; connection=connection, t=t_in_t(m; t_short=t), stochastic_scenario=s
-            )
-        )
-    )
-end

--- a/src/constraints/constraint_connection_flow_capacity.jl
+++ b/src/constraints/constraint_connection_flow_capacity.jl
@@ -77,6 +77,7 @@ function constraint_connection_flow_capacity_indices(m::Model)
         (connection=c, node=ng, direction=d, stochastic_path=path, t=t)
         for (c, ng, d) in indices(connection_capacity)
         for (t, path) in t_lowest_resolution_path(
+            m, 
             vcat(
                 connection_flow_indices(m; connection=c, node=ng, direction=d),
                 connections_invested_available_indices(m; connection=c)

--- a/src/constraints/constraint_connection_flow_capacity.jl
+++ b/src/constraints/constraint_connection_flow_capacity.jl
@@ -49,8 +49,7 @@ function add_constraint_connection_flow_capacity!(m::Model)
                 (connection=conn, node=ng, direction=d, stochastic_scenario=s, analysis_time=t0, t=t),
             ]
             * (
-                (candidate_connections(connection=conn) != nothing) ?
-                + expr_sum(
+                candidate_connections(connection=conn) != nothing ? expr_sum(
                     connections_invested_available[conn, s, t1]
                     for (conn, s, t1) in connections_invested_available_indices(
                         m; connection=conn, stochastic_scenario=s, t=t_in_t(m; t_short=t)
@@ -77,8 +76,12 @@ function constraint_connection_flow_capacity_indices(m::Model)
     (
         (connection=c, node=ng, direction=d, stochastic_path=path, t=t)
         for (c, ng, d) in indices(connection_capacity)
-        for t in t_lowest_resolution(time_slice(m; temporal_block=members(node__temporal_block(node=members(ng)))))
-        for path in active_stochastic_paths(collect(_constraint_connection_flow_capacity_scenarios(m, c, ng, d, t)))
+        for (t, path) in t_lowest_resolution_path(
+            vcat(
+                connection_flow_indices(m; connection=c, node=ng, direction=d),
+                connections_invested_available_indices(m; connection=c)
+            )
+        )
     )
 end
 

--- a/src/constraints/constraint_connection_flow_gas_capacity.jl
+++ b/src/constraints/constraint_connection_flow_gas_capacity.jl
@@ -37,11 +37,11 @@ function add_constraint_connection_flow_gas_capacity!(m::Model)
                         t=t_in_t(m; t_long=t),
                         direction=direction(:from_node),
                     )
-                ) + sum(
+                )
+                + sum(
                     connection_flow[conn, n_to, d, s, t] * duration(t)
                     for (conn, n_to, d, s, t) in connection_flow_indices(
-                        m;
-                        connection=conn,
+                        m; connection=conn,
                         node=n_to,
                         stochastic_scenario=s,
                         t=t_in_t(m; t_long=t),
@@ -51,7 +51,8 @@ function add_constraint_connection_flow_gas_capacity!(m::Model)
             )
             / 2
             <=
-            + big_m(model=m.ext[:spineopt].instance) * sum(
+            + big_m(model=m.ext[:spineopt].instance)
+            * sum(
                 binary_gas_connection_flow[conn, n_to, d, s, t] * duration(t)
                 for (conn, n_to, d, s, t) in connection_flow_indices(
                     m;
@@ -62,14 +63,16 @@ function add_constraint_connection_flow_gas_capacity!(m::Model)
                     direction=direction(:to_node),
                 )
             )
-        ) for (conn, n_from, n_to, s, t) in constraint_connection_flow_gas_capacity_indices(m)
+        )
+        for (conn, n_from, n_to, s, t) in constraint_connection_flow_gas_capacity_indices(m)
     )
 end
 
 function constraint_connection_flow_gas_capacity_indices(m::Model)
     unique(
         (connection=conn, node1=n1, node2=n2, stochastic_path=path, t=t)
-        for (conn, n1, n2) in indices(fixed_pressure_constant_1) for t in t_lowest_resolution(
+        for (conn, n1, n2) in indices(fixed_pressure_constant_1)
+        for t in t_lowest_resolution(
             time_slice(m; temporal_block=node__temporal_block(node=Iterators.flatten((members(n1), members(n2))))),
         )
         for path in active_stochastic_paths(

--- a/src/constraints/constraint_connection_flow_gas_capacity.jl
+++ b/src/constraints/constraint_connection_flow_gas_capacity.jl
@@ -72,7 +72,7 @@ function constraint_connection_flow_gas_capacity_indices(m::Model)
     unique(
         (connection=conn, node1=n1, node2=n2, stochastic_path=path, t=t)
         for (conn, n1, n2) in indices(fixed_pressure_constant_1)
-        for (t, path) in t_lowest_resolution_path(connection_flow_indices(m; connection=conn, node=[n1, n2]))
+        for (t, path) in t_lowest_resolution_path(m, connection_flow_indices(m; connection=conn, node=[n1, n2]))
     )
 end
 

--- a/src/constraints/constraint_connection_flow_gas_capacity.jl
+++ b/src/constraints/constraint_connection_flow_gas_capacity.jl
@@ -72,16 +72,7 @@ function constraint_connection_flow_gas_capacity_indices(m::Model)
     unique(
         (connection=conn, node1=n1, node2=n2, stochastic_path=path, t=t)
         for (conn, n1, n2) in indices(fixed_pressure_constant_1)
-        for t in t_lowest_resolution(
-            time_slice(m; temporal_block=node__temporal_block(node=Iterators.flatten((members(n1), members(n2))))),
-        )
-        for path in active_stochastic_paths(
-            collect(
-                s
-                for s in stochastic_scenario()
-                if !isempty(connection_flow_indices(m; connection=conn, node=[n1, n2], t=t, stochastic_scenario=s))
-            )
-        )
+        for (t, path) in t_lowest_resolution_path(connection_flow_indices(m; connection=conn, node=[n1, n2]))
     )
 end
 

--- a/src/constraints/constraint_connection_flow_intact_flow.jl
+++ b/src/constraints/constraint_connection_flow_intact_flow.jl
@@ -78,6 +78,7 @@ function constraint_connection_flow_intact_flow_indices(m::Model)
         for conn in connection(connection_monitored=true, has_ptdf=true, is_candidate=false)
         for (conn, n_to, d_to) in Iterators.drop(connection__from_node(connection=conn; _compact=false), 1)
         for (t, path) in t_lowest_resolution_path(
+            m, 
             x
             for conn_k in Iterators.flatten(((conn,), _candidate_connections(conn)))
             for x in connection_flow_indices(m; connection=conn_k, last(connection__from_node(connection=conn_k))...)

--- a/src/constraints/constraint_connection_flow_intact_flow.jl
+++ b/src/constraints/constraint_connection_flow_intact_flow.jl
@@ -77,9 +77,10 @@ function constraint_connection_flow_intact_flow_indices(m::Model)
         (connection=conn, node=n_to, stochastic_path=path, t=t)
         for conn in connection(connection_monitored=true, has_ptdf=true, is_candidate=false)
         for (conn, n_to, d_to) in Iterators.drop(connection__from_node(connection=conn; _compact=false), 1)
-        for t in _constraint_connection_flow_intact_flow_lowest_resolution_t(m, conn)
-        for path in active_stochastic_paths(
-            collect(_constraint_connection_flow_intact_flow_scenarios(m, conn, t)),
+        for (t, path) in t_lowest_resolution_path(
+            x
+            for conn_k in Iterators.flatten(((conn,), _candidate_connections(conn)))
+            for x in connection_flow_indices(m; connection=conn_k, last(connection__from_node(connection=conn_k))...)
         )
     )
 end
@@ -114,31 +115,5 @@ function _candidate_connections(conn)
         candidate_conn
         for candidate_conn in connection(is_candidate=true, has_ptdf=true)
         if candidate_conn !== conn && lodf(connection1=candidate_conn, connection2=conn) !== nothing
-    )
-end
-
-function _constraint_connection_flow_intact_flow_lowest_resolution_t(m, conn)
-    t_lowest_resolution(
-        ind.t
-        for conn_k in Iterators.flatten(((conn,), _candidate_connections(conn)))
-        for ind in connection_flow_indices(m; connection=conn_k, last(connection__from_node(connection=conn_k))...)
-    )
-end
-
-function _constraint_connection_flow_intact_flow_scenarios(m, conn, t)
-    (
-        s
-        for s in stochastic_scenario()
-        if iterate(
-            ind
-            for conn_k in Iterators.flatten(((conn,), _candidate_connections(conn)))
-            for ind in connection_flow_indices(
-                m;
-                connection=conn_k,
-                stochastic_scenario=s,
-                last(connection__from_node(connection=conn_k))...,
-                t=t_in_t(m; t_long=t),
-            )
-        ) !== nothing
     )
 end

--- a/src/constraints/constraint_connection_flow_lodf.jl
+++ b/src/constraints/constraint_connection_flow_lodf.jl
@@ -95,13 +95,16 @@ function constraint_connection_flow_lodf_indices(m::Model)
     unique(
         (connection_contingency=conn_cont, connection_monitored=conn_mon, stochastic_path=path, t=t)
         for (conn_cont, conn_mon) in lodf_connection__connection()
-        if all([
-            connection_contingency(connection=conn_cont) === true,
-            connection_monitored(connection=conn_mon) === true,
-            has_lodf(connection=conn_cont),
-            has_lodf(connection=conn_mon)
-        ])
+        if all(
+            [
+                connection_contingency(connection=conn_cont) === true,
+                connection_monitored(connection=conn_mon) === true,
+                has_lodf(connection=conn_cont),
+                has_lodf(connection=conn_mon)
+            ]
+        )
         for (t, path) in t_lowest_resolution_path(
+            m, 
             x
             for conn in (conn_cont, conn_mon)
             for x in connection_flow_indices(m; connection=conn, last(connection__from_node(connection=conn))...)

--- a/src/constraints/constraint_connection_flow_lodf.jl
+++ b/src/constraints/constraint_connection_flow_lodf.jl
@@ -101,9 +101,10 @@ function constraint_connection_flow_lodf_indices(m::Model)
             has_lodf(connection=conn_cont),
             has_lodf(connection=conn_mon)
         ])
-        for t in _constraint_connection_flow_lodf_lowest_resolution_t(m, conn_cont, conn_mon)
-        for path in active_stochastic_paths(
-            collect(_constraint_connection_flow_lodf_scenarios(m, conn_cont, conn_mon, t))
+        for (t, path) in t_lowest_resolution_path(
+            x
+            for conn in (conn_cont, conn_mon)
+            for x in connection_flow_indices(m; connection=conn, last(connection__from_node(connection=conn))...)
         )
     )
 end
@@ -133,43 +134,4 @@ function constraint_connection_flow_lodf_indices_filtered(
         )
     end
     filter(f, constraint_connection_flow_lodf_indices(m))
-end
-
-"""
-    _constraint_connection_flow_lodf_lowest_resolution_t(m::Model, conn_cont::Object, conn_mon::Object)
-
-Find the lowest resolution `t`s between the `connection_flow` variables of the `conn_cont` contingency connection and
-the `conn_mon` monitored connection.
-"""
-function _constraint_connection_flow_lodf_lowest_resolution_t(m, conn_cont, conn_mon)
-    t_lowest_resolution(
-        ind.t
-        for conn in (conn_cont, conn_mon)
-        for ind in connection_flow_indices(m; connection=conn, last(connection__from_node(connection=conn))...)
-    )
-end
-
-function _constraint_connection_flow_lodf_scenarios(m, conn_cont, conn_mon, t)
-    (
-        s
-        for s in stochastic_scenario()
-        if !isempty(
-            connection_flow_indices(
-                m;
-                connection=conn_mon,
-                last(connection__from_node(connection=conn_mon))...,
-                t=t_in_t(m; t_long=t),
-                stochastic_scenario=s
-            )
-        )
-        || !isempty(
-            connection_flow_indices(
-                m;
-                connection=conn_cont,
-                last(connection__from_node(connection=conn_cont))...,
-                t=t_in_t(m; t_long=t),
-                stochastic_scenario=s
-            )  # Excess flow due to outage on contingency connection
-        )
-    )
 end

--- a/src/constraints/constraint_connection_intact_flow_capacity.jl
+++ b/src/constraints/constraint_connection_intact_flow_capacity.jl
@@ -77,7 +77,7 @@ function constraint_connection_intact_flow_capacity_indices(m::Model)
         (connection=c, node=ng, direction=d, stochastic_path=path, t=t)
         for (c, ng, d) in indices(connection_capacity; connection=connection(has_ptdf=true))
         for (t, path) in t_lowest_resolution_path(
-            connection_intact_flow_indices(m; connection=c, node=ng, direction=d)
+            m, connection_intact_flow_indices(m; connection=c, node=ng, direction=d)
         )
     )
 end

--- a/src/constraints/constraint_connection_intact_flow_capacity.jl
+++ b/src/constraints/constraint_connection_intact_flow_capacity.jl
@@ -67,7 +67,8 @@ function add_constraint_connection_intact_flow_capacity!(m::Model)
                 ) if d_reverse != d && !is_reserve_node(node=n);
                 init=0,
             )
-        ) for (conn, ng, d, s, t) in constraint_connection_intact_flow_capacity_indices(m)
+        )
+        for (conn, ng, d, s, t) in constraint_connection_intact_flow_capacity_indices(m)
     )
 end
 
@@ -75,15 +76,8 @@ function constraint_connection_intact_flow_capacity_indices(m::Model)
     unique(
         (connection=c, node=ng, direction=d, stochastic_path=path, t=t)
         for (c, ng, d) in indices(connection_capacity; connection=connection(has_ptdf=true))
-        for t in t_lowest_resolution(time_slice(m; temporal_block=node__temporal_block(node=members(ng))))
-        for path in active_stochastic_paths(
-            collect(
-                s
-                for s in stochastic_scenario()
-                if !isempty(
-                    connection_intact_flow_indices(m; connection=c, node=ng, direction=d, t=t, stochastic_scenario=s)
-                )
-            ),
+        for (t, path) in t_lowest_resolution_path(
+            connection_intact_flow_indices(m; connection=c, node=ng, direction=d)
         )
     )
 end

--- a/src/constraints/constraint_connection_intact_flow_ptdf.jl
+++ b/src/constraints/constraint_connection_intact_flow_ptdf.jl
@@ -84,12 +84,9 @@ function constraint_connection_intact_flow_ptdf_indices(m::Model)
         for (n_to, t) in node_time_indices(m; node=n_to)
         for path in active_stochastic_paths(
             m,
-            unique(
-                ind.stochastic_scenario
-                for ind in vcat(
-                    connection_intact_flow_indices(m; connection=conn, node=n_to, direction=d_to, t=t),
-                    node_stochastic_time_indices(m; node=ptdf_connection__node(connection=conn), t=t)
-                )
+            vcat(
+                connection_intact_flow_indices(m; connection=conn, node=n_to, direction=d_to, t=t),
+                node_stochastic_time_indices(m; node=ptdf_connection__node(connection=conn), t=t)
             )
         )
     )

--- a/src/constraints/constraint_connection_intact_flow_ptdf.jl
+++ b/src/constraints/constraint_connection_intact_flow_ptdf.jl
@@ -83,6 +83,7 @@ function constraint_connection_intact_flow_ptdf_indices(m::Model)
         for (conn, n_to, d_to) in Iterators.drop(connection__from_node(connection=conn; _compact=false), 1)
         for (n_to, t) in node_time_indices(m; node=n_to)
         for path in active_stochastic_paths(
+            m,
             unique(
                 ind.stochastic_scenario
                 for ind in vcat(

--- a/src/constraints/constraint_connection_intact_flow_ptdf.jl
+++ b/src/constraints/constraint_connection_intact_flow_ptdf.jl
@@ -84,7 +84,7 @@ function constraint_connection_intact_flow_ptdf_indices(m::Model)
         for (n_to, t) in node_time_indices(m; node=n_to)
         for path in active_stochastic_paths(
             collect(_constraint_connection_intact_flow_ptdf_scenarios(m, conn, n_to, d_to, t))
-        )
+        ) # FIXME
     )
 end
 

--- a/src/constraints/constraint_connection_lifetime.jl
+++ b/src/constraints/constraint_connection_lifetime.jl
@@ -50,6 +50,7 @@ function constraint_connection_lifetime_indices(m::Model)
         for conn in indices(connection_investment_lifetime)
         for (conn, t) in connection_investment_time_indices(m; connection=conn)
         for path in active_stochastic_paths(
+            m, 
             unique(
                 ind.stochastic_scenario for ind in _past_connections_invested_available_indices(m, conn, anything, t)
             )

--- a/src/constraints/constraint_connection_lifetime.jl
+++ b/src/constraints/constraint_connection_lifetime.jl
@@ -29,11 +29,9 @@ function add_constraint_connection_lifetime!(m::Model)
         (connection=conn, stochastic_path=s, t=t) => @constraint(
             m,
             + expr_sum(
-                + connections_invested_available[conn, s, t] for (conn, s, t) in connections_invested_available_indices(
-                    m;
-                    connection=conn,
-                    stochastic_scenario=s,
-                    t=t,
+                + connections_invested_available[conn, s, t]
+                for (conn, s, t) in connections_invested_available_indices(
+                    m; connection=conn, stochastic_scenario=s, t=t
                 );
                 init=0,
             )
@@ -41,24 +39,19 @@ function add_constraint_connection_lifetime!(m::Model)
             + sum(
                 + connections_invested[conn, s_past, t_past]
                 for (conn, s_past, t_past) in connections_invested_available_indices(
-                    m;
-                    connection=conn,
-                    stochastic_scenario=s,
-                    t=to_time_slice(
+                    m; connection=conn, stochastic_scenario=s, t=to_time_slice(
                         m;
                         t=TimeSlice(
                             end_(t) - connection_investment_lifetime(
-                                connection=conn,
-                                stochastic_scenario=s,
-                                analysis_time=t0,
-                                t=t,
+                                connection=conn, stochastic_scenario=s, analysis_time=t0, t=t
                             ),
                             end_(t),
                         ),
                     ),
                 )
             )
-        ) for (conn, s, t) in constraint_connection_lifetime_indices(m)
+        )
+        for (conn, s, t) in constraint_connection_lifetime_indices(m)
     )
 end
 
@@ -67,8 +60,25 @@ function constraint_connection_lifetime_indices(m::Model)
     unique(
         (connection=conn, stochastic_path=path, t=t)
         for conn in indices(connection_investment_lifetime)
-        for (conn, s, t) in connections_invested_available_indices(m; connection=conn)
-        for path in active_stochastic_paths(collect(_constraint_connection_lifetime_scenarios(m, conn, s, t0, t)))
+        for (conn, s, t) in connection_investment_stochastic_time_indices(m; connection=conn)
+        for path in active_stochastic_paths(
+            unique(
+                ind.stochastic_scenario
+                for ind in connections_invested_available_indices(
+                    m;
+                    connection=conn,
+                    t=to_time_slice(
+                        m;
+                        t=TimeSlice(
+                            end_(t) - connection_investment_lifetime(
+                                connection=conn, analysis_time=t0, stochastic_scenario=s, t=t
+                            ),
+                            end_(t),
+                        )
+                    )
+                )
+            )
+        )  # FIXME
     )
 end
 
@@ -88,21 +98,4 @@ function constraint_connection_lifetime_indices_filtered(
 )
     f(ind) = _index_in(ind; connection=connection, stochastic_path=stochastic_path, t=t)
     filter(f, constraint_connection_lifetime_indices(m))
-end
-
-function _constraint_connection_lifetime_scenarios(m, conn, s, t0, t)
-    t_past_and_present = to_time_slice(
-        m;
-        t=TimeSlice(
-            end_(t) - connection_investment_lifetime(connection=conn, stochastic_scenario=s, analysis_time=t0, t=t),
-            end_(t),
-        ),
-    )
-    (
-        s
-        for s in stochastic_scenario()
-        if !isempty(
-            connections_invested_available_indices(m; connection=conn, t=t_past_and_present, stochastic_scenario=s)
-        )
-    )
 end

--- a/src/constraints/constraint_connection_lifetime.jl
+++ b/src/constraints/constraint_connection_lifetime.jl
@@ -49,12 +49,7 @@ function constraint_connection_lifetime_indices(m::Model)
         (connection=conn, stochastic_path=path, t=t)
         for conn in indices(connection_investment_lifetime)
         for (conn, t) in connection_investment_time_indices(m; connection=conn)
-        for path in active_stochastic_paths(
-            m, 
-            unique(
-                ind.stochastic_scenario for ind in _past_connections_invested_available_indices(m, conn, anything, t)
-            )
-        )
+        for path in active_stochastic_paths(m, _past_connections_invested_available_indices(m, conn, anything, t))
     )
 end
 

--- a/src/constraints/constraint_connection_unitary_gas_flow.jl
+++ b/src/constraints/constraint_connection_unitary_gas_flow.jl
@@ -27,29 +27,21 @@ function add_constraint_connection_unitary_gas_flow!(m::Model)
     m.ext[:spineopt].constraints[:connection_unitary_gas_flow] = Dict(
         (connection=conn, node1=n1, node2=n2, stochastic_scenario=s, t=t) => @constraint(
             m,
-            sum(
-                binary_gas_connection_flow[conn, n1, d, s, t] for (conn, n1, d, s, t) in connection_flow_indices(
+            expr_avg(
+                binary_gas_connection_flow[conn, n1, d, s, t]
+                for (conn, n1, d, s, t) in connection_flow_indices(
                     m;
                     connection=conn,
                     node=n1,
                     stochastic_scenario=s,
                     direction=direction(:to_node),
                     t=t_in_t(m; t_long=t),
-                )
-            )
-            / length(
-                connection_flow_indices(
-                    m;
-                    connection=conn,
-                    node=n1,
-                    stochastic_scenario=s,
-                    direction=direction(:to_node),
-                    t=t_in_t(m; t_long=t),
-                ),
+                );
+                init=0
             )
             ==
-            1
-            - sum(
+            + 1
+            - expr_avg(
                 binary_gas_connection_flow[conn, n2, direction(:to_node), s, t]
                 for (conn, n2, d, s, t) in connection_flow_indices(
                     m;
@@ -58,17 +50,10 @@ function add_constraint_connection_unitary_gas_flow!(m::Model)
                     stochastic_scenario=s,
                     direction=direction(:to_node),
                     t=t_in_t(m; t_long=t),
-                )
-            ) / length(
-                connection_flow_indices(
-                    m;
-                    connection=conn,
-                    node=n2,
-                    stochastic_scenario=s,
-                    direction=direction(:to_node),
-                    t=t_in_t(m; t_long=t),
-                ),
+                );
+                init=0
             )
-        ) for (conn, n1, n2, s, t) in constraint_connection_flow_gas_capacity_indices(m)
+        )
+        for (conn, n1, n2, s, t) in constraint_connection_flow_gas_capacity_indices(m)
     )
 end

--- a/src/constraints/constraint_connections_invested_available.jl
+++ b/src/constraints/constraint_connections_invested_available.jl
@@ -31,7 +31,8 @@ function add_constraint_connections_invested_available!(m::Model)
             + connections_invested_available[conn, s, t]
             <=
             + candidate_connections[(connection=conn, stochastic_scenario=s, analysis_time=t0, t=t)]
-        ) for (conn, s, t) in connections_invested_available_indices(m)
+        )
+        for (conn, s, t) in connections_invested_available_indices(m)
     )
 end
 # TODO: units_invested_available or \sum(units_invested)?

--- a/src/constraints/constraint_connections_invested_transition.jl
+++ b/src/constraints/constraint_connections_invested_transition.jl
@@ -54,6 +54,7 @@ function constraint_connections_invested_transition_indices(m::Model)
         (connection=conn, stochastic_path=path, t_before=t_before, t_after=t_after)
         for (conn, t_before, t_after) in connection_investment_dynamic_time_indices(m)
         for path in active_stochastic_paths(
+            m, 
             unique(
                 x.stochastic_scenario
                 for x in connections_invested_available_indices(m; connection=conn, t=[t_before, t_after])

--- a/src/constraints/constraint_connections_invested_transition.jl
+++ b/src/constraints/constraint_connections_invested_transition.jl
@@ -54,11 +54,7 @@ function constraint_connections_invested_transition_indices(m::Model)
         (connection=conn, stochastic_path=path, t_before=t_before, t_after=t_after)
         for (conn, t_before, t_after) in connection_investment_dynamic_time_indices(m)
         for path in active_stochastic_paths(
-            m, 
-            unique(
-                x.stochastic_scenario
-                for x in connections_invested_available_indices(m; connection=conn, t=[t_before, t_after])
-            )
+            m, connections_invested_available_indices(m; connection=conn, t=[t_before, t_after])
         )
     )
 end

--- a/src/constraints/constraint_connections_invested_transition.jl
+++ b/src/constraints/constraint_connections_invested_transition.jl
@@ -58,7 +58,7 @@ function constraint_connections_invested_transition_indices(m::Model)
                 x.stochastic_scenario
                 for x in connections_invested_available_indices(m; connection=conn, t=[t_before, t_after])
             )
-        )  # FIXME
+        )
     )
 end
 

--- a/src/constraints/constraint_connections_invested_transition.jl
+++ b/src/constraints/constraint_connections_invested_transition.jl
@@ -32,10 +32,7 @@ function add_constraint_connections_invested_transition!(m::Model)
                 + connections_invested_available[conn, s, t_after] - connections_invested[conn, s, t_after]
                 + connections_decommissioned[conn, s, t_after]
                 for (conn, s, t_after) in connections_invested_available_indices(
-                    m;
-                    connection=conn,
-                    stochastic_scenario=s,
-                    t=t_after,
+                    m; connection=conn, stochastic_scenario=s, t=t_after
                 );
                 init=0,
             )
@@ -43,14 +40,12 @@ function add_constraint_connections_invested_transition!(m::Model)
             expr_sum(
                 + connections_invested_available[conn, s, t_before]
                 for (conn, s, t_before) in connections_invested_available_indices(
-                    m;
-                    connection=conn,
-                    stochastic_scenario=s,
-                    t=t_before,
+                    m; connection=conn, stochastic_scenario=s, t=t_before
                 );
                 init=0,
             )
-        ) for (conn, s, t_before, t_after) in constraint_connections_invested_transition_indices(m)
+        )
+        for (conn, s, t_before, t_after) in constraint_connections_invested_transition_indices(m)
     )
 end
 
@@ -59,16 +54,11 @@ function constraint_connections_invested_transition_indices(m::Model)
         (connection=conn, stochastic_path=path, t_before=t_before, t_after=t_after)
         for (conn, t_before, t_after) in connection_investment_dynamic_time_indices(m)
         for path in active_stochastic_paths(
-            collect(
-                s
-                for s in stochastic_scenario()
-                if !isempty(
-                    connections_invested_available_indices(
-                        m; connection=conn, t=[t_before, t_after], stochastic_scenario=s
-                    )
-                )
+            unique(
+                x.stochastic_scenario
+                for x in connections_invested_available_indices(m; connection=conn, t=[t_before, t_after])
             )
-        )
+        )  # FIXME
     )
 end
 

--- a/src/constraints/constraint_cyclic_node_state.jl
+++ b/src/constraints/constraint_cyclic_node_state.jl
@@ -52,7 +52,7 @@ function constraint_cyclic_node_state_indices(m::Model)
         )
         for t_end in last(time_slice(m; temporal_block=members(blk)))
         for path in active_stochastic_paths(
-            unique(x.stochastic_scenario for x in node_state_indices(m; node=n, t=[t_start, t_end]))
+            m, unique(x.stochastic_scenario for x in node_state_indices(m; node=n, t=[t_start, t_end]))
         )
     )
 end

--- a/src/constraints/constraint_cyclic_node_state.jl
+++ b/src/constraints/constraint_cyclic_node_state.jl
@@ -37,23 +37,23 @@ function add_constraint_cyclic_node_state!(m::Model)
                 for (n, s, t_start) in node_state_indices(m; node=n, stochastic_scenario=s, t=t_start);
                 init=0,
             )
-        ) for (n, s, t_start, t_end) in constraint_cyclic_node_state_indices(m)
+        )
+        for (n, s, t_start, t_end) in constraint_cyclic_node_state_indices(m)
     )
 end
 
 function constraint_cyclic_node_state_indices(m::Model)
     unique(
         (node=n, stochastic_path=path, t_start=t_start, t_end=t_end)
-        for (n, blk) in indices(cyclic_condition) if cyclic_condition(node=n, temporal_block=blk)
-        for t_start in filter(x -> blk in blocks(x), t_before_t(m; t_after=first(time_slice(m; temporal_block=members(blk)))))
+        for (n, blk) in indices(cyclic_condition)
+        if cyclic_condition(node=n, temporal_block=blk)
+        for t_start in filter(
+            x -> blk in blocks(x), t_before_t(m; t_after=first(time_slice(m; temporal_block=members(blk))))
+        )
         for t_end in last(time_slice(m; temporal_block=members(blk)))
         for path in active_stochastic_paths(
-            collect(
-                s
-                for s in stochastic_scenario()
-                if !isempty(node_state_indices(m; node=n, t=[t_start, t_end], stochastic_scenario=s))
-            )
-        )
+            unique(x.stochastic_scenario for x in node_state_indices(m; node=n, t=[t_start, t_end]))
+        )  # FIXME
     )
 end
 

--- a/src/constraints/constraint_cyclic_node_state.jl
+++ b/src/constraints/constraint_cyclic_node_state.jl
@@ -51,9 +51,7 @@ function constraint_cyclic_node_state_indices(m::Model)
             x -> blk in blocks(x), t_before_t(m; t_after=first(time_slice(m; temporal_block=members(blk))))
         )
         for t_end in last(time_slice(m; temporal_block=members(blk)))
-        for path in active_stochastic_paths(
-            m, unique(x.stochastic_scenario for x in node_state_indices(m; node=n, t=[t_start, t_end]))
-        )
+        for path in active_stochastic_paths(m, node_state_indices(m; node=n, t=[t_start, t_end]))
     )
 end
 

--- a/src/constraints/constraint_cyclic_node_state.jl
+++ b/src/constraints/constraint_cyclic_node_state.jl
@@ -53,7 +53,7 @@ function constraint_cyclic_node_state_indices(m::Model)
         for t_end in last(time_slice(m; temporal_block=members(blk)))
         for path in active_stochastic_paths(
             unique(x.stochastic_scenario for x in node_state_indices(m; node=n, t=[t_start, t_end]))
-        )  # FIXME
+        )
     )
 end
 

--- a/src/constraints/constraint_fix_node_pressure_point.jl
+++ b/src/constraints/constraint_fix_node_pressure_point.jl
@@ -30,7 +30,8 @@ function add_constraint_fix_node_pressure_point!(m::Model)
             m,
             (
                 expr_sum(
-                    connection_flow[conn, n_orig, d, s, t] for (conn, n_orig, d, s, t) in connection_flow_indices(
+                    connection_flow[conn, n_orig, d, s, t]
+                    for (conn, n_orig, d, s, t) in connection_flow_indices(
                         m;
                         connection=conn,
                         node=n_orig,
@@ -39,8 +40,10 @@ function add_constraint_fix_node_pressure_point!(m::Model)
                         t=t_in_t(m; t_long=t),
                     );
                     init=0
-                ) + expr_sum(
-                    connection_flow[conn, n_dest, d, s, t] for (conn, n_dest, d, s, t) in connection_flow_indices(
+                )
+                + expr_sum(
+                    connection_flow[conn, n_dest, d, s, t]
+                    for (conn, n_dest, d, s, t) in connection_flow_indices(
                         m;
                         connection=conn,
                         node=n_dest,
@@ -54,29 +57,28 @@ function add_constraint_fix_node_pressure_point!(m::Model)
             / 2
             <=
             0
-            + (fixed_pressure_constant_1[
+            + fixed_pressure_constant_1[
                 (connection=conn, node1=n_orig, node2=n_dest, i=j, stochastic_scenario=s, analysis_time=t0, t=t),
-            ]) * expr_sum(
-                node_pressure[n_orig, s, t] for (n_orig, s, t) in node_pressure_indices(
-                    m;
-                    node=n_orig,
-                    stochastic_scenario=s,
-                    t=t_in_t(m; t_long=t),
+            ]
+            * expr_sum(
+                node_pressure[n_orig, s, t]
+                for (n_orig, s, t) in node_pressure_indices(
+                    m; node=n_orig, stochastic_scenario=s, t=t_in_t(m; t_long=t)
                 );
                 init=0
             )
-            - (fixed_pressure_constant_0[
+            - fixed_pressure_constant_0[
                 (connection=conn, node1=n_orig, node2=n_dest, i=j, stochastic_scenario=s, analysis_time=t0, t=t),
-            ]) * expr_sum(
-                node_pressure[n_dest, s, t] for (n_dest, s, t) in node_pressure_indices(
-                    m;
-                    node=n_dest,
-                    stochastic_scenario=s,
-                    t=t_in_t(m; t_long=t),
+            ]
+            * expr_sum(
+                node_pressure[n_dest, s, t]
+                for (n_dest, s, t) in node_pressure_indices(
+                    m; node=n_dest, stochastic_scenario=s, t=t_in_t(m; t_long=t)
                 );
                 init=0
             )            
-            + big_m(model=m.ext[:spineopt].instance) * (expr_sum(
+            + big_m(model=m.ext[:spineopt].instance)
+            * expr_sum(
                 1 - binary_gas_connection_flow[conn, n_dest, direction(:to_node), s, t]
                 for (conn, n_dest, d, s, t) in connection_flow_indices(
                     m;
@@ -87,9 +89,10 @@ function add_constraint_fix_node_pressure_point!(m::Model)
                     t=t_in_t(m; t_long=t),
                 );
                 init=0
-            ))
-        ) for (conn, n_orig, n_dest, s, t) in constraint_connection_flow_gas_capacity_indices(m)
+            )
+        )
+        for (conn, n_orig, n_dest, s, t) in constraint_connection_flow_gas_capacity_indices(m)
         for j = 1:length(fixed_pressure_constant_1(connection=conn, node1=n_orig, node2=n_dest))
-            if fixed_pressure_constant_1(connection=conn, node1=n_orig, node2=n_dest, i=j) != 0
+        if fixed_pressure_constant_1(connection=conn, node1=n_orig, node2=n_dest, i=j) != 0
     )
 end

--- a/src/constraints/constraint_max_node_pressure.jl
+++ b/src/constraints/constraint_max_node_pressure.jl
@@ -35,7 +35,8 @@ function add_constraint_max_node_pressure!(m::Model)
             )
             <=
             + max_node_pressure[(node=ng, stochastic_scenario=s, analysis_time=t0, t=t)]
-        ) for (ng, s, t) in constraint_max_node_pressure_indices(m)
+        )
+        for (ng, s, t) in constraint_max_node_pressure_indices(m)
     )
 end
 
@@ -43,13 +44,7 @@ function constraint_max_node_pressure_indices(m::Model)
     unique(
         (node=ng, stochastic_path=path, t=t)
         for (ng, s, t) in node_pressure_indices(m; node=indices(max_node_pressure))
-        for path in active_stochastic_paths(
-            collect(
-                s
-                for s in stochastic_scenario()
-                if !isempty(node_pressure_indices(m; node=ng, t=t, stochastic_scenario=s))
-            )
-        )
+        for path in active_stochastic_paths(s)
     )
 end
 

--- a/src/constraints/constraint_max_node_pressure.jl
+++ b/src/constraints/constraint_max_node_pressure.jl
@@ -44,7 +44,7 @@ function constraint_max_node_pressure_indices(m::Model)
     unique(
         (node=ng, stochastic_path=path, t=t)
         for (ng, s, t) in node_pressure_indices(m; node=indices(max_node_pressure))
-        for path in active_stochastic_paths(s)
+        for path in active_stochastic_paths(m, s)
     )
 end
 

--- a/src/constraints/constraint_max_node_voltage_angle.jl
+++ b/src/constraints/constraint_max_node_voltage_angle.jl
@@ -44,7 +44,7 @@ function constraint_max_node_voltage_angle_indices(m::Model)
     unique(
         (node=ng, stochastic_path=path, t=t)
         for (ng, s, t) in node_voltage_angle_indices(m; node=indices(max_voltage_angle))
-        for path in active_stochastic_paths(s)
+        for path in active_stochastic_paths(m, s)
     )
 end
 

--- a/src/constraints/constraint_max_node_voltage_angle.jl
+++ b/src/constraints/constraint_max_node_voltage_angle.jl
@@ -35,7 +35,8 @@ function add_constraint_max_node_voltage_angle!(m::Model)
             )
             <=
             + max_voltage_angle[(node=ng, stochastic_scenario=s, analysis_time=t0, t=t)]
-        ) for (ng, s, t) in constraint_max_node_voltage_angle_indices(m)
+        )
+        for (ng, s, t) in constraint_max_node_voltage_angle_indices(m)
     )
 end
 
@@ -43,13 +44,7 @@ function constraint_max_node_voltage_angle_indices(m::Model)
     unique(
         (node=ng, stochastic_path=path, t=t)
         for (ng, s, t) in node_voltage_angle_indices(m; node=indices(max_voltage_angle))
-        for path in active_stochastic_paths(
-            collect(
-                s
-                for s in stochastic_scenario()
-                if !isempty(node_voltage_angle_indices(m; node=ng, t=t, stochastic_scenario=s))
-            )
-        )
+        for path in active_stochastic_paths(s)
     )
 end
 

--- a/src/constraints/constraint_max_nonspin_ramp_down.jl
+++ b/src/constraints/constraint_max_nonspin_ramp_down.jl
@@ -31,13 +31,9 @@ function add_constraint_max_nonspin_ramp_down!(m::Model)
         (unit=u, node=ng, direction=d, stochastic_path=s, t=t) => @constraint(
             m,
             + sum(
-                nonspin_ramp_down_unit_flow[u, n, d, s, t] for (u, n, d, s, t) in nonspin_ramp_down_unit_flow_indices(
-                    m;
-                    unit=u,
-                    node=ng,
-                    direction=d,
-                    stochastic_scenario=s,
-                    t=t_in_t(m; t_long=t),
+                nonspin_ramp_down_unit_flow[u, n, d, s, t]
+                for (u, n, d, s, t) in nonspin_ramp_down_unit_flow_indices(
+                    m; unit=u, node=ng, direction=d, stochastic_scenario=s, t=t_in_t(m; t_long=t),
                 )
             )
             <=
@@ -47,15 +43,12 @@ function add_constraint_max_nonspin_ramp_down!(m::Model)
                 * unit_conv_cap_to_flow[(unit=u, node=n, direction=d, stochastic_scenario=s, analysis_time=t0, t=t)]
                 * unit_capacity[(unit=u, node=n, direction=d, stochastic_scenario=s, analysis_time=t0, t=t)]
                 for (u, n, s, t) in nonspin_units_shut_down_indices(
-                    m;
-                    unit=u,
-                    node=ng,
-                    stochastic_scenario=s,
-                    t=t_overlaps_t(m; t=t),
+                    m; unit=u, node=ng, stochastic_scenario=s, t=t_overlaps_t(m; t=t),
                 );
                 init=0,
             )
-        ) for (u, ng, d, s, t) in constraint_max_nonspin_ramp_down_indices(m)
+        )
+        for (u, ng, d, s, t) in constraint_max_nonspin_ramp_down_indices(m)
     )
 end
 
@@ -63,15 +56,10 @@ function constraint_max_nonspin_ramp_down_indices(m::Model)
     unique(
         (unit=u, node=ng, direction=d, stochastic_path=path, t=t)
         for (u, ng, d) in indices(max_res_shutdown_ramp)
-        for t in t_lowest_resolution(time_slice(m; temporal_block=members(node__temporal_block(node=members(ng)))))
-        for path in active_stochastic_paths(
-            collect(
-                s
-                for s in stochastic_scenario()
-                if !isempty(
-                    nonspin_ramp_down_unit_flow_indices(m; unit=u, node=ng, direction=d, t=t, stochastic_scenario=s)
-                )
-                || !isempty(nonspin_units_shut_down_indices(m; unit=u, node=ng, t=t, stochastic_scenario=s))
+        for (t, path) in t_lowest_resolution_path(
+            vcat(
+                nonspin_ramp_down_unit_flow_indices(m; unit=u, node=ng, direction=d),
+                nonspin_units_shut_down_indices(m; unit=u, node=ng)
             )
         )
     )

--- a/src/constraints/constraint_max_nonspin_ramp_down.jl
+++ b/src/constraints/constraint_max_nonspin_ramp_down.jl
@@ -57,6 +57,7 @@ function constraint_max_nonspin_ramp_down_indices(m::Model)
         (unit=u, node=ng, direction=d, stochastic_path=path, t=t)
         for (u, ng, d) in indices(max_res_shutdown_ramp)
         for (t, path) in t_lowest_resolution_path(
+            m, 
             vcat(
                 nonspin_ramp_down_unit_flow_indices(m; unit=u, node=ng, direction=d),
                 nonspin_units_shut_down_indices(m; unit=u, node=ng)

--- a/src/constraints/constraint_max_nonspin_ramp_up.jl
+++ b/src/constraints/constraint_max_nonspin_ramp_up.jl
@@ -57,6 +57,7 @@ function constraint_max_nonspin_ramp_up_indices(m::Model)
         (unit=u, node=ng, direction=d, stochastic_path=path, t=t)
         for (u, ng, d) in indices(max_res_startup_ramp)
         for (t, path) in t_lowest_resolution_path(
+            m, 
             vcat(
                 nonspin_ramp_up_unit_flow_indices(m; unit=u, node=ng, direction=d),
                 nonspin_units_started_up_indices(m; unit=u, node=ng),

--- a/src/constraints/constraint_max_nonspin_ramp_up.jl
+++ b/src/constraints/constraint_max_nonspin_ramp_up.jl
@@ -31,13 +31,9 @@ function add_constraint_max_nonspin_ramp_up!(m::Model)
         (unit=u, node=ng, direction=d, stochastic_path=s, t=t) => @constraint(
             m,
             + sum(
-                nonspin_ramp_up_unit_flow[u, n, d, s, t] for (u, n, d, s, t) in nonspin_ramp_up_unit_flow_indices(
-                    m;
-                    unit=u,
-                    node=ng,
-                    direction=d,
-                    stochastic_scenario=s,
-                    t=t_in_t(m; t_long=t),
+                nonspin_ramp_up_unit_flow[u, n, d, s, t]
+                for (u, n, d, s, t) in nonspin_ramp_up_unit_flow_indices(
+                    m; unit=u, node=ng, direction=d, stochastic_scenario=s, t=t_in_t(m; t_long=t),
                 )
             )
             <=
@@ -47,15 +43,12 @@ function add_constraint_max_nonspin_ramp_up!(m::Model)
                 * unit_conv_cap_to_flow[(unit=u, node=n, direction=d, stochastic_scenario=s, analysis_time=t0, t=t)]
                 * unit_capacity[(unit=u, node=n, direction=d, stochastic_scenario=s, analysis_time=t0, t=t)]
                 for (u, n, s, t) in nonspin_units_started_up_indices(
-                    m;
-                    unit=u,
-                    node=ng,
-                    stochastic_scenario=s,
-                    t=t_overlaps_t(m; t=t),
+                    m; unit=u, node=ng, stochastic_scenario=s, t=t_overlaps_t(m; t=t),
                 );
                 init=0,
             )
-        ) for (u, ng, d, s, t) in constraint_max_nonspin_ramp_up_indices(m)
+        )
+        for (u, ng, d, s, t) in constraint_max_nonspin_ramp_up_indices(m)
     )
 end
 
@@ -63,15 +56,10 @@ function constraint_max_nonspin_ramp_up_indices(m::Model)
     unique(
         (unit=u, node=ng, direction=d, stochastic_path=path, t=t)
         for (u, ng, d) in indices(max_res_startup_ramp)
-        for t in t_lowest_resolution(time_slice(m; temporal_block=members(node__temporal_block(node=members(ng)))))
-        for path in active_stochastic_paths(
-            collect(
-                s
-                for s in stochastic_scenario()
-                if !isempty(
-                    nonspin_ramp_up_unit_flow_indices(m; unit=u, node=ng, direction=d, t=t, stochastic_scenario=s)
-                )
-                || !isempty(nonspin_units_started_up_indices(m; unit=u, node=ng, t=t, stochastic_scenario=s))
+        for (t, path) in t_lowest_resolution_path(
+            vcat(
+                nonspin_ramp_up_unit_flow_indices(m; unit=u, node=ng, direction=d),
+                nonspin_units_started_up_indices(m; unit=u, node=ng),
             )
         )
     )

--- a/src/constraints/constraint_max_shut_down_ramp.jl
+++ b/src/constraints/constraint_max_shut_down_ramp.jl
@@ -53,7 +53,7 @@ function constraint_max_shut_down_ramp_indices(m::Model)
         (unit=u, node=ng, direction=d, stochastic_path=path, t=t)
         for (u, ng, d) in indices(max_shutdown_ramp)
         for (t, path) in t_lowest_resolution_path(
-            vcat(units_on_indices(m; unit=u), shut_down_unit_flow_indices(m; unit=u, node=ng, direction=d))
+            m, vcat(units_on_indices(m; unit=u), shut_down_unit_flow_indices(m; unit=u, node=ng, direction=d))
         )
     )
 end

--- a/src/constraints/constraint_max_shut_down_ramp.jl
+++ b/src/constraints/constraint_max_shut_down_ramp.jl
@@ -30,13 +30,9 @@ function add_constraint_max_shut_down_ramp!(m::Model)
         (unit=u, node=ng, direction=d, stochastic_path=s, t=t) => @constraint(
             m,
             + sum(
-                shut_down_unit_flow[u, n, d, s, t] for (u, n, d, s, t) in shut_down_unit_flow_indices(
-                    m;
-                    unit=u,
-                    node=ng,
-                    direction=d,
-                    stochastic_scenario=s,
-                    t=t_in_t(m; t_long=t),
+                shut_down_unit_flow[u, n, d, s, t]
+                for (u, n, d, s, t) in shut_down_unit_flow_indices(
+                    m; unit=u, node=ng, direction=d, stochastic_scenario=s, t=t_in_t(m; t_long=t)
                 )
             )
             <=
@@ -47,7 +43,8 @@ function add_constraint_max_shut_down_ramp!(m::Model)
                 * unit_capacity[(unit=u, node=ng, direction=d, stochastic_scenario=s, analysis_time=t0, t=t)]
                 for (u, s, t) in units_on_indices(m; unit=u, stochastic_scenario=s, t=t_overlaps_t(m; t=t))
             )
-        ) for (u, ng, d, s, t) in constraint_max_shut_down_ramp_indices(m)
+        )
+        for (u, ng, d, s, t) in constraint_max_shut_down_ramp_indices(m)
     )
 end
 
@@ -55,14 +52,8 @@ function constraint_max_shut_down_ramp_indices(m::Model)
     unique(
         (unit=u, node=ng, direction=d, stochastic_path=path, t=t)
         for (u, ng, d) in indices(max_shutdown_ramp)
-        for t in t_lowest_resolution(time_slice(m; temporal_block=members(node__temporal_block(node=members(ng)))))
-        for path in active_stochastic_paths(
-            collect(
-                s
-                for s in stochastic_scenario()
-                if !isempty(units_on_indices(m; unit=u, t=t, stochastic_scenario=s))
-                || !isempty(shut_down_unit_flow_indices(m; unit=u, node=ng, direction=d, t=t, stochastic_scenario=s))
-            )
+        for (t, path) in t_lowest_resolution_path(
+            vcat(units_on_indices(m; unit=u), shut_down_unit_flow_indices(m; unit=u, node=ng, direction=d))
         )
     )
 end

--- a/src/constraints/constraint_max_start_up_ramp.jl
+++ b/src/constraints/constraint_max_start_up_ramp.jl
@@ -30,13 +30,9 @@ function add_constraint_max_start_up_ramp!(m::Model)
         (unit=u, node=ng, direction=d, stochastic_path=s, t=t) => @constraint(
             m,
             + sum(
-                start_up_unit_flow[u, n, d, s, t] for (u, n, d, s, t) in start_up_unit_flow_indices(
-                    m;
-                    unit=u,
-                    node=ng,
-                    direction=d,
-                    stochastic_scenario=s,
-                    t=t_in_t(m; t_long=t),
+                start_up_unit_flow[u, n, d, s, t]
+                for (u, n, d, s, t) in start_up_unit_flow_indices(
+                    m; unit=u, node=ng, direction=d, stochastic_scenario=s, t=t_in_t(m; t_long=t),
                 )
             )
             <=
@@ -47,7 +43,8 @@ function add_constraint_max_start_up_ramp!(m::Model)
                 * unit_capacity[(unit=u, node=ng, direction=d, stochastic_scenario=s, analysis_time=t0, t=t)]
                 for (u, s, t) in units_on_indices(m; unit=u, stochastic_scenario=s, t=t_overlaps_t(m; t=t))
             )
-        ) for (u, ng, d, s, t) in constraint_max_start_up_ramp_indices(m)
+        )
+        for (u, ng, d, s, t) in constraint_max_start_up_ramp_indices(m)
     )
 end
 
@@ -55,16 +52,8 @@ function constraint_max_start_up_ramp_indices(m::Model)
     unique(
         (unit=u, node=ng, direction=d, stochastic_path=path, t=t)
         for (u, ng, d) in indices(max_startup_ramp)
-        for t in t_lowest_resolution(time_slice(m; temporal_block=members(node__temporal_block(node=members(ng)))))
-        for path in active_stochastic_paths(
-            collect(
-                s
-                for s in stochastic_scenario()
-                if !isempty(units_on_indices(m; unit=u, t=t, stochastic_scenario=s))
-                || !isempty(
-                    start_up_unit_flow_indices(m; unit=u, node=ng, direction=d, t=t, stochastic_scenario=s)
-                )  # Current `units_on` and `units_available`, plus `units_shut_down` during past time slices   
-            )
+        for (t, path) in t_lowest_resolution_path(
+            vcat(units_on_indices(m; unit=u), start_up_unit_flow_indices(m; unit=u, node=ng, direction=d))
         )
     )
 end

--- a/src/constraints/constraint_max_start_up_ramp.jl
+++ b/src/constraints/constraint_max_start_up_ramp.jl
@@ -53,7 +53,7 @@ function constraint_max_start_up_ramp_indices(m::Model)
         (unit=u, node=ng, direction=d, stochastic_path=path, t=t)
         for (u, ng, d) in indices(max_startup_ramp)
         for (t, path) in t_lowest_resolution_path(
-            vcat(units_on_indices(m; unit=u), start_up_unit_flow_indices(m; unit=u, node=ng, direction=d))
+            m, vcat(units_on_indices(m; unit=u), start_up_unit_flow_indices(m; unit=u, node=ng, direction=d))
         )
     )
 end

--- a/src/constraints/constraint_min_down_time.jl
+++ b/src/constraints/constraint_min_down_time.jl
@@ -67,12 +67,9 @@ function constraint_min_down_time_indices(m::Model)
         for (u, t) in unit_time_indices(m; unit=u)
         for path in active_stochastic_paths(
             m, 
-            unique(
-                ind.stochastic_scenario
-                for ind in vcat(
-                    past_units_on_indices(m, u, anything, t, min_down_time),
-                    nonspin_units_started_up_indices(m; unit=u, t=t_before_t(m; t_after=t), temporal_block=anything)
-                )
+            vcat(
+                past_units_on_indices(m, u, anything, t, min_down_time),
+                nonspin_units_started_up_indices(m; unit=u, t=t_before_t(m; t_after=t), temporal_block=anything)
             )
         )
     )

--- a/src/constraints/constraint_min_down_time.jl
+++ b/src/constraints/constraint_min_down_time.jl
@@ -66,6 +66,7 @@ function constraint_min_down_time_indices(m::Model)
         for u in indices(min_down_time)
         for (u, t) in unit_time_indices(m; unit=u)
         for path in active_stochastic_paths(
+            m, 
             unique(
                 ind.stochastic_scenario
                 for ind in vcat(

--- a/src/constraints/constraint_min_down_time.jl
+++ b/src/constraints/constraint_min_down_time.jl
@@ -43,23 +43,12 @@ function add_constraint_min_down_time!(m::Model)
             )
             >=
             + expr_sum(
-                + units_shut_down[u, s_past, t_past]
-                for (u, s_past, t_past) in units_on_indices(
-                    m;
-                    unit=u,
-                    stochastic_scenario=s,
-                    t=to_time_slice(
-                        m;
-                        t=TimeSlice(
-                            end_(t) - min_down_time(unit=u, stochastic_scenario=s, analysis_time=t0, t=t), end_(t)
-                        ),
-                    ),
-                    temporal_block=anything,
-                );
+                units_shut_down[u, s_past, t_past]
+                for (u, s_past, t_past) in past_units_on_indices(m, u, t0, s, t, min_down_time);
                 init=0,
             )
             + expr_sum(
-                + nonspin_units_started_up[u, n, s, t]
+                nonspin_units_started_up[u, n, s, t]
                 for (u, n, s, t) in nonspin_units_started_up_indices(
                     m; unit=u, stochastic_scenario=s, t=t, temporal_block=anything
                 );
@@ -81,22 +70,13 @@ function constraint_min_down_time_indices(m::Model)
             unique(
                 ind.stochastic_scenario
                 for ind in vcat(
-                    units_on_indices(
-                        m;
-                        unit=u,
-                        t=to_time_slice(
-                            m;
-                            t=TimeSlice(
-                                end_(t) - min_down_time(unit=u, analysis_time=t0, stochastic_scenario=s, t=t), end_(t)
-                            )
-                        )
-                    ),
+                    past_units_on_indices(m, u, t0, anything, t, min_down_time),
                     nonspin_units_started_up_indices(
                         m; unit=u, t=t_before_t(m; t_after=t), temporal_block=anything, stochastic_scenario=s
                     )
                 )
             )
-        )  # FIXME
+        )
     )
 end
 

--- a/src/constraints/constraint_min_down_time.jl
+++ b/src/constraints/constraint_min_down_time.jl
@@ -44,7 +44,7 @@ function add_constraint_min_down_time!(m::Model)
             >=
             + expr_sum(
                 units_shut_down[u, s_past, t_past]
-                for (u, s_past, t_past) in past_units_on_indices(m, u, t0, s, t, min_down_time);
+                for (u, s_past, t_past) in past_units_on_indices(m, u, s, t, min_down_time);
                 init=0,
             )
             + expr_sum(
@@ -61,19 +61,16 @@ end
 
 # TODO: Does this require nonspin_units_started_up_indices() to be added here?
 function constraint_min_down_time_indices(m::Model)
-    t0 = _analysis_time(m)
     unique(
         (unit=u, stochastic_path=path, t=t)
         for u in indices(min_down_time)
-        for (u, s, t) in units_on_indices(m; unit=u)
+        for (u, t) in unit_time_indices(m; unit=u)
         for path in active_stochastic_paths(
             unique(
                 ind.stochastic_scenario
                 for ind in vcat(
-                    past_units_on_indices(m, u, t0, anything, t, min_down_time),
-                    nonspin_units_started_up_indices(
-                        m; unit=u, t=t_before_t(m; t_after=t), temporal_block=anything, stochastic_scenario=s
-                    )
+                    past_units_on_indices(m, u, anything, t, min_down_time),
+                    nonspin_units_started_up_indices(m; unit=u, t=t_before_t(m; t_after=t), temporal_block=anything)
                 )
             )
         )

--- a/src/constraints/constraint_min_down_time.jl
+++ b/src/constraints/constraint_min_down_time.jl
@@ -28,13 +28,13 @@ function add_constraint_min_down_time!(m::Model)
     m.ext[:spineopt].constraints[:min_down_time] = Dict(
         (unit=u, stochastic_path=s, t=t) => @constraint(
             m,
-            +expr_sum(
-                +number_of_units[(unit=u, stochastic_scenario=s, analysis_time=t0, t=t)] 
+            + expr_sum(
+                + number_of_units[(unit=u, stochastic_scenario=s, analysis_time=t0, t=t)] 
                 + expr_sum(
                     units_invested_available[u, s, t1]
-                    for
-                    (u, s, t1) in
-                    units_invested_available_indices(m; unit=u, stochastic_scenario=s, t=t_in_t(m; t_short=t));
+                    for (u, s, t1) in units_invested_available_indices(
+                        m; unit=u, stochastic_scenario=s, t=t_in_t(m; t_short=t)
+                    );
                     init=0,
                 )
                 - units_on[u, s, t]
@@ -43,41 +43,60 @@ function add_constraint_min_down_time!(m::Model)
             )
             >=
             + expr_sum(
-                + units_shut_down[u, s_past, t_past] for (u, s_past, t_past) in units_on_indices(
+                + units_shut_down[u, s_past, t_past]
+                for (u, s_past, t_past) in units_on_indices(
                     m;
                     unit=u,
                     stochastic_scenario=s,
                     t=to_time_slice(
                         m;
                         t=TimeSlice(
-                            end_(t) - min_down_time(unit=u, stochastic_scenario=s, analysis_time=t0, t=t),
-                            end_(t),
+                            end_(t) - min_down_time(unit=u, stochastic_scenario=s, analysis_time=t0, t=t), end_(t)
                         ),
                     ),
                     temporal_block=anything,
                 );
                 init=0,
-            ) + expr_sum(
-                + nonspin_units_started_up[u, n, s, t] for (u, n, s, t) in nonspin_units_started_up_indices(
-                    m;
-                    unit=u,
-                    stochastic_scenario=s,
-                    t=t,
-                    temporal_block=anything,
+            )
+            + expr_sum(
+                + nonspin_units_started_up[u, n, s, t]
+                for (u, n, s, t) in nonspin_units_started_up_indices(
+                    m; unit=u, stochastic_scenario=s, t=t, temporal_block=anything
                 );
                 init=0,
             )
-        ) for (u, s, t) in constraint_min_down_time_indices(m)
+        )
+        for (u, s, t) in constraint_min_down_time_indices(m)
     )
 end
 
-#TODO: Does this require nonspin_units_started_up_indices() to be added here?
+# TODO: Does this require nonspin_units_started_up_indices() to be added here?
 function constraint_min_down_time_indices(m::Model)
     t0 = _analysis_time(m)
     unique(
         (unit=u, stochastic_path=path, t=t)
-        for u in indices(min_down_time) for (u, s, t) in units_on_indices(m; unit=u)
-        for path in active_stochastic_paths(collect(_constraint_min_down_time_scenarios(m, u, s, t0, t)))
+        for u in indices(min_down_time)
+        for (u, s, t) in units_on_indices(m; unit=u)
+        for path in active_stochastic_paths(
+            unique(
+                ind.stochastic_scenario
+                for ind in vcat(
+                    units_on_indices(
+                        m;
+                        unit=u,
+                        t=to_time_slice(
+                            m;
+                            t=TimeSlice(
+                                end_(t) - min_down_time(unit=u, analysis_time=t0, stochastic_scenario=s, t=t), end_(t)
+                            )
+                        )
+                    ),
+                    nonspin_units_started_up_indices(
+                        m; unit=u, t=t_before_t(m; t_after=t), temporal_block=anything, stochastic_scenario=s
+                    )
+                )
+            )
+        )  # FIXME
     )
 end
 
@@ -93,23 +112,4 @@ Keyword arguments can be used to filter the resulting Array.
 function constraint_min_down_time_indices_filtered(m::Model; unit=anything, stochastic_path=anything, t=anything)
     f(ind) = _index_in(ind; unit=unit, stochastic_path=stochastic_path, t=t)
     filter(f, constraint_min_down_time_indices(m))
-end
-
-function _constraint_min_down_time_scenarios(m, u, s, t0, t)
-    t_past_and_present = to_time_slice(
-        m;
-        t=TimeSlice(end_(t) - min_down_time(unit=u, stochastic_scenario=s, analysis_time=t0, t=t), end_(t)),
-    )
-    (
-        s
-        for s in stochastic_scenario()
-        if !isempty(
-            units_on_indices(m; unit=u, t=t_past_and_present, temporal_block=anything, stochastic_scenario=s)
-        )
-        || !isempty(
-            nonspin_units_started_up_indices(
-                m; unit=u, t=t_before_t(m; t_after=t), temporal_block=anything, stochastic_scenario=s
-            )
-        )
-    )
 end

--- a/src/constraints/constraint_min_node_pressure.jl
+++ b/src/constraints/constraint_min_node_pressure.jl
@@ -35,7 +35,8 @@ function add_constraint_min_node_pressure!(m::Model)
             )
             >=
             + min_node_pressure[(node=ng, stochastic_scenario=s, analysis_time=t0, t=t)]
-        ) for (ng, s, t) in constraint_min_node_pressure_indices(m)
+        )
+        for (ng, s, t) in constraint_min_node_pressure_indices(m)
     )
 end
 
@@ -43,13 +44,7 @@ function constraint_min_node_pressure_indices(m::Model)
     unique(
         (node=ng, stochastic_path=path, t=t)
         for (ng, s, t) in node_pressure_indices(m; node=indices(min_node_pressure))
-        for path in active_stochastic_paths(
-            collect(
-                s
-                for s in stochastic_scenario()
-                if !isempty(node_pressure_indices(m; node=ng, t=t, stochastic_scenario=s))
-            )
-        )
+        for path in active_stochastic_paths(s)
     )
 end
 

--- a/src/constraints/constraint_min_node_pressure.jl
+++ b/src/constraints/constraint_min_node_pressure.jl
@@ -44,7 +44,7 @@ function constraint_min_node_pressure_indices(m::Model)
     unique(
         (node=ng, stochastic_path=path, t=t)
         for (ng, s, t) in node_pressure_indices(m; node=indices(min_node_pressure))
-        for path in active_stochastic_paths(s)
+        for path in active_stochastic_paths(m, s)
     )
 end
 

--- a/src/constraints/constraint_min_node_voltage_angle.jl
+++ b/src/constraints/constraint_min_node_voltage_angle.jl
@@ -35,7 +35,8 @@ function add_constraint_min_node_voltage_angle!(m::Model)
             )
             >=
             + min_voltage_angle[(node=ng, stochastic_scenario=s, analysis_time=t0, t=t)]
-        ) for (ng, s, t) in constraint_min_node_voltage_angle_indices(m)
+        )
+        for (ng, s, t) in constraint_min_node_voltage_angle_indices(m)
     )
 end
 
@@ -43,13 +44,7 @@ function constraint_min_node_voltage_angle_indices(m::Model)
     unique(
         (node=ng, stochastic_path=path, t=t)
         for (ng, s, t) in node_voltage_angle_indices(m; node=indices(min_voltage_angle))
-        for path in active_stochastic_paths(
-            collect(
-                s
-                for s in stochastic_scenario()
-                if !isempty(node_voltage_angle_indices(m; node=ng, t=t, stochastic_scenario=s))
-            )
-        )
+        for path in active_stochastic_paths(s)
     )
 end
 

--- a/src/constraints/constraint_min_node_voltage_angle.jl
+++ b/src/constraints/constraint_min_node_voltage_angle.jl
@@ -44,7 +44,7 @@ function constraint_min_node_voltage_angle_indices(m::Model)
     unique(
         (node=ng, stochastic_path=path, t=t)
         for (ng, s, t) in node_voltage_angle_indices(m; node=indices(min_voltage_angle))
-        for path in active_stochastic_paths(s)
+        for path in active_stochastic_paths(m, s)
     )
 end
 

--- a/src/constraints/constraint_min_nonspin_ramp_down.jl
+++ b/src/constraints/constraint_min_nonspin_ramp_down.jl
@@ -31,13 +31,9 @@ function add_constraint_min_nonspin_ramp_down!(m::Model)
         (unit=u, node=ng, direction=d, stochastic_path=s, t=t) => @constraint(
             m,
             + sum(
-                nonspin_ramp_down_unit_flow[u, n, d, s, t] for (u, n, d, s, t) in nonspin_ramp_down_unit_flow_indices(
-                    m;
-                    unit=u,
-                    node=ng,
-                    direction=d,
-                    stochastic_scenario=s,
-                    t=t_in_t(m; t_long=t),
+                nonspin_ramp_down_unit_flow[u, n, d, s, t]
+                for (u, n, d, s, t) in nonspin_ramp_down_unit_flow_indices(
+                    m; unit=u, node=ng, direction=d, stochastic_scenario=s, t=t_in_t(m; t_long=t)
                 )
             )
             >=
@@ -47,15 +43,12 @@ function add_constraint_min_nonspin_ramp_down!(m::Model)
                 * unit_conv_cap_to_flow[(unit=u, node=ng, direction=d, stochastic_scenario=s, analysis_time=t0, t=t)]
                 * unit_capacity[(unit=u, node=ng, direction=d, stochastic_scenario=s, analysis_time=t0, t=t)]
                 for (u, n, s, t) in nonspin_units_shut_down_indices(
-                    m;
-                    unit=u,
-                    node=ng,
-                    stochastic_scenario=s,
-                    t=t_overlaps_t(m; t=t),
+                    m; unit=u, node=ng, stochastic_scenario=s, t=t_overlaps_t(m; t=t)
                 );
                 init=0,
             )
-        ) for (u, ng, d, s, t) in constraint_min_nonspin_ramp_down_indices(m)
+        )
+        for (u, ng, d, s, t) in constraint_min_nonspin_ramp_down_indices(m)
     )
 end
 
@@ -63,17 +56,10 @@ function constraint_min_nonspin_ramp_down_indices(m::Model)
     unique(
         (unit=u, node=ng, direction=d, stochastic_path=path, t=t)
         for (u, ng, d) in indices(min_res_shutdown_ramp)
-        for t in t_lowest_resolution(time_slice(m; temporal_block=members(node__temporal_block(node=members(ng)))))
-        for path in active_stochastic_paths(
-            collect(
-                s
-                for s in stochastic_scenario()
-                if !isempty(
-                    nonspin_ramp_down_unit_flow_indices(m; unit=u, node=ng, direction=d, t=t, stochastic_scenario=s)
-                )
-                || !isempty(
-                    nonspin_units_shut_down_indices(m; unit=u, node=ng, t=t, stochastic_scenario=s)
-                )
+        for (t, path) in t_lowest_resolution_path(
+            vcat(
+                nonspin_ramp_down_unit_flow_indices(m; unit=u, node=ng, direction=d),
+                nonspin_units_shut_down_indices(m; unit=u, node=ng)
             )
         )
     )

--- a/src/constraints/constraint_min_nonspin_ramp_down.jl
+++ b/src/constraints/constraint_min_nonspin_ramp_down.jl
@@ -57,6 +57,7 @@ function constraint_min_nonspin_ramp_down_indices(m::Model)
         (unit=u, node=ng, direction=d, stochastic_path=path, t=t)
         for (u, ng, d) in indices(min_res_shutdown_ramp)
         for (t, path) in t_lowest_resolution_path(
+            m, 
             vcat(
                 nonspin_ramp_down_unit_flow_indices(m; unit=u, node=ng, direction=d),
                 nonspin_units_shut_down_indices(m; unit=u, node=ng)

--- a/src/constraints/constraint_min_nonspin_ramp_up.jl
+++ b/src/constraints/constraint_min_nonspin_ramp_up.jl
@@ -57,6 +57,7 @@ function constraint_min_nonspin_ramp_up_indices(m::Model)
         (unit=u, node=ng, direction=d, stochastic_path=path, t=t)
         for (u, ng, d) in indices(min_res_startup_ramp)
         for (t, path) in t_lowest_resolution_path(
+            m, 
             vcat(
                 nonspin_ramp_up_unit_flow_indices(m; unit=u, node=ng, direction=d),
                 nonspin_units_started_up_indices(m; unit=u, node=ng)

--- a/src/constraints/constraint_min_shut_down_ramp.jl
+++ b/src/constraints/constraint_min_shut_down_ramp.jl
@@ -31,13 +31,9 @@ function add_constraint_min_shut_down_ramp!(m::Model)
         (unit=u, node=ng, direction=d, stochastic_path=s, t=t) => @constraint(
             m,
             + sum(
-                shut_down_unit_flow[u, n, d, s, t] for (u, n, d, s, t) in shut_down_unit_flow_indices(
-                    m;
-                    unit=u,
-                    node=ng,
-                    direction=d,
-                    stochastic_scenario=s,
-                    t=t_in_t(m; t_long=t),
+                shut_down_unit_flow[u, n, d, s, t]
+                for (u, n, d, s, t) in shut_down_unit_flow_indices(
+                    m; unit=u, node=ng, direction=d, stochastic_scenario=s, t=t_in_t(m; t_long=t)
                 )
             )
             >=
@@ -48,7 +44,8 @@ function add_constraint_min_shut_down_ramp!(m::Model)
                 * unit_capacity[(unit=u, node=ng, direction=d, stochastic_scenario=s, analysis_time=t0, t=t)]
                 for (u, s, t) in units_on_indices(m; unit=u, stochastic_scenario=s, t=t_overlaps_t(m; t=t))
             )
-        ) for (u, ng, d, s, t) in constraint_min_shut_down_ramp_indices(m)
+        )
+        for (u, ng, d, s, t) in constraint_min_shut_down_ramp_indices(m)
     )
 end
 
@@ -56,18 +53,8 @@ function constraint_min_shut_down_ramp_indices(m::Model)
     unique(
         (unit=u, node=ng, direction=d, stochastic_path=path, t=t)
         for (u, ng, d) in indices(min_shutdown_ramp)
-        for t in t_lowest_resolution(time_slice(m; temporal_block=members(node__temporal_block(node=members(ng)))))
-        for path in active_stochastic_paths(
-            collect(
-                s
-                for s in stochastic_scenario()
-                if !isempty(
-                    units_on_indices(m; unit=u, t=t, stochastic_scenario=s)
-                )
-                || !isempty(
-                    shut_down_unit_flow_indices(m; unit=u, node=ng, direction=d, t=t, stochastic_scenario=s)
-                )
-            )
+        for (t, path) in t_lowest_resolution_path(
+            vcat(units_on_indices(m; unit=u), shut_down_unit_flow_indices(m; unit=u, node=ng, direction=d))
         )
     )
 end

--- a/src/constraints/constraint_min_shut_down_ramp.jl
+++ b/src/constraints/constraint_min_shut_down_ramp.jl
@@ -54,7 +54,7 @@ function constraint_min_shut_down_ramp_indices(m::Model)
         (unit=u, node=ng, direction=d, stochastic_path=path, t=t)
         for (u, ng, d) in indices(min_shutdown_ramp)
         for (t, path) in t_lowest_resolution_path(
-            vcat(units_on_indices(m; unit=u), shut_down_unit_flow_indices(m; unit=u, node=ng, direction=d))
+            m, vcat(units_on_indices(m; unit=u), shut_down_unit_flow_indices(m; unit=u, node=ng, direction=d))
         )
     )
 end

--- a/src/constraints/constraint_min_start_up_ramp.jl
+++ b/src/constraints/constraint_min_start_up_ramp.jl
@@ -54,7 +54,7 @@ function constraint_min_start_up_ramp_indices(m::Model)
         (unit=u, node=ng, direction=d, stochastic_path=path, t=t)
         for (u, ng, d) in indices(min_startup_ramp)
         for (t, path) in t_lowest_resolution_path(
-            vcat(units_on_indices(m; unit=u), start_up_unit_flow_indices(m; unit=u, node=ng))
+            m, vcat(units_on_indices(m; unit=u), start_up_unit_flow_indices(m; unit=u, node=ng))
         )
     )
 end

--- a/src/constraints/constraint_min_start_up_ramp.jl
+++ b/src/constraints/constraint_min_start_up_ramp.jl
@@ -31,13 +31,9 @@ function add_constraint_min_start_up_ramp!(m::Model)
         (unit=u, node=ng, direction=d, stochastic_path=s, t=t) => @constraint(
             m,
             + sum(
-                start_up_unit_flow[u, n, d, s, t] for (u, n, d, s, t) in start_up_unit_flow_indices(
-                    m;
-                    unit=u,
-                    node=ng,
-                    direction=d,
-                    stochastic_scenario=s,
-                    t=t_in_t(m; t_long=t),
+                start_up_unit_flow[u, n, d, s, t]
+                for (u, n, d, s, t) in start_up_unit_flow_indices(
+                    m; unit=u, node=ng, direction=d, stochastic_scenario=s, t=t_in_t(m; t_long=t)
                 )
             )
             >=
@@ -48,7 +44,8 @@ function add_constraint_min_start_up_ramp!(m::Model)
                 * unit_capacity[(unit=u, node=ng, direction=d, stochastic_scenario=s, analysis_time=t0, t=t)]
                 for (u, s, t) in units_on_indices(m; unit=u, stochastic_scenario=s, t=t_overlaps_t(m; t=t))
             )
-        ) for (u, ng, d, s, t) in constraint_min_start_up_ramp_indices(m)
+        )
+        for (u, ng, d, s, t) in constraint_min_start_up_ramp_indices(m)
     )
 end
 
@@ -56,16 +53,8 @@ function constraint_min_start_up_ramp_indices(m::Model)
     unique(
         (unit=u, node=ng, direction=d, stochastic_path=path, t=t)
         for (u, ng, d) in indices(min_startup_ramp)
-        for t in t_lowest_resolution(time_slice(m; temporal_block=members(node__temporal_block(node=members(ng)))))
-        for path in active_stochastic_paths(
-            collect(
-                s
-                for s in stochastic_scenario()
-                if !isempty(units_on_indices(m; unit=u, t=t, stochastic_scenario=s))
-                || !isempty(
-                    start_up_unit_flow_indices(m; unit=u, node=ng, direction=d, t=t, stochastic_scenario=s)
-                )  # Current `units_on` and `units_available`, plus `units_shut_down` during past time slices
-            )
+        for (t, path) in t_lowest_resolution_path(
+            vcat(units_on_indices(m; unit=u), start_up_unit_flow_indices(m; unit=u, node=ng))
         )
     )
 end

--- a/src/constraints/constraint_min_up_time.jl
+++ b/src/constraints/constraint_min_up_time.jl
@@ -44,7 +44,7 @@ function add_constraint_min_up_time!(m::Model)
             >=
             + sum(
                 units_started_up[u, s_past, t_past]
-                for (u, s_past, t_past) in past_units_on_indices(m, u, t0, s, t, min_up_time)
+                for (u, s_past, t_past) in past_units_on_indices(m, u, s, t, min_up_time)
             )
         )
         for (u, s, t) in constraint_min_up_time_indices(m)
@@ -52,13 +52,12 @@ function add_constraint_min_up_time!(m::Model)
 end
 
 function constraint_min_up_time_indices(m::Model; unit=anything, stochastic_path=anything, t=anything)
-    t0 = _analysis_time(m)
     unique(
         (unit=u, stochastic_path=path, t=t)
         for u in indices(min_up_time)
-        for (u, s, t) in units_on_indices(m; unit=u)
+        for (u, t) in unit_time_indices(m; unit=u)
         for path in active_stochastic_paths(
-            unique(ind.stochastic_scenario for ind in past_units_on_indices(m, u, t0, anything, t, min_up_time))
+            unique(ind.stochastic_scenario for ind in past_units_on_indices(m, u, anything, t, min_up_time))
         )
     )
 end

--- a/src/constraints/constraint_min_up_time.jl
+++ b/src/constraints/constraint_min_up_time.jl
@@ -57,7 +57,7 @@ function constraint_min_up_time_indices(m::Model; unit=anything, stochastic_path
         for u in indices(min_up_time)
         for (u, t) in unit_time_indices(m; unit=u)
         for path in active_stochastic_paths(
-            unique(ind.stochastic_scenario for ind in past_units_on_indices(m, u, anything, t, min_up_time))
+            m, unique(ind.stochastic_scenario for ind in past_units_on_indices(m, u, anything, t, min_up_time))
         )
     )
 end

--- a/src/constraints/constraint_min_up_time.jl
+++ b/src/constraints/constraint_min_up_time.jl
@@ -56,9 +56,7 @@ function constraint_min_up_time_indices(m::Model; unit=anything, stochastic_path
         (unit=u, stochastic_path=path, t=t)
         for u in indices(min_up_time)
         for (u, t) in unit_time_indices(m; unit=u)
-        for path in active_stochastic_paths(
-            m, unique(ind.stochastic_scenario for ind in past_units_on_indices(m, u, anything, t, min_up_time))
-        )
+        for path in active_stochastic_paths(m, past_units_on_indices(m, u, anything, t, min_up_time))
     )
 end
 

--- a/src/constraints/constraint_min_up_time.jl
+++ b/src/constraints/constraint_min_up_time.jl
@@ -43,18 +43,8 @@ function add_constraint_min_up_time!(m::Model)
             )
             >=
             + sum(
-                + units_started_up[u, s_past, t_past] for (u, s_past, t_past) in units_on_indices(
-                    m;
-                    unit=u,
-                    stochastic_scenario=s,
-                    t=to_time_slice(
-                        m;
-                        t=TimeSlice(
-                            end_(t) - min_up_time(unit=u, stochastic_scenario=s, analysis_time=t0, t=t), end_(t)
-                        ),
-                    ),
-                    temporal_block=anything,
-                )
+                units_started_up[u, s_past, t_past]
+                for (u, s_past, t_past) in past_units_on_indices(m, u, t0, s, t, min_up_time)
             )
         )
         for (u, s, t) in constraint_min_up_time_indices(m)
@@ -68,20 +58,8 @@ function constraint_min_up_time_indices(m::Model; unit=anything, stochastic_path
         for u in indices(min_up_time)
         for (u, s, t) in units_on_indices(m; unit=u)
         for path in active_stochastic_paths(
-            unique(
-                ind.stochastic_scenario
-                for ind in units_on_indices(
-                    m;
-                    unit=u,
-                    t=to_time_slice(
-                        m;
-                        t=TimeSlice(
-                            end_(t) - min_up_time(unit=u, stochastic_scenario=s, analysis_time=t0, t=t), end_(t)
-                        )
-                    )
-                )
-            )
-        )  # FIXME
+            unique(ind.stochastic_scenario for ind in past_units_on_indices(m, u, t0, anything, t, min_up_time))
+        )
     )
 end
 

--- a/src/constraints/constraint_minimum_operating_point.jl
+++ b/src/constraints/constraint_minimum_operating_point.jl
@@ -29,19 +29,13 @@ function add_constraint_minimum_operating_point!(m::Model)
         (unit=u, node=ng, direction=d, stochastic_path=s, t=t) => @constraint(
             m,
             + expr_sum(
-                + unit_flow[u, n, d, s, t] for (u, n, d, s, t) in unit_flow_indices(
-                    m;
-                    unit=u,
-                    node=ng,
-                    direction=d,
-                    stochastic_scenario=s,
-                    t=t_in_t(m, t_long=t),
+                + unit_flow[u, n, d, s, t]
+                for (u, n, d, s, t) in unit_flow_indices(
+                    m; unit=u, node=ng, direction=d, stochastic_scenario=s, t=t_in_t(m, t_long=t)
                 );
                 init=0,
             )
-            * duration(
-                t,
-            )
+            * duration(t)
             >=
             + expr_sum(
                 + units_on[u, s, t1]
@@ -54,7 +48,8 @@ function add_constraint_minimum_operating_point!(m::Model)
                 for (u, s, t1) in units_on_indices(m; unit=u, stochastic_scenario=s, t=t_overlaps_t(m; t=t));
                 init=0,
             )
-        ) for (u, ng, d, s, t) in constraint_minimum_operating_point_indices(m)
+        )
+        for (u, ng, d, s, t) in constraint_minimum_operating_point_indices(m)
     )
 end
 
@@ -62,8 +57,9 @@ function constraint_minimum_operating_point_indices(m::Model)
     unique(
         (unit=u, node=ng, direction=d, stochastic_path=path, t=t)
         for (u, ng, d) in indices(minimum_operating_point)
-        for t in t_lowest_resolution(time_slice(m; temporal_block=members(node__temporal_block(node=members(ng)))))
-        for path in active_stochastic_paths(collect(_constraint_unit_flow_capacity_scenarios(m, u, ng, d, t)))
+        for (t, path) in t_lowest_resolution_path(
+            vcat(unit_flow_indices(m; unit=u, node=ng, direction=d), units_on_indices(m; unit=u))
+        )
     )
 end
 

--- a/src/constraints/constraint_minimum_operating_point.jl
+++ b/src/constraints/constraint_minimum_operating_point.jl
@@ -58,7 +58,7 @@ function constraint_minimum_operating_point_indices(m::Model)
         (unit=u, node=ng, direction=d, stochastic_path=path, t=t)
         for (u, ng, d) in indices(minimum_operating_point)
         for (t, path) in t_lowest_resolution_path(
-            vcat(unit_flow_indices(m; unit=u, node=ng, direction=d), units_on_indices(m; unit=u))
+            m, vcat(unit_flow_indices(m; unit=u, node=ng, direction=d), units_on_indices(m; unit=u))
         )
     )
 end

--- a/src/constraints/constraint_node_injection.jl
+++ b/src/constraints/constraint_node_injection.jl
@@ -115,6 +115,7 @@ function constraint_node_injection_indices(m::Model)
         (node=n, stochastic_path=path, t_before=t_before, t_after=t_after)
         for (n, t_before, t_after) in node_dynamic_time_indices(m)
         for path in active_stochastic_paths(
+            m,
             unique(
                 ind.stochastic_scenario
                 for ind in vcat(

--- a/src/constraints/constraint_node_injection.jl
+++ b/src/constraints/constraint_node_injection.jl
@@ -115,7 +115,7 @@ function constraint_node_injection_indices(m::Model)
         (node=n, stochastic_path=path, t_before=t_before, t_after=t_after)
         for (n, t_before, t_after) in node_dynamic_time_indices(m)
         for path in active_stochastic_paths(collect(_constraint_node_injection_scenarios(m, n, t_after, t_before)))
-    )
+    )  # FIXME
 end
 
 """

--- a/src/constraints/constraint_node_injection.jl
+++ b/src/constraints/constraint_node_injection.jl
@@ -114,8 +114,17 @@ function constraint_node_injection_indices(m::Model)
     unique(
         (node=n, stochastic_path=path, t_before=t_before, t_after=t_after)
         for (n, t_before, t_after) in node_dynamic_time_indices(m)
-        for path in active_stochastic_paths(collect(_constraint_node_injection_scenarios(m, n, t_after, t_before)))
-    )  # FIXME
+        for path in active_stochastic_paths(
+            unique(
+                ind.stochastic_scenario
+                for ind in vcat(
+                    node_stochastic_time_indices(m; node=n, t=t_after),
+                    node_state_indices(m; node=n, t=t_before),
+                    node_state_indices(m; node=[node__node(node2=n); node__node(node1=n)], t=t_after)
+                )
+            )
+        )
+    )
 end
 
 """
@@ -135,31 +144,4 @@ function constraint_node_injection_indices_filtered(
 )
     f(ind) = _index_in(ind; node=node, stochastic_path=stochastic_path, t_before=t_before, t_after=t_after)
     filter(f, constraint_node_injection_indices(m))
-end
-
-function _constraint_node_injection_scenarios(m, node, t_after, t_before)
-    (
-        s
-        for s in stochastic_scenario()
-        # `node` on `t_after`, this needs to be included regardless of whether the `node` has a `node_state`
-        if !isempty(node_stochastic_time_indices(m; node=node, t=t_after, stochastic_scenario=s))
-        # `node_state` on `t_before`
-        || !isempty(node_state_indices(m; node=node, t=t_before, stochastic_scenario=s))
-        # Diffusion to this `node`
-        || iterate(
-            (
-                ind
-                for n1 in node__node(node2=node)
-                for ind in node_state_indices(m; node=n1, t=t_after, stochastic_scenario=s)
-            )
-        ) !== nothing
-        # Diffusion from this `node`
-        || iterate(
-            (
-                ind
-                for n2 in node__node(node1=node)
-                for ind in node_state_indices(m; node=n2, t=t_after, stochastic_scenario=s)
-            )
-        ) !== nothing
-    )
 end

--- a/src/constraints/constraint_node_injection.jl
+++ b/src/constraints/constraint_node_injection.jl
@@ -116,13 +116,10 @@ function constraint_node_injection_indices(m::Model)
         for (n, t_before, t_after) in node_dynamic_time_indices(m)
         for path in active_stochastic_paths(
             m,
-            unique(
-                ind.stochastic_scenario
-                for ind in vcat(
-                    node_stochastic_time_indices(m; node=n, t=t_after),
-                    node_state_indices(m; node=n, t=t_before),
-                    node_state_indices(m; node=[node__node(node2=n); node__node(node1=n)], t=t_after)
-                )
+            vcat(
+                node_stochastic_time_indices(m; node=n, t=t_after),
+                node_state_indices(m; node=n, t=t_before),
+                node_state_indices(m; node=[node__node(node2=n); node__node(node1=n)], t=t_after)
             )
         )
     )

--- a/src/constraints/constraint_node_state_capacity.jl
+++ b/src/constraints/constraint_node_state_capacity.jl
@@ -33,19 +33,19 @@ function add_constraint_node_state_capacity!(m::Model)
                 init=0,
             )
             <=
-            + node_state_cap[(node=ng, stochastic_scenario=s, analysis_time=t0, t=t)] * (
-                (candidate_storages(node=ng) != nothing) ?
+            + node_state_cap[(node=ng, stochastic_scenario=s, analysis_time=t0, t=t)]
+            * (
+                candidate_storages(node=ng) != nothing ?
                 + expr_sum(
-                    storages_invested_available[n, s, t1] for (n, s, t1) in storages_invested_available_indices(
-                        m;
-                        node=ng,
-                        stochastic_scenario=s,
-                        t=t_in_t(m; t_short=t),
+                    storages_invested_available[n, s, t1]
+                    for (n, s, t1) in storages_invested_available_indices(
+                        m; node=ng, stochastic_scenario=s, t=t_in_t(m; t_short=t)
                     );
                     init=0,
                 ) : 1
             )
-        ) for (ng, s, t) in constraint_node_state_capacity_indices(m)
+        )
+        for (ng, s, t) in constraint_node_state_capacity_indices(m)
     )
 end
 
@@ -54,7 +54,7 @@ function constraint_node_state_capacity_indices(m::Model)
         (node=ng, stochastic_path=path, t=t)
         for (ng, s, t) in node_state_indices(m; node=indices(node_state_cap))
         for path in active_stochastic_paths(collect(_constraint_node_state_capacity_scenarios(m, ng, t)))
-    )
+    )  # FIXME
 end
 
 """

--- a/src/constraints/constraint_node_state_capacity.jl
+++ b/src/constraints/constraint_node_state_capacity.jl
@@ -54,13 +54,10 @@ function constraint_node_state_capacity_indices(m::Model)
         (node=ng, stochastic_path=path, t=t)
         for (ng, t) in node_time_indices(m; node=indices(node_state_cap))
         for path in active_stochastic_paths(
-            m, 
-            unique(
-                ind.stochastic_scenario
-                for ind in vcat(
-                    node_state_indices(m; node=ng, t=t),
-                    storages_invested_available_indices(m; node=ng, t=t_in_t(m; t_short=t))
-                )
+            m,
+            vcat(
+                node_state_indices(m; node=ng, t=t),
+                storages_invested_available_indices(m; node=ng, t=t_in_t(m; t_short=t))
             )
         )
     )

--- a/src/constraints/constraint_node_state_capacity.jl
+++ b/src/constraints/constraint_node_state_capacity.jl
@@ -54,6 +54,7 @@ function constraint_node_state_capacity_indices(m::Model)
         (node=ng, stochastic_path=path, t=t)
         for (ng, t) in node_time_indices(m; node=indices(node_state_cap))
         for path in active_stochastic_paths(
+            m, 
             unique(
                 ind.stochastic_scenario
                 for ind in vcat(

--- a/src/constraints/constraint_node_state_capacity.jl
+++ b/src/constraints/constraint_node_state_capacity.jl
@@ -35,7 +35,7 @@ function add_constraint_node_state_capacity!(m::Model)
             <=
             + node_state_cap[(node=ng, stochastic_scenario=s, analysis_time=t0, t=t)]
             * (
-                candidate_storages(node=ng) != nothing ?
+                candidate_storages(node=ng) !== nothing ?
                 + expr_sum(
                     storages_invested_available[n, s, t1]
                     for (n, s, t1) in storages_invested_available_indices(

--- a/src/constraints/constraint_node_voltage_angle.jl
+++ b/src/constraints/constraint_node_voltage_angle.jl
@@ -63,7 +63,7 @@ function constraint_node_voltage_angle_indices(m::Model)
         for conn in indices(connection_reactance)
         for (conn, n_to, n_from) in indices(fix_ratio_out_in_connection_flow; connection=conn)
         if has_voltage_angle(node=n_from) && has_voltage_angle(node=n_to)
-        for (t, path) in t_lowest_resolution_path(node_voltage_angle_indices(m; node=[n_to, n_from]))
+        for (t, path) in t_lowest_resolution_path(m, node_voltage_angle_indices(m; node=[n_to, n_from]))
     )
 end
 

--- a/src/constraints/constraint_operating_point_bounds.jl
+++ b/src/constraints/constraint_operating_point_bounds.jl
@@ -32,8 +32,9 @@ function add_constraint_operating_point_bounds!(m::Model)
             + unit_flow_op[u, n, d, op, s, t]
             <=
             (
-                + operating_points[(unit=u, node=n, direction=d, stochastic_scenario=s, analysis_time=t0, i=op)] - (
-                    (op > 1) ?
+                + operating_points[(unit=u, node=n, direction=d, stochastic_scenario=s, analysis_time=t0, i=op)]
+                - (
+                    op > 1 ?
                     operating_points[(unit=u, node=n, direction=d, stochastic_scenario=s, analysis_time=t0, i=op - 1)] :
                     0
                 )
@@ -42,7 +43,8 @@ function add_constraint_operating_point_bounds!(m::Model)
             * units_available[u, s, t]
             * unit_conv_cap_to_flow[(unit=u, node=n, direction=d, stochastic_scenario=s, analysis_time=t0, t=t)]
             # TODO: extend to investment functionality ? (is that even possible)
-        ) for (u, n, d) in indices(unit_capacity)
+        )
+        for (u, n, d) in indices(unit_capacity)
         for (u, n, d, op, s, t) in unit_flow_op_indices(m; unit=u, node=n, direction=d)
     )
 end

--- a/src/constraints/constraint_operating_point_sum.jl
+++ b/src/constraints/constraint_operating_point_sum.jl
@@ -31,10 +31,11 @@ function add_constraint_operating_point_sum!(m::Model)
             + unit_flow[u, n, d, s, t]
             ==
             + expr_sum(
-                + unit_flow_op[u, n, d, op, s, t] for op in 1:length(operating_points(unit=u, node=n, direction=d));
+                unit_flow_op[u, n, d, op, s, t] for op in 1:length(operating_points(unit=u, node=n, direction=d));
                 init=0,
             )
-        ) for (u, n, d) in indices(operating_points)
+        )
+        for (u, n, d) in indices(operating_points)
         for (u, n, d, s, t) in unit_flow_indices(m; unit=u, node=n, direction=d)
     )
 end

--- a/src/constraints/constraint_ramp_down.jl
+++ b/src/constraints/constraint_ramp_down.jl
@@ -64,7 +64,7 @@ function constraint_ramp_down_indices(m::Model)
         (unit=u, node=ng, direction=d, stochastic_path=path, t=t)
         for (u, ng, d) in indices(ramp_down_limit)
         for (t, path) in t_lowest_resolution_path(
-            vcat(units_on_indices(m; unit=u), ramp_down_unit_flow_indices(m; unit=u, node=ng, direction=d))
+            m, vcat(units_on_indices(m; unit=u), ramp_down_unit_flow_indices(m; unit=u, node=ng, direction=d))
         )
     )
 end

--- a/src/constraints/constraint_ramp_down.jl
+++ b/src/constraints/constraint_ramp_down.jl
@@ -30,22 +30,20 @@ function add_constraint_ramp_down!(m::Model)
         (unit=u, node=ng, direction=d, stochastic_path=s, t=t) => @constraint(
             m,
             + sum(
-                ramp_down_unit_flow[u, n, d, s, t] * duration(t) for (u, n, d, s, t) in ramp_down_unit_flow_indices(
-                    m;
-                    unit=u,
-                    node=ng,
-                    direction=d,
-                    t=t_in_t(m; t_long=t),
-                    stochastic_scenario=s,
+                ramp_down_unit_flow[u, n, d, s, t] * duration(t)
+                for (u, n, d, s, t) in ramp_down_unit_flow_indices(
+                    m; unit=u, node=ng, direction=d, t=t_in_t(m; t_long=t), stochastic_scenario=s
                 )
             )
             <=
             + sum(
                 (
-                    units_on[u, s, t1] - units_started_up[u, s, t1] - expr_sum(
+                    + units_on[u, s, t1]
+                    - units_started_up[u, s, t1]
+                    - expr_sum(
                         + nonspin_units_shut_down[u, n, s, t1]
                         for (u, n, s, t1) in nonspin_units_shut_down_indices(m; unit=u, stochastic_scenario=s, t=t1)
-                            if is_reserve_node(node=n) && downward_reserve(node=n);
+                        if is_reserve_node(node=n) && downward_reserve(node=n);
                         init=0,
                     )
                 )
@@ -54,8 +52,10 @@ function add_constraint_ramp_down!(m::Model)
                 * unit_conv_cap_to_flow[(unit=u, node=ng, direction=d, stochastic_scenario=s, analysis_time=t0, t=t)]
                 * unit_capacity[(unit=u, node=ng, direction=d, stochastic_scenario=s, analysis_time=t0, t=t)]
                 for (u, s, t1) in units_on_indices(m; unit=u, stochastic_scenario=s, t=t_overlaps_t(m; t=t))
-            ) * duration(t) ## [ramp_down_limit]=MW/h
-        ) for (u, ng, d, s, t) in constraint_ramp_down_indices(m)
+            )
+            * duration(t) ## [ramp_down_limit]=MW/h
+        )
+        for (u, ng, d, s, t) in constraint_ramp_down_indices(m)
     )
 end
 
@@ -63,14 +63,8 @@ function constraint_ramp_down_indices(m::Model)
     unique(
         (unit=u, node=ng, direction=d, stochastic_path=path, t=t)
         for (u, ng, d) in indices(ramp_down_limit)
-        for t in t_lowest_resolution(time_slice(m; temporal_block=members(node__temporal_block(node=members(ng)))))
-        for path in active_stochastic_paths(
-            collect(
-                s
-                for s in stochastic_scenario()
-                if !isempty(units_on_indices(m; unit=u, t=t, stochastic_scenario=s))
-                || !isempty(ramp_down_unit_flow_indices(m; unit=u, node=ng, direction=d, t=t, stochastic_scenario=s))
-            )
+        for (t, path) in t_lowest_resolution_path(
+            vcat(units_on_indices(m; unit=u), ramp_down_unit_flow_indices(m; unit=u, node=ng, direction=d))
         )
     )
 end

--- a/src/constraints/constraint_ramp_up.jl
+++ b/src/constraints/constraint_ramp_up.jl
@@ -30,13 +30,9 @@ function add_constraint_ramp_up!(m::Model)
         (unit=u, node=ng, direction=d, stochastic_path=s, t=t) => @constraint(
             m,
             + sum(
-                ramp_up_unit_flow[u, n, d, s, t] * duration(t) for (u, n, d, s, t) in ramp_up_unit_flow_indices(
-                    m;
-                    unit=u,
-                    node=ng,
-                    direction=d,
-                    t=t_in_t(m; t_long=t),
-                    stochastic_scenario=s,
+                ramp_up_unit_flow[u, n, d, s, t] * duration(t)
+                for (u, n, d, s, t) in ramp_up_unit_flow_indices(
+                    m; unit=u, node=ng, direction=d, t=t_in_t(m; t_long=t), stochastic_scenario=s
                 )
             )
             <=
@@ -47,8 +43,10 @@ function add_constraint_ramp_up!(m::Model)
                 * unit_conv_cap_to_flow[(unit=u, node=ng, direction=d, stochastic_scenario=s, analysis_time=t0, t=t)]
                 * unit_capacity[(unit=u, node=ng, direction=d, stochastic_scenario=s, analysis_time=t0, t=t)]
                 for (u, s, t1) in units_on_indices(m; unit=u, stochastic_scenario=s, t=t_overlaps_t(m; t=t))
-            ) * duration(t) ## [ramp_up_limit]=MW/h
-        ) for (u, ng, d, s, t) in constraint_ramp_up_indices(m)
+            )
+            * duration(t) ## [ramp_up_limit]=MW/h
+        )
+        for (u, ng, d, s, t) in constraint_ramp_up_indices(m)
     )
 end
 
@@ -56,14 +54,8 @@ function constraint_ramp_up_indices(m::Model)
     unique(
         (unit=u, node=ng, direction=d, stochastic_path=path, t=t)
         for (u, ng, d) in indices(ramp_up_limit)
-        for t in t_lowest_resolution(time_slice(m; temporal_block=members(node__temporal_block(node=members(ng)))))
-        for path in active_stochastic_paths(
-            collect(
-                s
-                for s in stochastic_scenario()
-                if !isempty(units_on_indices(m; unit=u, t=t, stochastic_scenario=s))
-                || !isempty(ramp_up_unit_flow_indices(m; unit=u, node=ng, direction=d, t=t, stochastic_scenario=s))
-            )
+        for (t, path) in t_lowest_resolution_path(
+            vcat(units_on_indices(m; unit=u), ramp_up_unit_flow_indices(m; unit=u, node=ng, direction=d))
         )
     )
 end

--- a/src/constraints/constraint_ramp_up.jl
+++ b/src/constraints/constraint_ramp_up.jl
@@ -55,7 +55,7 @@ function constraint_ramp_up_indices(m::Model)
         (unit=u, node=ng, direction=d, stochastic_path=path, t=t)
         for (u, ng, d) in indices(ramp_up_limit)
         for (t, path) in t_lowest_resolution_path(
-            vcat(units_on_indices(m; unit=u), ramp_up_unit_flow_indices(m; unit=u, node=ng, direction=d))
+            m, vcat(units_on_indices(m; unit=u), ramp_up_unit_flow_indices(m; unit=u, node=ng, direction=d))
         )
     )
 end

--- a/src/constraints/constraint_ratio_out_in_connection_flow.jl
+++ b/src/constraints/constraint_ratio_out_in_connection_flow.jl
@@ -52,12 +52,7 @@ function add_constraint_ratio_out_in_connection_flow!(m::Model, ratio_out_in, se
                 * overlap_duration(
                     t_short,
                     t - connection_flow_delay(
-                        connection=conn,
-                        node1=ng_out,
-                        node2=ng_in,
-                        stochastic_scenario=s,
-                        analysis_time=t0,
-                        t=t,
+                        connection=conn, node1=ng_out, node2=ng_in, stochastic_scenario=s, analysis_time=t0, t=t
                     ),
                 )
                 for (conn, n_in, d, s, t_short) in connection_flow_indices(
@@ -69,12 +64,7 @@ function add_constraint_ratio_out_in_connection_flow!(m::Model, ratio_out_in, se
                     t=to_time_slice(
                         m;
                         t=t - connection_flow_delay(
-                            connection=conn,
-                            node1=ng_out,
-                            node2=ng_in,
-                            stochastic_scenario=s,
-                            analysis_time=t0,
-                            t=t,
+                            connection=conn, node1=ng_out, node2=ng_in, stochastic_scenario=s, analysis_time=t0, t=t
                         ),
                     ),
                 );

--- a/src/constraints/constraint_ratio_out_in_connection_flow.jl
+++ b/src/constraints/constraint_ratio_out_in_connection_flow.jl
@@ -101,21 +101,19 @@ function constraint_ratio_out_in_connection_flow_indices(m::Model, ratio_out_in)
         )
         for path in active_stochastic_paths(
             m, 
-            unique(
-                vcat(
-                    path_out,
-                    [
-                        ind.stochastic_scenario
-                        for s in path_out
-                        for ind in connection_flow_indices(
-                            m;
-                            connection=conn,
-                            node=ng_in,
-                            direction=direction(:from_node),
-                            t=_to_delayed_time_slice(m, conn, ng_out, ng_in, s, t)
-                        )
-                    ]
-                )
+            vcat(
+                path_out,
+                [
+                    ind.stochastic_scenario
+                    for s in path_out
+                    for ind in connection_flow_indices(
+                        m;
+                        connection=conn,
+                        node=ng_in,
+                        direction=direction(:from_node),
+                        t=_to_delayed_time_slice(m, conn, ng_out, ng_in, s, t)
+                    )
+                ]
             )
         )
     )

--- a/src/constraints/constraint_ratio_out_in_connection_flow.jl
+++ b/src/constraints/constraint_ratio_out_in_connection_flow.jl
@@ -59,7 +59,8 @@ function add_constraint_ratio_out_in_connection_flow!(m::Model, ratio_out_in, se
                         analysis_time=t0,
                         t=t,
                     ),
-                ) for (conn, n_in, d, s, t_short) in connection_flow_indices(
+                )
+                for (conn, n_in, d, s, t_short) in connection_flow_indices(
                     m;
                     connection=conn,
                     node=ng_in,
@@ -79,7 +80,8 @@ function add_constraint_ratio_out_in_connection_flow!(m::Model, ratio_out_in, se
                 );
                 init=0,
             ),
-        ) for (conn, ng_out, ng_in, s, t) in constraint_ratio_out_in_connection_flow_indices(m, ratio_out_in)
+        )
+        for (conn, ng_out, ng_in, s, t) in constraint_ratio_out_in_connection_flow_indices(m, ratio_out_in)
     )
 end
 
@@ -122,7 +124,7 @@ function constraint_ratio_out_in_connection_flow_indices(m::Model, ratio_out_in)
         )
         for path in active_stochastic_paths(
             collect(_constraint_ratio_out_in_connection_flow_scenarios(m, conn, n_out, n_in, t0, t))
-        )
+        )  # FIXME
     )
 end
 

--- a/src/constraints/constraint_ratio_out_in_connection_intact_flow.jl
+++ b/src/constraints/constraint_ratio_out_in_connection_intact_flow.jl
@@ -67,16 +67,12 @@ function constraint_ratio_out_in_connection_intact_flow_indices(m::Model)
         (connection=conn, node1=n_out, node2=n_in, stochastic_path=path, t=t)
         for conn in connection(connection_monitored=true, has_ptdf=true)
         for (n_in, n_out) in connection__node__node(connection=conn)
-        for t in t_lowest_resolution(
-            x.t for x in connection_flow_indices(
-                m;
-                connection=conn,
-                node=Iterators.flatten((members(n_out), members(n_in))),
+        for (t, path) in t_lowest_resolution_path(
+            vcat(
+                connection_intact_flow_indices(m; connection=conn, node=n_out, direction=direction(:to_node)),
+                connection_intact_flow_indices(m; connection=conn, node=n_in, direction=direction(:from_node))
             )
         )
-        for path in active_stochastic_paths(
-            collect(_constraint_ratio_out_in_connection_intact_flow_scenarios(m, conn, n_in, n_out, t0, t))
-        )  # FIXME
     )
 end
 
@@ -98,31 +94,4 @@ function constraint_ratio_out_in_connection_intact_flow_indices_filtered(
 )
     f(ind) = _index_in(ind; connection=connection, node1=node1, node2=node2, stochastic_path=stochastic_path, t=t)
     filter(f, constraint_ratio_out_in_connection_intact_flow_indices(m))
-end
-
-function _constraint_ratio_out_in_connection_intact_flow_scenarios(m, connection, node_in, node_out, t0, t)
-    (
-        s
-        for s in stochastic_scenario()
-        if !isempty(
-            connection_intact_flow_indices(
-                m;
-                connection=connection,
-                node=node_out,
-                direction=direction(:to_node),
-                t=t_in_t(m; t_long=t),
-                stochastic_scenario=s
-            )  # `to_node` `connection_flow`s
-        )
-        || !isempty(
-            connection_intact_flow_indices(
-                m;
-                connection=connection,
-                node=node_in,
-                direction=direction(:from_node),
-                t=t_in_t(m; t_long=t),
-                stochastic_scenario=s
-            )  # `from_node` `connection_flow`s
-        )
-    )
 end

--- a/src/constraints/constraint_ratio_out_in_connection_intact_flow.jl
+++ b/src/constraints/constraint_ratio_out_in_connection_intact_flow.jl
@@ -56,7 +56,8 @@ function add_constraint_ratio_out_in_connection_intact_flow!(m::Model)
                 );
                 init=0,
             )
-        ) for (conn, ng_in, ng_out, s, t) in constraint_ratio_out_in_connection_intact_flow_indices(m)
+        )
+        for (conn, ng_in, ng_out, s, t) in constraint_ratio_out_in_connection_intact_flow_indices(m)
     )
 end
 
@@ -65,7 +66,8 @@ function constraint_ratio_out_in_connection_intact_flow_indices(m::Model)
     unique(
         (connection=conn, node1=n_out, node2=n_in, stochastic_path=path, t=t)
         for conn in connection(connection_monitored=true, has_ptdf=true)
-        for (n_in, n_out) in connection__node__node(connection=conn) for t in t_lowest_resolution(
+        for (n_in, n_out) in connection__node__node(connection=conn)
+        for t in t_lowest_resolution(
             x.t for x in connection_flow_indices(
                 m;
                 connection=conn,
@@ -74,7 +76,7 @@ function constraint_ratio_out_in_connection_intact_flow_indices(m::Model)
         )
         for path in active_stochastic_paths(
             collect(_constraint_ratio_out_in_connection_intact_flow_scenarios(m, conn, n_in, n_out, t0, t))
-        )
+        )  # FIXME
     )
 end
 

--- a/src/constraints/constraint_ratio_out_in_connection_intact_flow.jl
+++ b/src/constraints/constraint_ratio_out_in_connection_intact_flow.jl
@@ -68,6 +68,7 @@ function constraint_ratio_out_in_connection_intact_flow_indices(m::Model)
         for conn in connection(connection_monitored=true, has_ptdf=true)
         for (n_in, n_out) in connection__node__node(connection=conn)
         for (t, path) in t_lowest_resolution_path(
+            m, 
             vcat(
                 connection_intact_flow_indices(m; connection=conn, node=n_out, direction=direction(:to_node)),
                 connection_intact_flow_indices(m; connection=conn, node=n_in, direction=direction(:from_node))

--- a/src/constraints/constraint_ratio_unit_flow.jl
+++ b/src/constraints/constraint_ratio_unit_flow.jl
@@ -32,13 +32,9 @@ function add_constraint_ratio_unit_flow!(m::Model, ratio, units_on_coefficient, 
         (unit=u, node1=ng1, node2=ng2, stochastic_path=s, t=t) => sense_constraint(
             m,
             + expr_sum(
-                unit_flow[u, n1, d1, s, t_short] * duration(t_short) for (u, n1, d1, s, t_short) in unit_flow_indices(
-                    m;
-                    unit=u,
-                    node=ng1,
-                    direction=d1,
-                    stochastic_scenario=s,
-                    t=t_in_t(m; t_long=t),
+                unit_flow[u, n1, d1, s, t_short] * duration(t_short)
+                for (u, n1, d1, s, t_short) in unit_flow_indices(
+                    m; unit=u, node=ng1, direction=d1, stochastic_scenario=s, t=t_in_t(m; t_long=t)
                 );
                 init=0,
             ),
@@ -48,22 +44,19 @@ function add_constraint_ratio_unit_flow!(m::Model, ratio, units_on_coefficient, 
                 * duration(t_short)
                 * ratio[(unit=u, node1=ng1, node2=ng2, stochastic_scenario=s, analysis_time=t0, t=t)]
                 for (u, n2, d2, s, t_short) in unit_flow_indices(
-                    m;
-                    unit=u,
-                    node=ng2,
-                    direction=d2,
-                    stochastic_scenario=s,
-                    t=t_in_t(m; t_long=t),
+                    m; unit=u, node=ng2, direction=d2, stochastic_scenario=s, t=t_in_t(m; t_long=t)
                 );
                 init=0,
-            ) + expr_sum(
+            )
+            + expr_sum(
                 units_on[u, s, t1]
                 * min(duration(t1), duration(t))
                 * units_on_coefficient[(unit=u, node1=ng1, node2=ng2, stochastic_scenario=s, analysis_time=t0, t=t)]
                 for (u, s, t1) in units_on_indices(m; unit=u, stochastic_scenario=s, t=t_overlaps_t(m; t=t));
                 init=0,
-            ),
-        ) for (u, ng1, ng2, s, t) in constraint_ratio_unit_flow_indices(m, ratio, d1, d2)
+            )
+        )
+        for (u, ng1, ng2, s, t) in constraint_ratio_unit_flow_indices(m, ratio, d1, d2)
     )
 end
 
@@ -262,10 +255,12 @@ end
 function constraint_ratio_unit_flow_indices(m::Model, ratio, d1, d2)
     unique(
         (unit=u, node1=n1, node2=n2, stochastic_path=path, t=t)
-        for (u, n1, n2) in indices(ratio) for t in t_lowest_resolution(
+        for (u, n1, n2) in indices(ratio)
+        for t in t_lowest_resolution(
             x.t for x in unit_flow_indices(m; unit=u, node=Iterators.flatten((members(n1), members(n2))))
         )
         for path in active_stochastic_paths(collect(_constraint_ratio_unit_flow_scenarios(m, u, n1, d1, n2, d2, t)))
+        # FIXME
     )
 end
 

--- a/src/constraints/constraint_ratio_unit_flow.jl
+++ b/src/constraints/constraint_ratio_unit_flow.jl
@@ -197,6 +197,7 @@ function constraint_ratio_unit_flow_indices(m::Model, ratio, d1, d2)
         (unit=u, node1=n1, node2=n2, stochastic_path=path, t=t)
         for (u, n1, n2) in indices(ratio)
         for (t, path) in t_lowest_resolution_path(
+            m, 
             vcat(
                 unit_flow_indices(m; unit=u, node=n1, direction=d1),
                 unit_flow_indices(m; unit=u, node=n2, direction=d2),

--- a/src/constraints/constraint_ratio_unit_flow.jl
+++ b/src/constraints/constraint_ratio_unit_flow.jl
@@ -256,11 +256,13 @@ function constraint_ratio_unit_flow_indices(m::Model, ratio, d1, d2)
     unique(
         (unit=u, node1=n1, node2=n2, stochastic_path=path, t=t)
         for (u, n1, n2) in indices(ratio)
-        for t in t_lowest_resolution(
-            x.t for x in unit_flow_indices(m; unit=u, node=Iterators.flatten((members(n1), members(n2))))
+        for (t, path) in t_lowest_resolution_path(
+            vcat(
+                unit_flow_indices(m; unit=u, node=n1, direction=d1),
+                unit_flow_indices(m; unit=u, node=n2, direction=d2),
+                units_on_indices(m; unit=u)
+            )
         )
-        for path in active_stochastic_paths(collect(_constraint_ratio_unit_flow_scenarios(m, u, n1, d1, n2, d2, t)))
-        # FIXME
     )
 end
 

--- a/src/constraints/constraint_ratio_unit_flow.jl
+++ b/src/constraints/constraint_ratio_unit_flow.jl
@@ -67,12 +67,7 @@ Call `add_constraint_ratio_unit_flow!` with the appropriate parameter and `direc
 """
 function add_constraint_fix_ratio_out_in_unit_flow!(m::Model)
     add_constraint_ratio_unit_flow!(
-        m,
-        fix_ratio_out_in_unit_flow,
-        fix_units_on_coefficient_out_in,
-        ==,
-        direction(:to_node),
-        direction(:from_node),
+        m, fix_ratio_out_in_unit_flow, fix_units_on_coefficient_out_in, ==, direction(:to_node), direction(:from_node)
     )
 end
 
@@ -83,12 +78,7 @@ Call `add_constraint_ratio_unit_flow!` with the appropriate parameter and `direc
 """
 function add_constraint_max_ratio_out_in_unit_flow!(m::Model)
     add_constraint_ratio_unit_flow!(
-        m,
-        max_ratio_out_in_unit_flow,
-        max_units_on_coefficient_out_in,
-        <=,
-        direction(:to_node),
-        direction(:from_node),
+        m, max_ratio_out_in_unit_flow, max_units_on_coefficient_out_in, <=, direction(:to_node), direction(:from_node)
     )
 end
 
@@ -99,12 +89,7 @@ Call `add_constraint_ratio_unit_flow!` with the appropriate parameter and `direc
 """
 function add_constraint_min_ratio_out_in_unit_flow!(m::Model)
     add_constraint_ratio_unit_flow!(
-        m,
-        min_ratio_out_in_unit_flow,
-        min_units_on_coefficient_out_in,
-        >=,
-        direction(:to_node),
-        direction(:from_node),
+        m, min_ratio_out_in_unit_flow, min_units_on_coefficient_out_in, >=, direction(:to_node), direction(:from_node)
     )
 end
 
@@ -115,12 +100,7 @@ Call `add_constraint_ratio_unit_flow!` with the appropriate parameter and `direc
 """
 function add_constraint_fix_ratio_in_in_unit_flow!(m::Model)
     add_constraint_ratio_unit_flow!(
-        m,
-        fix_ratio_in_in_unit_flow,
-        fix_units_on_coefficient_in_in,
-        ==,
-        direction(:from_node),
-        direction(:from_node),
+        m, fix_ratio_in_in_unit_flow, fix_units_on_coefficient_in_in, ==, direction(:from_node), direction(:from_node)
     )
 end
 
@@ -131,12 +111,7 @@ Call `add_constraint_ratio_unit_flow!` with the appropriate parameter and `direc
 """
 function add_constraint_max_ratio_in_in_unit_flow!(m::Model)
     add_constraint_ratio_unit_flow!(
-        m,
-        max_ratio_in_in_unit_flow,
-        max_units_on_coefficient_in_in,
-        <=,
-        direction(:from_node),
-        direction(:from_node),
+        m, max_ratio_in_in_unit_flow, max_units_on_coefficient_in_in, <=, direction(:from_node), direction(:from_node)
     )
 end
 
@@ -147,12 +122,7 @@ Call `add_constraint_ratio_unit_flow!` with the appropriate parameter and `direc
 """
 function add_constraint_min_ratio_in_in_unit_flow!(m::Model)
     add_constraint_ratio_unit_flow!(
-        m,
-        min_ratio_in_in_unit_flow,
-        min_units_on_coefficient_in_in,
-        >=,
-        direction(:from_node),
-        direction(:from_node),
+        m, min_ratio_in_in_unit_flow, min_units_on_coefficient_in_in, >=, direction(:from_node), direction(:from_node)
     )
 end
 
@@ -163,12 +133,7 @@ Call `add_constraint_ratio_unit_flow!` with the appropriate parameter and `direc
 """
 function add_constraint_fix_ratio_out_out_unit_flow!(m::Model)
     add_constraint_ratio_unit_flow!(
-        m,
-        fix_ratio_out_out_unit_flow,
-        fix_units_on_coefficient_out_out,
-        ==,
-        direction(:to_node),
-        direction(:to_node),
+        m, fix_ratio_out_out_unit_flow, fix_units_on_coefficient_out_out, ==, direction(:to_node), direction(:to_node)
     )
 end
 
@@ -179,12 +144,7 @@ Call `add_constraint_ratio_unit_flow!` with the appropriate parameter and `direc
 """
 function add_constraint_max_ratio_out_out_unit_flow!(m::Model)
     add_constraint_ratio_unit_flow!(
-        m,
-        max_ratio_out_out_unit_flow,
-        max_units_on_coefficient_out_out,
-        <=,
-        direction(:to_node),
-        direction(:to_node),
+        m, max_ratio_out_out_unit_flow, max_units_on_coefficient_out_out, <=, direction(:to_node), direction(:to_node)
     )
 end
 
@@ -195,12 +155,7 @@ Call `add_constraint_ratio_unit_flow!` with the appropriate parameter and `direc
 """
 function add_constraint_min_ratio_out_out_unit_flow!(m::Model)
     add_constraint_ratio_unit_flow!(
-        m,
-        min_ratio_out_out_unit_flow,
-        min_units_on_coefficient_out_out,
-        >=,
-        direction(:to_node),
-        direction(:to_node),
+        m, min_ratio_out_out_unit_flow, min_units_on_coefficient_out_out, >=, direction(:to_node), direction(:to_node)
     )
 end
 
@@ -211,12 +166,7 @@ Call `add_constraint_ratio_unit_flow!` with the appropriate parameter and `direc
 """
 function add_constraint_fix_ratio_in_out_unit_flow!(m::Model)
     add_constraint_ratio_unit_flow!(
-        m,
-        fix_ratio_in_out_unit_flow,
-        fix_units_on_coefficient_in_out,
-        ==,
-        direction(:from_node),
-        direction(:to_node),
+        m, fix_ratio_in_out_unit_flow, fix_units_on_coefficient_in_out, ==, direction(:from_node), direction(:to_node)
     )
 end
 
@@ -227,12 +177,7 @@ Call `add_constraint_ratio_unit_flow!` with the appropriate parameter and `direc
 """
 function add_constraint_max_ratio_in_out_unit_flow!(m::Model)
     add_constraint_ratio_unit_flow!(
-        m,
-        max_ratio_in_out_unit_flow,
-        max_units_on_coefficient_in_out,
-        <=,
-        direction(:from_node),
-        direction(:to_node),
+        m, max_ratio_in_out_unit_flow, max_units_on_coefficient_in_out, <=, direction(:from_node), direction(:to_node)
     )
 end
 
@@ -243,12 +188,7 @@ Call `add_constraint_ratio_unit_flow!` with the appropriate parameter and `direc
 """
 function add_constraint_min_ratio_in_out_unit_flow!(m::Model)
     add_constraint_ratio_unit_flow!(
-        m,
-        min_ratio_in_out_unit_flow,
-        min_units_on_coefficient_in_out,
-        >=,
-        direction(:from_node),
-        direction(:to_node),
+        m, min_ratio_in_out_unit_flow, min_units_on_coefficient_in_out, >=, direction(:from_node), direction(:to_node)
     )
 end
 
@@ -288,22 +228,4 @@ function constraint_ratio_unit_flow_indices_filtered(
 )
     f(ind) = _index_in(ind; unit=unit, node1=node1, node2=node2, stochastic_path=stochastic_path, t=t)
     filter(f, constraint_ratio_unit_flow_indices(m, ratio, d1, d2))
-end
-
-function _constraint_ratio_unit_flow_scenarios(m, unit, node1, direction1, node2, direction2, t)
-    (
-        s
-        for s in stochastic_scenario()
-        if !isempty(
-            unit_flow_indices(
-                m; unit=unit, node=node1, direction=direction1, t=t_in_t(m; t_long=t), stochastic_scenario=s
-            )
-        )
-        || !isempty(
-            unit_flow_indices(
-                m; unit=unit, node=node2, direction=direction2, t=t_in_t(m; t_long=t), stochastic_scenario=s
-            )
-        )
-        || !isempty(units_on_indices(m; unit=unit, t=t_in_t(m; t_long=t), stochastic_scenario=s))
-    )
 end

--- a/src/constraints/constraint_res_minimum_node_state.jl
+++ b/src/constraints/constraint_res_minimum_node_state.jl
@@ -82,14 +82,7 @@ function constraint_res_minimum_node_state_indices(m::Model)
             m; unit=u, node=node(has_state=true), direction=direction(:to_node), t=t
         )
         for path in active_stochastic_paths(
-            m, 
-            unique(
-                ind.stochastic_scenario
-                for ind in vcat(
-                    node_state_indices(m; node=n_stor, t=t),
-                    unit_flow_indices(m; unit=u, node=n_res, direction=d_to, t=t)
-                )
-            )
+            m, [node_state_indices(m; node=n_stor, t=t); unit_flow_indices(m; unit=u, node=n_res, direction=d_to, t=t)]
         )
     )
 end

--- a/src/constraints/constraint_res_minimum_node_state.jl
+++ b/src/constraints/constraint_res_minimum_node_state.jl
@@ -82,6 +82,7 @@ function constraint_res_minimum_node_state_indices(m::Model)
             m; unit=u, node=node(has_state=true), direction=direction(:to_node), t=t
         )
         for path in active_stochastic_paths(
+            m, 
             unique(
                 ind.stochastic_scenario
                 for ind in vcat(

--- a/src/constraints/constraint_res_minimum_node_state.jl
+++ b/src/constraints/constraint_res_minimum_node_state.jl
@@ -29,43 +29,43 @@ function add_constraint_res_minimum_node_state!(m::Model)
         (node=n_stor, stochastic_path=s, t=t_after) => @constraint(
             m,
             expr_sum(
-                node_state[n_stor, s, t_before] for (n_stor, s, t_before) in node_state_indices(
-                    m;
-                    node=n_stor,
-                    stochastic_scenario=s,
-                    t=t_before_t(m; t_after=t_after),
+                node_state[n_stor, s, t_before]
+                for (n_stor, s, t_before) in node_state_indices(
+                    m; node=n_stor, stochastic_scenario=s, t=t_before_t(m; t_after=t_after)
                 );
                 init=0,
             )
             >=
-            node_state_min[(node=n_stor, stochastic_scenario=s, analysis_time=t0, t=t_after)] + expr_sum(
+            + node_state_min[(node=n_stor, stochastic_scenario=s, analysis_time=t0, t=t_after)]
+            + expr_sum(
                 unit_flow[u, n_res, d, s, t_after]
                 * duration(t_after)
                 * _div(
-                    minimum_reserve_activation_time(node=n_res, stochastic_scenario=s, analysis_time=t0, t=t_after), #TODO: fix time dependent paramter call
+                    minimum_reserve_activation_time(node=n_res, stochastic_scenario=s, analysis_time=t0, t=t_after),
+                    # TODO: fix time dependent parameter call
                     end_(t_after) - start(t_after),
-                ) / fix_ratio_out_in_unit_flow[
+                )
+                / fix_ratio_out_in_unit_flow[
                     (unit=u, node1=n_conv, node2=n_stor, stochastic_scenario=s, analysis_time=t0, t=t_after),
-                ] for (u, n_stor, d, s, t_after) in unit_flow_indices(
-                    m;
-                    node=n_stor,
-                    direction=direction(:from_node),
-                    stochastic_scenario=s,
-                    t=t_in_t(m; t_long=t_after),
-                ) for (u, n_res, d, s, t_after) in unit_flow_indices(
+                ]
+                for (u, n_stor, d, s, t_after) in unit_flow_indices(
+                    m; node=n_stor, direction=direction(:from_node), stochastic_scenario=s, t=t_in_t(m; t_long=t_after)
+                )
+                for (u, n_res, d, s, t_after) in unit_flow_indices(
                     m;
                     unit=u,
                     node=indices(minimum_reserve_activation_time),
                     direction=direction(:to_node),
                     t=t_in_t(m; t_long=t_after),
-                ) for (u, n_conv, n_stor) in indices(fix_ratio_out_in_unit_flow; unit=u, node2=n_stor)
-                    if is_reserve_node(node=n_res) &&
-                       realize(
-                    minimum_reserve_activation_time[(node=n_res, stochastic_scenario=s, analysis_time=t0, t=t_after)],
+                )
+                for (u, n_conv, n_stor) in indices(fix_ratio_out_in_unit_flow; unit=u, node2=n_stor)
+                if is_reserve_node(node=n_res) && minimum_reserve_activation_time(
+                    node=n_res, stochastic_scenario=s, analysis_time=t0, t=t_after
                 ) !== nothing;  # NOTE: this is an additional sanity check
                 init=0,
             )
-        ) for (n_stor, s, t_after) in constraint_res_minimum_node_state_indices(m)
+        )
+        for (n_stor, s, t_after) in constraint_res_minimum_node_state_indices(m)
     )
 end
 # TODO: only for upward reserves? add downward res constraint
@@ -75,16 +75,16 @@ _div(x::Period, y::Period) = Minute(x) / Minute(y)
 function constraint_res_minimum_node_state_indices(m::Model)
     unique(
         (node=n_stor, stochastic_path=path, t=t)
-        for (u, n_aFRR, d, s, t) in unit_flow_indices(m; node=indices(minimum_reserve_activation_time))
+        for (u, n_afrr, d, s, t) in unit_flow_indices(m; node=indices(minimum_reserve_activation_time))
         for (u, n_stor, d, s, t) in unit_flow_indices(m; unit=u, node=node(has_state=true), t=t)
         for path in active_stochastic_paths(
             collect(
                 s
                 for s in stochastic_scenario()
                 if !isempty(node_state_indices(m; node=n_stor, t=t, stochastic_scenario=s))
-                || !isempty(unit_flow_indices(m; unit=u, node=n_aFRR, direction=d, t=t, stochastic_scenario=s))
+                || !isempty(unit_flow_indices(m; unit=u, node=n_afrr, direction=d, t=t, stochastic_scenario=s))
             )
-        )
+        )  # FIXME
     )
 end
 

--- a/src/constraints/constraint_split_ramps.jl
+++ b/src/constraints/constraint_split_ramps.jl
@@ -104,13 +104,7 @@ function constraint_split_ramps_indices(m::Model)
             )
         )
         for (n, t_before, t_after) in node_dynamic_time_indices(m; node=n, t_after=t_after)
-        for path in active_stochastic_paths(
-            m, 
-            unique(
-                ind.stochastic_scenario
-                for ind in unit_flow_indices(m; unit=u, node=n, direction=d, t=[t_before, t_after])
-            )
-        )
+        for path in active_stochastic_paths(m, unit_flow_indices(m; unit=u, node=n, direction=d, t=[t_before, t_after]))
     )
 end
 

--- a/src/constraints/constraint_split_ramps.jl
+++ b/src/constraints/constraint_split_ramps.jl
@@ -93,26 +93,23 @@ end
 function constraint_split_ramps_indices(m::Model)
     unique(
         (unit=u, node=n, direction=d, stochastic_path=path, t_before=t_before, t_after=t_after)
-        for (u, n, d, s, t_after) in unique(
-            Iterators.flatten((
+        for (u, n, d, s, t_after) in unique!(
+            vcat(
                 ramp_up_unit_flow_indices(m),
                 start_up_unit_flow_indices(m),
                 nonspin_ramp_up_unit_flow_indices(m),
                 ramp_down_unit_flow_indices(m),
                 start_up_unit_flow_indices(m),
                 nonspin_ramp_down_unit_flow_indices(m),
-            )),
+            )
         )
         for (n, t_before, t_after) in node_dynamic_time_indices(m; node=n, t_after=t_after)
         for path in active_stochastic_paths(
-            collect(
-                s
-                for s in stochastic_scenario()
-                if !isempty(
-                    unit_flow_indices(m; unit=u, node=n, direction=d, t=[t_before, t_after], stochastic_scenario=s)
-                )
+            unique(
+                ind.stochastic_scenario
+                for ind in unit_flow_indices(m; unit=u, node=n, direction=d, t=[t_before, t_after])
             )
-        )  # FIXME
+        )
     )
 end
 

--- a/src/constraints/constraint_split_ramps.jl
+++ b/src/constraints/constraint_split_ramps.jl
@@ -105,6 +105,7 @@ function constraint_split_ramps_indices(m::Model)
         )
         for (n, t_before, t_after) in node_dynamic_time_indices(m; node=n, t_after=t_after)
         for path in active_stochastic_paths(
+            m, 
             unique(
                 ind.stochastic_scenario
                 for ind in unit_flow_indices(m; unit=u, node=n, direction=d, t=[t_before, t_after])

--- a/src/constraints/constraint_storage_lifetime.jl
+++ b/src/constraints/constraint_storage_lifetime.jl
@@ -35,7 +35,8 @@ function add_constraint_storage_lifetime!(m::Model)
             )
             >=
             + sum(
-                + storages_invested[n, s_past, t_past] for (n, s_past, t_past) in storages_invested_available_indices(
+                + storages_invested[n, s_past, t_past]
+                for (n, s_past, t_past) in storages_invested_available_indices(
                     m;
                     node=n,
                     stochastic_scenario=s,
@@ -43,12 +44,13 @@ function add_constraint_storage_lifetime!(m::Model)
                         m;
                         t=TimeSlice(
                             end_(t) - storage_investment_lifetime(node=n, stochastic_scenario=s, analysis_time=t0, t=t),
-                            end_(t),
-                        ),
-                    ),
+                            end_(t)
+                        )
+                    )
                 )
             )
-        ) for (n, s, t) in constraint_storage_lifetime_indices(m)
+        )
+        for (n, s, t) in constraint_storage_lifetime_indices(m)
     )
 end
 
@@ -58,7 +60,7 @@ function constraint_storage_lifetime_indices(m::Model)
         (node=n, stochastic_path=path, t=t)
         for n in indices(storage_investment_lifetime) for (n, s, t) in storages_invested_available_indices(m; node=n)
         for path in active_stochastic_paths(collect(_constraint_storage_lifetime_scenarios(m, n, s, t0, t)))
-    )
+    )  # FIXME
 end
 
 """

--- a/src/constraints/constraint_storage_lifetime.jl
+++ b/src/constraints/constraint_storage_lifetime.jl
@@ -28,26 +28,15 @@ function add_constraint_storage_lifetime!(m::Model)
     m.ext[:spineopt].constraints[:storage_lifetime] = Dict(
         (node=n, stochastic_path=s, t=t) => @constraint(
             m,
-            + expr_sum(
-                + storages_invested_available[n, s, t]
+            expr_sum(
+                storages_invested_available[n, s, t]
                 for (n, s, t) in storages_invested_available_indices(m; node=n, stochastic_scenario=s, t=t);
                 init=0,
             )
             >=
-            + sum(
-                + storages_invested[n, s_past, t_past]
-                for (n, s_past, t_past) in storages_invested_available_indices(
-                    m;
-                    node=n,
-                    stochastic_scenario=s,
-                    t=to_time_slice(
-                        m;
-                        t=TimeSlice(
-                            end_(t) - storage_investment_lifetime(node=n, stochastic_scenario=s, analysis_time=t0, t=t),
-                            end_(t)
-                        )
-                    )
-                )
+            sum(
+                storages_invested[n, s_past, t_past]
+                for (n, s_past, t_past) in _past_storages_invested_available_indices(m, n, s, t)
             )
         )
         for (n, s, t) in constraint_storage_lifetime_indices(m)
@@ -55,12 +44,29 @@ function add_constraint_storage_lifetime!(m::Model)
 end
 
 function constraint_storage_lifetime_indices(m::Model)
-    t0 = _analysis_time(m)
     unique(
         (node=n, stochastic_path=path, t=t)
-        for n in indices(storage_investment_lifetime) for (n, s, t) in storages_invested_available_indices(m; node=n)
-        for path in active_stochastic_paths(collect(_constraint_storage_lifetime_scenarios(m, n, s, t0, t)))
-    )  # FIXME
+        for n in indices(storage_investment_lifetime)
+        for (n, t) in node_investment_time_indices(m; node=n)
+        for path in active_stochastic_paths(
+            unique(ind.stochastic_scenario for ind in _past_storages_invested_available_indices(m, n, anything, t))
+        )
+    )
+end
+
+function _past_storages_invested_available_indices(m, n, s, t)
+    t0 = _analysis_time(m)
+    storages_invested_available_indices(
+        m;
+        node=n,
+        stochastic_scenario=s,
+        t=to_time_slice(
+            m;
+            t=TimeSlice(
+                end_(t) - storage_investment_lifetime(node=n, analysis_time=t0, stochastic_scenario=s, t=t), end_(t)
+            )
+        )
+    )
 end
 
 """
@@ -74,18 +80,4 @@ Keyword arguments can be used to filther the resulting Array.
 function constraint_storage_lifetime_indices_filtered(m::Model; node=anything, stochastic_path=anything, t=anything)
     f(ind) = _index_in(ind; node=node, stochastic_path=stochastic_path, t=t)
     filter(f, constraint_storage_lifetime_indices(m))
-end
-
-function _constraint_storage_lifetime_scenarios(m, n, s, t0, t)
-    t_past_and_present = to_time_slice(
-        m;
-        t=TimeSlice(
-            end_(t) - storage_investment_lifetime(node=n, stochastic_scenario=s, analysis_time=t0, t=t), end_(t)
-        )
-    )
-    (
-        s
-        for s in stochastic_scenario()
-        if !isempty(storages_invested_available_indices(m; node=n, t=t_past_and_present, stochastic_scenario=s))
-    )
 end

--- a/src/constraints/constraint_storage_lifetime.jl
+++ b/src/constraints/constraint_storage_lifetime.jl
@@ -48,10 +48,7 @@ function constraint_storage_lifetime_indices(m::Model)
         (node=n, stochastic_path=path, t=t)
         for n in indices(storage_investment_lifetime)
         for (n, t) in node_investment_time_indices(m; node=n)
-        for path in active_stochastic_paths(
-            m, 
-            unique(ind.stochastic_scenario for ind in _past_storages_invested_available_indices(m, n, anything, t))
-        )
+        for path in active_stochastic_paths(m, _past_storages_invested_available_indices(m, n, anything, t))
     )
 end
 

--- a/src/constraints/constraint_storage_lifetime.jl
+++ b/src/constraints/constraint_storage_lifetime.jl
@@ -49,6 +49,7 @@ function constraint_storage_lifetime_indices(m::Model)
         for n in indices(storage_investment_lifetime)
         for (n, t) in node_investment_time_indices(m; node=n)
         for path in active_stochastic_paths(
+            m, 
             unique(ind.stochastic_scenario for ind in _past_storages_invested_available_indices(m, n, anything, t))
         )
     )

--- a/src/constraints/constraint_storage_line_pack.jl
+++ b/src/constraints/constraint_storage_line_pack.jl
@@ -48,6 +48,7 @@ function constraint_storage_line_pack_indices(m::Model)
         (connection=conn, node1=n_stor, node2=ng, stochastic_path=path, t=t)
         for (conn, n_stor, ng) in indices(connection_linepack_constant)
         for (t, path) in t_lowest_resolution_path(
+            m, 
             vcat(node_state_indices(m; node=n_stor), node_pressure_indices(m; node=ng))
         )
     )

--- a/src/constraints/constraint_storage_line_pack.jl
+++ b/src/constraints/constraint_storage_line_pack.jl
@@ -38,17 +38,18 @@ function add_constraint_storage_line_pack!(m::Model)
                 node_pressure[ng, s, t] * duration(t)
                 for (ng, s, t) in node_pressure_indices(m; node=ng, stochastic_scenario=s, t=t_in_t(m; t_long=t))
             )
-        ) for (conn, stor, ng, s, t) in constraint_storage_line_pack_indices(m)
+        )
+        for (conn, stor, ng, s, t) in constraint_storage_line_pack_indices(m)
     )
 end
 
 function constraint_storage_line_pack_indices(m::Model)
     unique(
         (connection=conn, node1=n_stor, node2=ng, stochastic_path=path, t=t)
-        for (conn, n_stor, ng) in indices(connection_linepack_constant) for t in t_lowest_resolution(
-            time_slice(m; temporal_block=node__temporal_block(node=Iterators.flatten((members(n_stor), members(ng))))),
+        for (conn, n_stor, ng) in indices(connection_linepack_constant)
+        for (t, path) in t_lowest_resolution_path(
+            vcat(node_state_indices(m; node=n_stor), node_pressure_indices(m; node=ng))
         )
-        for path in active_stochastic_paths(collect(_constraint_storage_line_pack_scenarios(m, n_stor, ng, t)))
     )
 end
 
@@ -75,13 +76,4 @@ function constraint_storage_line_pack_indices_filtered(
         t=t,
     )
     filter(f, constraint_storage_line_pack_indices(m))
-end
-
-function _constraint_storage_line_pack_scenarios(m, n_stor, ng, t)
-    (
-        s
-        for s in stochastic_scenario()
-        if !isempty(node_state_indices(m; node=n_stor, t=t_in_t(m; t_long=t), stochastic_scenario=s))
-        || !isempty(node_pressure_indices(m; node=ng, t=t_in_t(m; t_long=t), stochastic_scenario=s))
-    )
 end

--- a/src/constraints/constraint_storages_invested_available.jl
+++ b/src/constraints/constraint_storages_invested_available.jl
@@ -31,6 +31,7 @@ function add_constraint_storages_invested_available!(m::Model)
             + storages_invested_available[n, s, t]
             <=
             + candidate_storages[(node=n, stochastic_scenario=s, analysis_time=t0, t=t)]
-        ) for (n, s, t) in storages_invested_available_indices(m)
+        )
+        for (n, s, t) in storages_invested_available_indices(m)
     )
 end

--- a/src/constraints/constraint_storages_invested_transition.jl
+++ b/src/constraints/constraint_storages_invested_transition.jl
@@ -51,14 +51,10 @@ function constraint_storages_invested_transition_indices(m::Model)
         (node=n, stochastic_path=path, t_before=t_before, t_after=t_after)
         for (n, t_before, t_after) in node_investment_dynamic_time_indices(m)
         for path in active_stochastic_paths(
-            collect(
-                s
-                for s in stochastic_scenario()
-                if !isempty(
-                    storages_invested_available_indices(m; node=n, t=[t_before, t_after], stochastic_scenario=s)
-                )
+            unique(
+                ind.stochastic_scenario for ind in storages_invested_available_indices(m; node=n, t=[t_before, t_after])
             )
-        ) # FIXME
+        )
     )
 end
 

--- a/src/constraints/constraint_storages_invested_transition.jl
+++ b/src/constraints/constraint_storages_invested_transition.jl
@@ -51,6 +51,7 @@ function constraint_storages_invested_transition_indices(m::Model)
         (node=n, stochastic_path=path, t_before=t_before, t_after=t_after)
         for (n, t_before, t_after) in node_investment_dynamic_time_indices(m)
         for path in active_stochastic_paths(
+            m, 
             unique(
                 ind.stochastic_scenario for ind in storages_invested_available_indices(m; node=n, t=[t_before, t_after])
             )

--- a/src/constraints/constraint_storages_invested_transition.jl
+++ b/src/constraints/constraint_storages_invested_transition.jl
@@ -37,14 +37,12 @@ function add_constraint_storages_invested_transition!(m::Model)
             expr_sum(
                 + storages_invested_available[n, s, t_before]
                 for (n, s, t_before) in storages_invested_available_indices(
-                    m;
-                    node=n,
-                    stochastic_scenario=s,
-                    t=t_before,
+                    m; node=n, stochastic_scenario=s, t=t_before
                 );
                 init=0,
             )
-        ) for (n, s, t_before, t_after) in constraint_storages_invested_transition_indices(m)
+        )
+        for (n, s, t_before, t_after) in constraint_storages_invested_transition_indices(m)
     )
 end
 
@@ -60,7 +58,7 @@ function constraint_storages_invested_transition_indices(m::Model)
                     storages_invested_available_indices(m; node=n, t=[t_before, t_after], stochastic_scenario=s)
                 )
             )
-        )
+        ) # FIXME
     )
 end
 

--- a/src/constraints/constraint_storages_invested_transition.jl
+++ b/src/constraints/constraint_storages_invested_transition.jl
@@ -50,12 +50,7 @@ function constraint_storages_invested_transition_indices(m::Model)
     unique(
         (node=n, stochastic_path=path, t_before=t_before, t_after=t_after)
         for (n, t_before, t_after) in node_investment_dynamic_time_indices(m)
-        for path in active_stochastic_paths(
-            m, 
-            unique(
-                ind.stochastic_scenario for ind in storages_invested_available_indices(m; node=n, t=[t_before, t_after])
-            )
-        )
+        for path in active_stochastic_paths(m, storages_invested_available_indices(m; node=n, t=[t_before, t_after]))
     )
 end
 

--- a/src/constraints/constraint_total_cumulated_unit_flow_bounds.jl
+++ b/src/constraints/constraint_total_cumulated_unit_flow_bounds.jl
@@ -50,9 +50,7 @@ function constraint_total_cumulated_unit_flow_indices(m::Model,bound)
     unique(
         (unit=ug, node=ng, direction=d, stochastic_path=s)
         for (ug, ng, d) in indices(bound)
-        for s in active_stochastic_paths(
-            m, unique(ind.stochastic_scenario for ind in unit_flow_indices(m, direction=d, unit=ug, node=ng))
-        )
+        for s in active_stochastic_paths(m, unit_flow_indices(m, direction=d, unit=ug, node=ng))
     )
 end
 

--- a/src/constraints/constraint_total_cumulated_unit_flow_bounds.jl
+++ b/src/constraints/constraint_total_cumulated_unit_flow_bounds.jl
@@ -51,7 +51,7 @@ function constraint_total_cumulated_unit_flow_indices(m::Model,bound)
         (unit=ug, node=ng, direction=d, stochastic_path=s)
         for (ug, ng, d) in indices(bound)
         for s in active_stochastic_paths(
-            unique(ind.stochastic_scenario for ind in unit_flow_indices(m, direction=d, unit=ug, node=ng))
+            m, unique(ind.stochastic_scenario for ind in unit_flow_indices(m, direction=d, unit=ug, node=ng))
         )
     )
 end

--- a/src/constraints/constraint_total_cumulated_unit_flow_bounds.jl
+++ b/src/constraints/constraint_total_cumulated_unit_flow_bounds.jl
@@ -17,6 +17,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #############################################################################
 
+# TODO: Calling `max_cum_in_unit_flow_bound[(unit=ug)]` fails´?
+
 """
     add_constraint_max_cum_in_unit_flow_bound!(m::Model)
 
@@ -44,20 +46,13 @@ function add_constraint_total_cumulated_unit_flow!(m::Model, bound, sense)
     )
 end
 
-# TODO: Calling `max_cum_in_unit_flow_bound[(unit=ug)]` fails.
-
-
 function constraint_total_cumulated_unit_flow_indices(m::Model,bound)
     unique(
         (unit=ug, node=ng, direction=d, stochastic_path=s)
         for (ug, ng, d) in indices(bound)
         for s in active_stochastic_paths(
-            collect(
-                s
-                for s in stochastic_scenario()
-                if !isempty(unit_flow_indices(m, direction=d, unit=ug, node=ng, stochastic_scenario=s))
-            )
-        )  # FIXME
+            unique(ind.stochastic_scenario for ind in unit_flow_indices(m, direction=d, unit=ug, node=ng))
+        )
     )
 end
 

--- a/src/constraints/constraint_unit_flow_capacity.jl
+++ b/src/constraints/constraint_unit_flow_capacity.jl
@@ -57,7 +57,7 @@ function constraint_unit_flow_capacity_indices(m::Model)
         (unit=u, node=ng, direction=d, stochastic_path=path, t=t)
         for (u, ng, d) in indices(unit_capacity)
         for (t, path) in t_lowest_resolution_path(
-            vcat(unit_flow_indices(m; unit=u, node=ng, direction=d), units_on_indices(m; unit=u))
+            m, vcat(unit_flow_indices(m; unit=u, node=ng, direction=d), units_on_indices(m; unit=u))
         )
     )
 end

--- a/src/constraints/constraint_unit_flow_capacity.jl
+++ b/src/constraints/constraint_unit_flow_capacity.jl
@@ -56,8 +56,9 @@ function constraint_unit_flow_capacity_indices(m::Model)
     unique(
         (unit=u, node=ng, direction=d, stochastic_path=path, t=t)
         for (u, ng, d) in indices(unit_capacity)
-        for t in t_lowest_resolution(time_slice(m; temporal_block=members(node__temporal_block(node=members(ng)))))
-        for path in active_stochastic_paths(collect(_constraint_unit_flow_capacity_scenarios(m, u, ng, d, t)))
+        for (t, path) in t_lowest_resolution_path(
+            vcat(unit_flow_indices(m; unit=u, node=ng, direction=d), units_on_indices(m; unit=u))
+        )
     )
 end
 

--- a/src/constraints/constraint_unit_flow_capacity_w_ramps.jl
+++ b/src/constraints/constraint_unit_flow_capacity_w_ramps.jl
@@ -250,13 +250,10 @@ function constraint_unit_flow_capacity_w_ramp_indices(m::Model)
         )
         for path in active_stochastic_paths(
             m, 
-            unique(
-                ind.stochastic_scenario
-                for ind in vcat(
-                    unit_flow_indices(m; unit=unit, node=node, direction=direction, t=t_before),
-                    units_on_indices(m; unit=unit, t=t_in_t(m; t_long=t_before)),
-                    units_on_indices(m; unit=unit, t=t_in_t(m; t_long=t_after)),
-                )
+            vcat(
+                unit_flow_indices(m; unit=unit, node=node, direction=direction, t=t_before),
+                units_on_indices(m; unit=unit, t=t_in_t(m; t_long=t_before)),
+                units_on_indices(m; unit=unit, t=t_in_t(m; t_long=t_after))
             )
         )
     )

--- a/src/constraints/constraint_unit_flow_capacity_w_ramps.jl
+++ b/src/constraints/constraint_unit_flow_capacity_w_ramps.jl
@@ -249,6 +249,7 @@ function constraint_unit_flow_capacity_w_ramp_indices(m::Model)
             )
         )
         for path in active_stochastic_paths(
+            m, 
             unique(
                 ind.stochastic_scenario
                 for ind in vcat(

--- a/src/constraints/constraint_unit_flow_capacity_w_ramps.jl
+++ b/src/constraints/constraint_unit_flow_capacity_w_ramps.jl
@@ -22,13 +22,13 @@
 
 Limit the maximum in/out `unit_flow` of a `unit` for all `unit_capacity` indices if ramping is considered.
 Note that equations including the variables `unit_flow` and `units_on/started_up/shut_down` always take the assumption
-that the resolution of the commitment variable is lower or equal than the resolution the flow variables.
+that the resolution of the commitment variable is lower or equal than the resolution of the flow variables.
 
 Check if `unit_conv_cap_to_flow` is defined.
 """
 function add_constraint_unit_flow_capacity_w_ramp!(m::Model)
     return
-    # FIXME: MethodError: no method matching isless(::SpineInterface.OperatorCall{typeof(-)}, ::SpineInterface.IdentityCall{Float64})
+    # FIXME: MethodError still???
     @fetch unit_flow, units_on, units_started_up, units_shut_down = m.ext[:spineopt].variables
     t0 = _analysis_time(m)
     m.ext[:spineopt].constraints[:unit_flow_capacity_w_ramp] = constraint = Dict()
@@ -38,41 +38,36 @@ function add_constraint_unit_flow_capacity_w_ramp!(m::Model)
             for (u, s, t) in units_on_indices(m; unit=u, stochastic_scenario=s, t=t_overlaps_t(m; t=t_before))
         )
         if min_up_time(unit=u) != nothing && min_up_time(unit=u) > cutout
-            constraint[
-                (unit=u, node=ng, direction=d, stochastic_path=s, t=t_before),
-            ] = @constraint(
+            constraint[(unit=u, node=ng, direction=d, stochastic_path=s, t=t_before)] = @constraint(
                 m,
                 expr_sum(
-                    + unit_flow[u, n, d, s, t_before1] * duration(t_before1)
+                    unit_flow[u, n, d, s, t_before1] * duration(t_before1)
                     for (u, n, d, s, t_before1) in unit_flow_indices(
-                        m;
-                        unit=u,
-                        node=ng,
-                        direction=d,
-                        stochastic_scenario=s,
-                        t=t_overlaps_t(m; t=t_before),
+                        m; unit=u, node=ng, direction=d, stochastic_scenario=s, t=t_overlaps_t(m; t=t_before)
                     );
                     init=0,
                 )
                 <=
                 + expr_sum(
-                    (units_on[u, s, t_before1] - units_started_up[u, s, t_before1] - units_shut_down[u, s, t_after1])
+                    + (units_on[u, s, t_before1] - units_started_up[u, s, t_before1] - units_shut_down[u, s, t_after1])
                     * min(duration(t_before1), duration(t_before))
                     * unit_capacity[
                         (unit=u, node=ng, direction=d, stochastic_scenario=s, analysis_time=t0, t=t_before),
                     ]
                     * unit_conv_cap_to_flow[
                         (unit=u, node=ng, direction=d, stochastic_scenario=s, analysis_time=t0, t=t_before),
-                    ] for (u, s, t_before1) in units_on_indices(
+                    ]
+                    for (u, s, t_before1) in units_on_indices(
                         m;
                         unit=u,
                         stochastic_scenario=s,
                         t=t_overlaps_t(m; t=t_before),
-                    ) for (u, s, t_after1) in units_on_indices(m; unit=u, stochastic_scenario=s, t=t_after);
+                    )
+                    for (u, s, t_after1) in units_on_indices(m; unit=u, stochastic_scenario=s, t=t_after);
                     init=0,
                 )
                 + expr_sum(
-                    units_started_up[u, s, t_before1]
+                    + units_started_up[u, s, t_before1]
                     * min(duration(t_before1), duration(t_before))
                     * max_startup_ramp[
                         (unit=u, node=ng, direction=d, stochastic_scenario=s, analysis_time=t0, t=t_before),
@@ -82,16 +77,14 @@ function add_constraint_unit_flow_capacity_w_ramp!(m::Model)
                     ]
                     * unit_capacity[
                         (unit=u, node=ng, direction=d, stochastic_scenario=s, analysis_time=t0, t=t_before),
-                    ] for (u, s, t_before1) in units_on_indices(
-                        m;
-                        unit=u,
-                        stochastic_scenario=s,
-                        t=t_overlaps_t(m; t=t_before),
+                    ]
+                    for (u, s, t_before1) in units_on_indices(
+                        m; unit=u, stochastic_scenario=s, t=t_overlaps_t(m; t=t_before)
                     );
                     init=0,
                 )
                 + expr_sum(
-                    units_shut_down[u, s, t_after1]
+                    + units_shut_down[u, s, t_after1]
                     * min(duration(t_after1), duration(t_before))
                     * max_shutdown_ramp[
                         (unit=u, node=ng, direction=d, stochastic_scenario=s, analysis_time=t0, t=t_after),
@@ -101,68 +94,63 @@ function add_constraint_unit_flow_capacity_w_ramp!(m::Model)
                     ]
                     * unit_conv_cap_to_flow[
                         (unit=u, node=ng, direction=d, stochastic_scenario=s, analysis_time=t0, t=t_after),
-                    ] for (u, s, t_after1) in units_on_indices(m; unit=u, stochastic_scenario=s, t=t = t_after);
+                    ]
+                    for (u, s, t_after1) in units_on_indices(m; unit=u, stochastic_scenario=s, t=t = t_after);
                     # do we need t_overlap_t here?
                     init=0,
                 )
             )
         else
             # Part 1
-            constraint[
-                (unit=u, node=ng, direction=d, stochastic_path=s, t=t_before, i=1),
-            ] = @constraint(
+            constraint[(unit=u, node=ng, direction=d, stochastic_path=s, t=t_before, i=1)] = @constraint(
                 m,
                 expr_sum(
-                    + unit_flow[u, n, d, s, t] * duration(t) for (u, n, d, s, t) in unit_flow_indices(
-                        m;
-                        unit=u,
-                        node=ng,
-                        direction=d,
-                        stochastic_scenario=s,
-                        t=t_overlaps_t(m; t=t_before),
+                    unit_flow[u, n, d, s, t] * duration(t)
+                    for (u, n, d, s, t) in unit_flow_indices(
+                        m; unit=u, node=ng, direction=d, stochastic_scenario=s, t=t_overlaps_t(m; t=t_before)
                     );
                     init=0,
                 )
                 <=
                 + expr_sum(
-                    (units_on[u, s, t_before1] - units_shut_down[u, s, t_after1])
+                    + (units_on[u, s, t_before1] - units_shut_down[u, s, t_after1])
                     * min(duration(t_before1), duration(t_before))
                     * unit_capacity[
                         (unit=u, node=ng, direction=d, stochastic_scenario=s, analysis_time=t0, t=t_before),
                     ]
                     * unit_conv_cap_to_flow[
                         (unit=u, node=ng, direction=d, stochastic_scenario=s, analysis_time=t0, t=t_before),
-                    ] for (u, s, t_before1) in units_on_indices(
-                        m;
-                        unit=u,
-                        stochastic_scenario=s,
-                        t=t_overlaps_t(m; t=t_before),
-                    ) for (u, s, t_after1) in units_on_indices(m; unit=u, stochastic_scenario=s, t=t_after);
+                    ]
+                    for (u, s, t_before1) in units_on_indices(
+                        m; unit=u, stochastic_scenario=s, t=t_overlaps_t(m; t=t_before)
+                    )
+                    for (u, s, t_after1) in units_on_indices(m; unit=u, stochastic_scenario=s, t=t_after);
                     init=0,
-                ) - expr_sum(
-                    units_started_up[u, s, t_before1]
+                )
+                - expr_sum(
+                    + units_started_up[u, s, t_before1]
                     * min(duration(t_before1), duration(t_before))
                     * max(
                         + max_shutdown_ramp[
                             (unit=u, node=ng, direction=d, stochastic_scenario=s, analysis_time=t0, t=t_before),
-                        ] - max_startup_ramp[
+                        ]
+                        - max_startup_ramp[
                             (unit=u, node=ng, direction=d, stochastic_scenario=s, analysis_time=t0, t=t_before),
                         ],
-                        0,
+                        0
                     )
                     * unit_conv_cap_to_flow[
                         (unit=u, node=ng, direction=d, stochastic_scenario=s, analysis_time=t0, t=t_before),
                     ]
                     * unit_capacity[
                         (unit=u, node=ng, direction=d, stochastic_scenario=s, analysis_time=t0, t=t_before),
-                    ] for (u, s, t_before1) in units_on_indices(
-                        m;
-                        unit=u,
-                        stochastic_scenario=s,
-                        t=t_overlaps_t(m; t=t_before),
+                    ]
+                    for (u, s, t_before1) in units_on_indices(
+                        m; unit=u, stochastic_scenario=s, t=t_overlaps_t(m; t=t_before)
                     );
                     init=0,
-                ) + expr_sum(
+                )
+                + expr_sum(
                     units_shut_down[u, s, t_after1]
                     * min(duration(t_after1), duration(t_after))
                     * max_shutdown_ramp[
@@ -173,46 +161,39 @@ function add_constraint_unit_flow_capacity_w_ramp!(m::Model)
                     ]
                     * unit_conv_cap_to_flow[
                         (unit=u, node=ng, direction=d, stochastic_scenario=s, analysis_time=t0, t=t_after),
-                    ] for (u, s, t_after1) in units_on_indices(m; unit=u, stochastic_scenario=s, t=t_after);
+                    ]
+                    for (u, s, t_after1) in units_on_indices(m; unit=u, stochastic_scenario=s, t=t_after);
                     # do we need t_overlap_t here?
                     init=0,
                 )
             )
             # Part 2
-            constraint[
-                (unit=u, node=ng, direction=d, stochastic_path=s, t=t_before, i=2),
-            ] = @constraint(
+            constraint[(unit=u, node=ng, direction=d, stochastic_path=s, t=t_before, i=2)] = @constraint(
                 m,
                 expr_sum(
-                    + unit_flow[u, n, d, s, t] * min(duration(t), duration(t_before))
+                    unit_flow[u, n, d, s, t] * min(duration(t), duration(t_before))
                     for (u, n, d, s, t) in unit_flow_indices(
-                        m;
-                        unit=u,
-                        node=ng,
-                        direction=d,
-                        stochastic_scenario=s,
-                        t=t_overlaps_t(m; t=t_before),
+                        m; unit=u, node=ng, direction=d, stochastic_scenario=s, t=t_overlaps_t(m; t=t_before)
                     );
                     init=0,
                 )
                 <=
                 + expr_sum(
-                    (units_on[u, s, t_before1] - units_started_up[u, s, t_before1])
+                    + (units_on[u, s, t_before1] - units_started_up[u, s, t_before1])
                     * min(duration(t_before1), duration(t_before))
                     * unit_capacity[
                         (unit=u, node=ng, direction=d, stochastic_scenario=s, analysis_time=t0, t=t_before),
                     ]
                     * unit_conv_cap_to_flow[
                         (unit=u, node=ng, direction=d, stochastic_scenario=s, analysis_time=t0, t=t_before),
-                    ] for (u, s, t_before1) in units_on_indices(
-                        m;
-                        unit=u,
-                        stochastic_scenario=s,
-                        t=t_overlaps_t(m; t=t_before),
+                    ]
+                    for (u, s, t_before1) in units_on_indices(
+                        m; unit=u, stochastic_scenario=s, t=t_overlaps_t(m; t=t_before)
                     );
                     init=0,
-                ) + expr_sum(
-                    units_started_up[u, s, t_before1]
+                )
+                + expr_sum(
+                    + units_started_up[u, s, t_before1]
                     * min(duration(t_before1), duration(t_before))
                     * max_startup_ramp[
                         (unit=u, node=ng, direction=d, stochastic_scenario=s, analysis_time=t0, t=t_before),
@@ -222,20 +203,20 @@ function add_constraint_unit_flow_capacity_w_ramp!(m::Model)
                     ]
                     * unit_capacity[
                         (unit=u, node=ng, direction=d, stochastic_scenario=s, analysis_time=t0, t=t_before),
-                    ] for (u, s, t_before1) in units_on_indices(
-                        m;
-                        unit=u,
-                        stochastic_scenario=s,
-                        t=t_overlaps_t(m; t=t_before),
+                    ]
+                    for (u, s, t_before1) in units_on_indices(
+                        m; unit=u, stochastic_scenario=s, t=t_overlaps_t(m; t=t_before)
                     );
                     init=0,
-                ) - expr_sum(
-                    units_shut_down[u, s, t_after1]
+                )
+                - expr_sum(
+                    + units_shut_down[u, s, t_after1]
                     * min(duration(t_after1), duration(t_after))
                     * max(
-                        max_startup_ramp[
+                        + max_startup_ramp[
                             (unit=u, node=ng, direction=d, stochastic_scenario=s, analysis_time=t0, t=t_after),
-                        ] - max_shutdown_ramp[
+                        ]
+                        - max_shutdown_ramp[
                             (unit=u, node=ng, direction=d, stochastic_scenario=s, analysis_time=t0, t=t_after),
                         ],
                         0,
@@ -245,7 +226,8 @@ function add_constraint_unit_flow_capacity_w_ramp!(m::Model)
                     ]
                     * unit_conv_cap_to_flow[
                         (unit=u, node=ng, direction=d, stochastic_scenario=s, analysis_time=t0, t=t_after),
-                    ] for (u, s, t_after1) in units_on_indices(m; unit=u, stochastic_scenario=s, t=t_after);
+                    ]
+                    for (u, s, t_after1) in units_on_indices(m; unit=u, stochastic_scenario=s, t=t_after);
                     # do we need t_overlap_t here?
                     init=0,
                 )
@@ -263,12 +245,18 @@ function constraint_unit_flow_capacity_w_ramp_indices(m::Model)
         for t_after in time_slice(m; temporal_block=units_on__temporal_block(unit=u))
         for t_before in t_lowest_resolution(
             time_slice(
-                m;
-                temporal_block=members(node__temporal_block(node=members(ng))),
-                t=t_before_t(m, t_after=t_after),
-            ),
-        ) for path in active_stochastic_paths(
-            collect(_constraint_unit_flow_capacity_w_ramp_scenarios(m, u, ng, d, t_before, t_after))
+                m; temporal_block=members(node__temporal_block(node=members(ng))), t=t_before_t(m, t_after=t_after)
+            )
+        )
+        for path in active_stochastic_paths(
+            unique(
+                ind.stochastic_scenario
+                for ind in vcat(
+                    unit_flow_indices(m; unit=unit, node=node, direction=direction, t=t_before),
+                    units_on_indices(m; unit=unit, t=t_in_t(m; t_long=t_before)),
+                    units_on_indices(m; unit=unit, t=t_in_t(m; t_long=t_after)),
+                )
+            )
         )
     )
 end
@@ -302,14 +290,4 @@ function constraint_unit_flow_capacity_w_ramp_indices_filtered(
         )
     end
     filter(f, constraint_unit_flow_capacity_w_ramp_indices(m))
-end
-
-function _constraint_unit_flow_capacity_w_ramp_scenarios(m::Model, unit, node, direction, t_before, t_after)
-    (
-        s
-        for s in stochastic_scenario()
-        if !isempty(unit_flow_indices(m; unit=unit, node=node, direction=direction, t=t_before, stochastic_scenario=s))
-        || !isempty(units_on_indices(m; unit=unit, t=t_in_t(m; t_long=t_before), stochastic_scenario=s))
-        || !isempty(units_on_indices(m; unit=unit, t=t_in_t(m; t_long=t_after), stochastic_scenario=s))
-    )
 end

--- a/src/constraints/constraint_unit_lifetime.jl
+++ b/src/constraints/constraint_unit_lifetime.jl
@@ -49,9 +49,7 @@ function constraint_unit_lifetime_indices(m::Model)
         (unit=u, stochastic_path=path, t=t)
         for u in indices(unit_investment_lifetime)
         for (u, t) in unit_investment_time_indices(m; unit=u)
-        for path in active_stochastic_paths(
-            m, unique(ind.stochastic_scenario for ind in _past_units_invested_available_indices(m, u, anything, t))
-        )
+        for path in active_stochastic_paths(m, _past_units_invested_available_indices(m, u, anything, t))
     )
 end
 

--- a/src/constraints/constraint_unit_lifetime.jl
+++ b/src/constraints/constraint_unit_lifetime.jl
@@ -28,27 +28,18 @@ function add_constraint_unit_lifetime!(m::Model)
     m.ext[:spineopt].constraints[:unit_lifetime] = Dict(
         (unit=u, stochastic_path=s, t=t) => @constraint(
             m,
-            + expr_sum(
-                + units_invested_available[u, s, t]
+            expr_sum(
+                units_invested_available[u, s, t]
                 for (u, s, t) in units_invested_available_indices(m; unit=u, stochastic_scenario=s, t=t);
                 init=0,
             )
             >=
-            + sum(
-                + units_invested[u, s_past, t_past] for (u, s_past, t_past) in units_invested_available_indices(
-                    m;
-                    unit=u,
-                    stochastic_scenario=s,
-                    t=to_time_slice(
-                        m;
-                        t=TimeSlice(
-                            end_(t) - unit_investment_lifetime(unit=u, stochastic_scenario=s, analysis_time=t0, t=t),
-                            end_(t),
-                        ),
-                    ),
-                )
+            sum(
+                units_invested[u, s_past, t_past]
+                for (u, s_past, t_past) in _past_units_invested_available_indices(m, u, s, t)
             )
-        ) for (u, s, t) in constraint_unit_lifetime_indices(m)
+        )
+        for (u, s, t) in constraint_unit_lifetime_indices(m)
     )
 end
 
@@ -56,9 +47,27 @@ function constraint_unit_lifetime_indices(m::Model)
     t0 = _analysis_time(m)
     unique(
         (unit=u, stochastic_path=path, t=t)
-        for u in indices(unit_investment_lifetime) for (u, s, t) in units_invested_available_indices(m; unit=u)
-        for path in active_stochastic_paths(collect(_constraint_unit_lifetime_scenarios(m, u, s, t0, t)))
-    )  # FIXME
+        for u in indices(unit_investment_lifetime)
+        for (u, t) in unit_investment_time_indices(m; unit=u)
+        for path in active_stochastic_paths(
+            unique(ind.stochastic_scenario for ind in _past_units_invested_available_indices(m, u, anything, t))
+        )
+    )
+end
+
+function _past_units_invested_available_indices(m, u, s, t)
+    t0 = _analysis_time(m)
+    units_invested_available_indices(
+        m;
+        unit=u,
+        stochastic_scenario=s,
+        t=to_time_slice(
+            m;
+            t=TimeSlice(
+                end_(t) - unit_investment_lifetime(unit=u, analysis_time=t0, stochastic_scenario=s, t=t), end_(t)
+            )
+        )
+    )
 end
 
 """

--- a/src/constraints/constraint_unit_lifetime.jl
+++ b/src/constraints/constraint_unit_lifetime.jl
@@ -58,7 +58,7 @@ function constraint_unit_lifetime_indices(m::Model)
         (unit=u, stochastic_path=path, t=t)
         for u in indices(unit_investment_lifetime) for (u, s, t) in units_invested_available_indices(m; unit=u)
         for path in active_stochastic_paths(collect(_constraint_unit_lifetime_scenarios(m, u, s, t0, t)))
-    )
+    )  # FIXME
 end
 
 """

--- a/src/constraints/constraint_unit_lifetime.jl
+++ b/src/constraints/constraint_unit_lifetime.jl
@@ -82,15 +82,3 @@ function constraint_unit_lifetime_indices_filtered(m::Model; unit=anything, stoc
     f(ind) = _index_in(ind; unit=unit, stochastic_path=stochastic_path, t=t)
     filter(f, constraint_unit_lifetime_indices(m))
 end
-
-function _constraint_unit_lifetime_scenarios(m, u, s, t0, t)
-    t_past_and_present = to_time_slice(
-        m;
-        t=TimeSlice(end_(t) - unit_investment_lifetime(unit=u, stochastic_scenario=s, analysis_time=t0, t=t), end_(t)),
-    )
-    (
-        s
-        for s in stochastic_scenario()
-        if !isempty(units_invested_available_indices(m; unit=u, t=t_past_and_present, stochastic_scenario=s))
-    )
-end

--- a/src/constraints/constraint_unit_lifetime.jl
+++ b/src/constraints/constraint_unit_lifetime.jl
@@ -50,7 +50,7 @@ function constraint_unit_lifetime_indices(m::Model)
         for u in indices(unit_investment_lifetime)
         for (u, t) in unit_investment_time_indices(m; unit=u)
         for path in active_stochastic_paths(
-            unique(ind.stochastic_scenario for ind in _past_units_invested_available_indices(m, u, anything, t))
+            m, unique(ind.stochastic_scenario for ind in _past_units_invested_available_indices(m, u, anything, t))
         )
     )
 end

--- a/src/constraints/constraint_unit_pw_heat_rate.jl
+++ b/src/constraints/constraint_unit_pw_heat_rate.jl
@@ -31,7 +31,8 @@ function add_constraint_unit_pw_heat_rate!(m::Model)
         (unit=u, node1=n_from, node2=n_to, stochastic_path=s, t=t) => @constraint(
             m,
             expr_sum(
-                + unit_flow[u, n, d, s, t_short] * duration(t_short) for (u, n, d, s, t_short) in unit_flow_indices(
+                + unit_flow[u, n, d, s, t_short] * duration(t_short)
+                for (u, n, d, s, t_short) in unit_flow_indices(
                     m;
                     unit=u,
                     node=n_from,
@@ -42,19 +43,14 @@ function add_constraint_unit_pw_heat_rate!(m::Model)
                 init=0,
             )
             ==
-            0
             + expr_sum(
                 + unit_flow_op[u, n, d, op, s, t_short]
                 * unit_incremental_heat_rate[
                     (unit=u, node1=n_from, node2=n, i=op, stochastic_scenario=s, analysis_time=t0, t=t_short),
                 ]
-                * duration(t_short) for (u, n, d, op, s, t_short) in unit_flow_op_indices(
-                    m;
-                    unit=u,
-                    node=n_to,
-                    direction=direction(:to_node),
-                    stochastic_scenario=s,
-                    t=t_in_t(m; t_long=t),
+                * duration(t_short)
+                for (u, n, d, op, s, t_short) in unit_flow_op_indices(
+                    m; unit=u, node=n_to, direction=direction(:to_node), stochastic_scenario=s, t=t_in_t(m; t_long=t)
                 );
                 init=0,
             )
@@ -63,26 +59,24 @@ function add_constraint_unit_pw_heat_rate!(m::Model)
                 * unit_incremental_heat_rate[
                     (unit=u, node1=n_from, node2=n, i=1, stochastic_scenario=s, analysis_time=t0, t=t_short),
                 ]
-                * duration(t_short) for (u, n, d, s, t_short) in unit_flow_indices(
-                    m;
-                    unit=u,
-                    node=n_to,
-                    direction=direction(:to_node),
-                    stochastic_scenario=s,
-                    t=t_in_t(m; t_long=t),
-                ) if isempty(unit_flow_op_indices(m; unit=u, node=n, direction=d, t=t_short));
+                * duration(t_short)
+                for (u, n, d, s, t_short) in unit_flow_indices(
+                    m; unit=u, node=n_to, direction=direction(:to_node), stochastic_scenario=s, t=t_in_t(m; t_long=t)
+                )
+                if isempty(unit_flow_op_indices(m; unit=u, node=n, direction=d, t=t_short));
                 init=0,
             )
             + expr_sum(
-                0
-                + (units_on[u, s, t1]
-                   * min(duration(t1), duration(t))
-                   * unit_idle_heat_rate[
-                       (unit=u, node1=n_from, node2=n_to, stochastic_scenario=s, analysis_time=t0, t=t),
-                   ])
-                + (units_started_up[u, s, t1] * unit_start_flow[
-                    (unit=u, node1=n_from, node2=n_to, stochastic_scenario=s, analysis_time=t0, t=t),
-                ]) for (u, s, t1) in units_on_indices(m; unit=u, stochastic_scenario=s, t=t_overlaps_t(m; t=t));
+                + units_on[u, s, t1]
+                * min(duration(t1), duration(t))
+                * unit_idle_heat_rate[
+                   (unit=u, node1=n_from, node2=n_to, stochastic_scenario=s, analysis_time=t0, t=t)
+                ]
+                + units_started_up[u, s, t1]
+                * unit_start_flow[
+                    (unit=u, node1=n_from, node2=n_to, stochastic_scenario=s, analysis_time=t0, t=t)
+                ]
+                for (u, s, t1) in units_on_indices(m; unit=u, stochastic_scenario=s, t=t_overlaps_t(m; t=t));
                 init=0,
             )
         ) for (u, n_from, n_to, s, t) in constraint_unit_pw_heat_rate_indices(m)
@@ -95,7 +89,7 @@ function constraint_unit_pw_heat_rate_indices(m::Model)
         for (u, n_from, n_to) in indices(unit_incremental_heat_rate)
         for t in t_lowest_resolution(x.t for x in unit_flow_indices(m; unit=u, node=[n_from, n_to]))
         for path in active_stochastic_paths(collect(_constraint_unit_pw_heat_rate_scenarios(m, u, n_from, n_to, t)))
-    )
+    )  # FIXME
 end
 
 """

--- a/src/constraints/constraint_unit_pw_heat_rate.jl
+++ b/src/constraints/constraint_unit_pw_heat_rate.jl
@@ -89,6 +89,7 @@ function constraint_unit_pw_heat_rate_indices(m::Model)
         (unit=u, node_from=n_from, node_to=n_to, stochastic_path=path, t=t)
         for (u, n_from, n_to) in indices(unit_incremental_heat_rate)
         for (t, path) in t_lowest_resolution_path(
+            m, 
             vcat(
                 unit_flow_indices(m; unit=u, node=n_from, direction=direction(:from_node)),
                 unit_flow_indices(m; unit=u, node=n_to, direction=direction(:to_node)),

--- a/src/constraints/constraint_unit_state_transition.jl
+++ b/src/constraints/constraint_unit_state_transition.jl
@@ -54,11 +54,7 @@ function constraint_unit_state_transition_indices(m::Model)
         (unit=u, stochastic_path=path, t_before=t_before, t_after=t_after)
         for (u, t_before, t_after) in unit_dynamic_time_indices(m)
         for path in active_stochastic_paths(
-            m, 
-            unique(
-                ind.stochastic_scenario
-                for ind in units_on_indices(m; unit=u, t=[t_before, t_after], temporal_block=anything)
-            )
+            m, units_on_indices(m; unit=u, t=[t_before, t_after], temporal_block=anything)
         )
     )
 end

--- a/src/constraints/constraint_unit_state_transition.jl
+++ b/src/constraints/constraint_unit_state_transition.jl
@@ -54,6 +54,7 @@ function constraint_unit_state_transition_indices(m::Model)
         (unit=u, stochastic_path=path, t_before=t_before, t_after=t_after)
         for (u, t_before, t_after) in unit_dynamic_time_indices(m)
         for path in active_stochastic_paths(
+            m, 
             unique(
                 ind.stochastic_scenario
                 for ind in units_on_indices(m; unit=u, t=[t_before, t_after], temporal_block=anything)

--- a/src/constraints/constraint_unit_state_transition.jl
+++ b/src/constraints/constraint_unit_state_transition.jl
@@ -32,26 +32,20 @@ function add_constraint_unit_state_transition!(m::Model)
             expr_sum(
                 + units_on[u, s, t_after] - units_started_up[u, s, t_after] + units_shut_down[u, s, t_after]
                 for (u, s, t_after) in units_on_indices(
-                    m;
-                    unit=u,
-                    stochastic_scenario=s,
-                    t=t_after,
-                    temporal_block=anything,
+                    m; unit=u, stochastic_scenario=s, t=t_after, temporal_block=anything,
                 );
                 init=0,
             )
             ==
             expr_sum(
-                + units_on[u, s, t_before] for (u, s, t_before) in units_on_indices(
-                    m;
-                    unit=u,
-                    stochastic_scenario=s,
-                    t=t_before,
-                    temporal_block=anything,
+                + units_on[u, s, t_before]
+                for (u, s, t_before) in units_on_indices(
+                    m; unit=u, stochastic_scenario=s, t=t_before, temporal_block=anything,
                 );
                 init=0,
             )
-        ) for (u, s, t_before, t_after) in constraint_unit_state_transition_indices(m)
+        )
+        for (u, s, t_before, t_after) in constraint_unit_state_transition_indices(m)
     )
 end
 
@@ -67,7 +61,7 @@ function constraint_unit_state_transition_indices(m::Model)
                     units_on_indices(m; unit=u, t=[t_before, t_after], temporal_block=anything, stochastic_scenario=s)
                 )
             )
-        )
+        )  # FIXME
     )
 end
 

--- a/src/constraints/constraint_unit_state_transition.jl
+++ b/src/constraints/constraint_unit_state_transition.jl
@@ -52,16 +52,13 @@ end
 function constraint_unit_state_transition_indices(m::Model)
     unique(
         (unit=u, stochastic_path=path, t_before=t_before, t_after=t_after)
-        for (u, t_before, t_after) in unit_dynamic_time_indices(m; unit=unit())
+        for (u, t_before, t_after) in unit_dynamic_time_indices(m)
         for path in active_stochastic_paths(
-            collect(
-                s
-                for s in stochastic_scenario()
-                if !isempty(
-                    units_on_indices(m; unit=u, t=[t_before, t_after], temporal_block=anything, stochastic_scenario=s)
-                )
+            unique(
+                ind.stochastic_scenario
+                for ind in units_on_indices(m; unit=u, t=[t_before, t_after], temporal_block=anything)
             )
-        )  # FIXME
+        )
     )
 end
 

--- a/src/constraints/constraint_units_available.jl
+++ b/src/constraints/constraint_units_available.jl
@@ -71,7 +71,7 @@ function constraint_units_available_indices(m::Model)
                     units_invested_available_indices(m; unit=u, t=t_overlaps_t(m; t=t), stochastic_scenario=s)
                 )
             )
-        )
+        )  # FIXME
         for s in path
     )
 end

--- a/src/constraints/constraint_units_available.jl
+++ b/src/constraints/constraint_units_available.jl
@@ -63,6 +63,7 @@ function constraint_units_available_indices(m::Model)
         (unit=u, stochastic_scenario=s, t=t)
         for (u, t) in unit_time_indices(m)
         for path in active_stochastic_paths(
+            m, 
             unique(
                 ind.stochastic_scenario
                 for ind in vcat(

--- a/src/constraints/constraint_units_available.jl
+++ b/src/constraints/constraint_units_available.jl
@@ -63,14 +63,7 @@ function constraint_units_available_indices(m::Model)
         (unit=u, stochastic_scenario=s, t=t)
         for (u, t) in unit_time_indices(m)
         for path in active_stochastic_paths(
-            m, 
-            unique(
-                ind.stochastic_scenario
-                for ind in vcat(
-                    units_on_indices(m; unit=u, t=t),
-                    units_invested_available_indices(m; unit=u, t=t_overlaps_t(m; t=t))
-                )
-            )
+            m, [units_on_indices(m; unit=u, t=t); units_invested_available_indices(m; unit=u, t=t_overlaps_t(m; t=t))]
         )
         for s in path
     )

--- a/src/constraints/constraint_units_available.jl
+++ b/src/constraints/constraint_units_available.jl
@@ -63,15 +63,14 @@ function constraint_units_available_indices(m::Model)
         (unit=u, stochastic_scenario=s, t=t)
         for (u, t) in unit_time_indices(m)
         for path in active_stochastic_paths(
-            collect(
-                s
-                for s in stochastic_scenario()
-                if !isempty(units_on_indices(m; unit=u, t=t, stochastic_scenario=s))
-                || !isempty(
-                    units_invested_available_indices(m; unit=u, t=t_overlaps_t(m; t=t), stochastic_scenario=s)
+            unique(
+                ind.stochastic_scenario
+                for ind in vcat(
+                    units_on_indices(m; unit=u, t=t),
+                    units_invested_available_indices(m; unit=u, t=t_overlaps_t(m; t=t))
                 )
             )
-        )  # FIXME
+        )
         for s in path
     )
 end

--- a/src/constraints/constraint_units_invested_available.jl
+++ b/src/constraints/constraint_units_invested_available.jl
@@ -31,7 +31,8 @@ function add_constraint_units_invested_available!(m::Model)
             + units_invested_available[u, s, t]
             <=
             + candidate_units[(unit=u, stochastic_scenario=s, analysis_time=t0, t=t)]
-        ) for (u, s, t) in units_invested_available_indices(m)
+        )
+        for (u, s, t) in units_invested_available_indices(m)
     )
 end
 # TODO: units_invested_available or \sum(units_invested)?

--- a/src/constraints/constraint_units_invested_transition.jl
+++ b/src/constraints/constraint_units_invested_transition.jl
@@ -39,7 +39,8 @@ function add_constraint_units_invested_transition!(m::Model)
                 for (u, s, t_before) in units_invested_available_indices(m; unit=u, stochastic_scenario=s, t=t_before);
                 init=0,
             )
-        ) for (u, s, t_before, t_after) in constraint_units_invested_transition_indices(m)
+        )
+        for (u, s, t_before, t_after) in constraint_units_invested_transition_indices(m)
     )
 end
 
@@ -53,7 +54,7 @@ function constraint_units_invested_transition_indices(m::Model)
                 for s in stochastic_scenario()
                 if !isempty(units_invested_available_indices(m; unit=u, t=[t_before, t_after], stochastic_scenario=s))
             )
-        )
+        )  # FIXME
     )
 end
 

--- a/src/constraints/constraint_units_invested_transition.jl
+++ b/src/constraints/constraint_units_invested_transition.jl
@@ -49,12 +49,10 @@ function constraint_units_invested_transition_indices(m::Model)
         (unit=u, stochastic_path=path, t_before=t_before, t_after=t_after)
         for (u, t_before, t_after) in unit_investment_dynamic_time_indices(m)
         for path in active_stochastic_paths(
-            collect(
-                s
-                for s in stochastic_scenario()
-                if !isempty(units_invested_available_indices(m; unit=u, t=[t_before, t_after], stochastic_scenario=s))
+            unique(
+                ind.stochastic_scenario for ind in units_invested_available_indices(m; unit=u, t=[t_before, t_after])
             )
-        )  # FIXME
+        )
     )
 end
 

--- a/src/constraints/constraint_units_invested_transition.jl
+++ b/src/constraints/constraint_units_invested_transition.jl
@@ -49,6 +49,7 @@ function constraint_units_invested_transition_indices(m::Model)
         (unit=u, stochastic_path=path, t_before=t_before, t_after=t_after)
         for (u, t_before, t_after) in unit_investment_dynamic_time_indices(m)
         for path in active_stochastic_paths(
+            m, 
             unique(
                 ind.stochastic_scenario for ind in units_invested_available_indices(m; unit=u, t=[t_before, t_after])
             )

--- a/src/constraints/constraint_units_invested_transition.jl
+++ b/src/constraints/constraint_units_invested_transition.jl
@@ -48,12 +48,7 @@ function constraint_units_invested_transition_indices(m::Model)
     unique(
         (unit=u, stochastic_path=path, t_before=t_before, t_after=t_after)
         for (u, t_before, t_after) in unit_investment_dynamic_time_indices(m)
-        for path in active_stochastic_paths(
-            m, 
-            unique(
-                ind.stochastic_scenario for ind in units_invested_available_indices(m; unit=u, t=[t_before, t_after])
-            )
-        )
+        for path in active_stochastic_paths(m, units_invested_available_indices(m; unit=u, t=[t_before, t_after]))
     )
 end
 

--- a/src/constraints/constraint_units_on.jl
+++ b/src/constraints/constraint_units_on.jl
@@ -25,7 +25,7 @@ Limit the units_on by the number of available units.
 function add_constraint_units_on!(m::Model)
     @fetch units_on, units_available = m.ext[:spineopt].variables
     m.ext[:spineopt].constraints[:units_on] = Dict(
-        (unit=u, stochastic_scenario=s, t=t) => @constraint(m, + units_on[u, s, t] <= + units_available[u, s, t])
+        (unit=u, stochastic_scenario=s, t=t) => @constraint(m, units_on[u, s, t] <= units_available[u, s, t])
         for (u, s, t) in units_on_indices(m)
     )
 end

--- a/src/constraints/constraint_user_constraint.jl
+++ b/src/constraints/constraint_user_constraint.jl
@@ -267,6 +267,7 @@ function constraint_user_constraint_indices(m::Model)
         (user_constraint=uc, stochastic_path=path, t=t)
         for uc in user_constraint()
         for (t, path) in t_lowest_resolution_path(
+            m, 
             Iterators.flatten((
                 _constraint_user_constraint_unit_flow_indices(m, uc),
                 _constraint_user_constraint_units_on_indices(m, uc),

--- a/src/constraints/constraint_user_constraint.jl
+++ b/src/constraints/constraint_user_constraint.jl
@@ -124,9 +124,9 @@ function add_constraint_user_constraint!(m::Model)
                     + units_on[u, s, t1]
                     * units_on_coefficient[(user_constraint=uc, unit=u, stochastic_scenario=s, analysis_time=t0, t=t1)]
                     + units_started_up[u, s, t1]
-                    * units_started_up_coefficient[(
-                        user_constraint=uc, unit=u, stochastic_scenario=s, analysis_time=t0, t=t1
-                    )]
+                    * units_started_up_coefficient[
+                        (user_constraint=uc, unit=u, stochastic_scenario=s, analysis_time=t0, t=t1)
+                    ]
                 )
                 * min(duration(t1), duration(t))
                 for u in unit__user_constraint(user_constraint=uc)
@@ -136,13 +136,13 @@ function add_constraint_user_constraint!(m::Model)
             + expr_sum(
                 (   
                     + units_invested_available[u, s, t1]
-                    * units_invested_available_coefficient[(
-                        user_constraint=uc, unit=u, stochastic_scenario=s, analysis_time=t0, t=t1
-                    )]
+                    * units_invested_available_coefficient[
+                        (user_constraint=uc, unit=u, stochastic_scenario=s, analysis_time=t0, t=t1)
+                    ]
                     + units_invested[u, s, t1]
-                    * units_invested_coefficient[(
-                        user_constraint=uc, unit=u, stochastic_scenario=s, analysis_time=t0, t=t1
-                    )]
+                    * units_invested_coefficient[
+                        (user_constraint=uc, unit=u, stochastic_scenario=s, analysis_time=t0, t=t1)
+                    ]
                 )
                 * min(duration(t1), duration(t))
                 for u in unit__user_constraint(user_constraint=uc)
@@ -154,13 +154,13 @@ function add_constraint_user_constraint!(m::Model)
             + expr_sum(
                 (   
                     + connections_invested_available[c, s, t1]
-                    * connections_invested_available_coefficient[(
-                        user_constraint=uc, connection=c, stochastic_scenario=s, analysis_time=t0, t=t1
-                    )]
+                    * connections_invested_available_coefficient[
+                        (user_constraint=uc, connection=c, stochastic_scenario=s, analysis_time=t0, t=t1)
+                    ]
                     + connections_invested[c, s, t1]
-                    * connections_invested_coefficient[(
-                        user_constraint=uc, connection=c, stochastic_scenario=s, analysis_time=t0, t=t1
-                    )]
+                    * connections_invested_coefficient[
+                        (user_constraint=uc, connection=c, stochastic_scenario=s, analysis_time=t0, t=t1)
+                    ]
                 )
                 * min(duration(t1), duration(t))
                 for c in connection__user_constraint(user_constraint=uc)
@@ -172,13 +172,13 @@ function add_constraint_user_constraint!(m::Model)
             + expr_sum(
                 (   
                     + storages_invested_available[n, s, t1]
-                    * storages_invested_available_coefficient[(
-                        user_constraint=uc, node=n, stochastic_scenario=s, analysis_time=t0, t=t1
-                    )]
+                    * storages_invested_available_coefficient[
+                        (user_constraint=uc, node=n, stochastic_scenario=s, analysis_time=t0, t=t1)
+                    ]
                     + storages_invested[n, s, t1]
-                    * storages_invested_coefficient[(
-                        user_constraint=uc, node=n, stochastic_scenario=s, analysis_time=t0, t=t1
-                    )]
+                    * storages_invested_coefficient[
+                        (user_constraint=uc, node=n, stochastic_scenario=s, analysis_time=t0, t=t1)
+                    ]
                 )
                 * min(duration(t1), duration(t))
                 for n in node__user_constraint(user_constraint=uc)
@@ -266,7 +266,7 @@ function constraint_user_constraint_indices(m::Model)
     unique(
         (user_constraint=uc, stochastic_path=path, t=t)
         for uc in user_constraint() for t in _constraint_user_constraint_lowest_resolution_t(m, uc)
-        for path in active_stochastic_paths(collect(_constraint_user_constraint_scenarios(m, uc, t)))
+        for path in active_stochastic_paths(collect(_constraint_user_constraint_scenarios(m, uc, t)))  # FIXME
     )
 end
 

--- a/src/constraints/constraint_user_constraint.jl
+++ b/src/constraints/constraint_user_constraint.jl
@@ -265,8 +265,19 @@ end
 function constraint_user_constraint_indices(m::Model)
     unique(
         (user_constraint=uc, stochastic_path=path, t=t)
-        for uc in user_constraint() for t in _constraint_user_constraint_lowest_resolution_t(m, uc)
-        for path in active_stochastic_paths(collect(_constraint_user_constraint_scenarios(m, uc, t)))  # FIXME
+        for uc in user_constraint()
+        for (t, path) in t_lowest_resolution_path(
+            Iterators.flatten((
+                _constraint_user_constraint_unit_flow_indices(m, uc),
+                _constraint_user_constraint_units_on_indices(m, uc),
+                _constraint_user_constraint_connection_flow_indices(m, uc),
+                _constraint_user_constraint_node_state_indices(m, uc),
+                _constraint_user_constraint_node_stochastic_time_indices(m, uc),
+                _constraint_user_constraint_units_invested_indices(m, uc),
+                _constraint_user_constraint_connections_invested_indices(m, uc),
+                _constraint_user_constraint_storages_invested_indices(m, uc)
+            ))
+        )
     )
 end
 
@@ -288,176 +299,52 @@ function constraint_user_constraint_indices_filtered(
     filter(f, constraint_user_constraint_indices(m))
 end
 
-"""
-    _constraint_user_constraint_lowest_resolution_t(m, uc, t)
-
-Find the lowest temporal resolution amoung the `unit_flow` variables appearing in the `user_constraint`.
-"""
-function _constraint_user_constraint_lowest_resolution_t(m, uc)
-    t_lowest_resolution(ind.t for ind in _constraint_user_constraint_indices(m, uc))
-end
-
-"""
-    _constraint_user_constraint_unit_flow_indices(uc, t)
-
-Gather the `unit_flow` variable indices appearing in `add_constraint_user_constraint!`.
-"""
-function _constraint_user_constraint_unit_flow_indices(m, uc, t, s=anything)
+function _constraint_user_constraint_unit_flow_indices(m, uc)
     (
         ind
         for (unit__node__user_constraint, d) in (
             (unit__from_node__user_constraint, :from_node), (unit__to_node__user_constraint, :to_node)
         )
         for (u, n) in unit__node__user_constraint(user_constraint=uc)
-        for ind in unit_flow_indices(m; unit=u, node=n, direction=direction(d), t=t, stochastic_scenario=s)
+        for ind in unit_flow_indices(m; unit=u, node=n, direction=direction(d))
     )
 end
 
-"""
-    _constraint_user_constraint_units_on_indices(uc, t)
-
-Gather the `units_on` variable indices appearing in `add_constraint_user_constraint!`.
-"""
-function _constraint_user_constraint_units_on_indices(m, uc, t, s=anything)
-    (
-        ind
-        for u in unit__user_constraint(user_constraint=uc)
-        for ind in units_on_indices(m; unit=u, t=t, stochastic_scenario=s)
-    )
+function _constraint_user_constraint_units_on_indices(m, uc)
+    (ind for u in unit__user_constraint(user_constraint=uc) for ind in units_on_indices(m; unit=u))
 end
 
-"""
-    _constraint_user_constraint_connection_flow_indices(uc, t)
-
-Gather the `connection_flow` variable indices appearing in `add_constraint_user_constraint!`.
-"""
-function _constraint_user_constraint_connection_flow_indices(m, uc, t, s=anything)
+function _constraint_user_constraint_connection_flow_indices(m, uc)
     (
         ind
         for (connection__node__user_constraint, d) in (
             (connection__from_node__user_constraint, :from_node), (connection__to_node__user_constraint, :to_node)
         )
         for (c, n) in connection__node__user_constraint(user_constraint=uc)
-        for ind in connection_flow_indices(m; connection=c, node=n, direction=direction(d), t=t, stochastic_scenario=s)
+        for ind in connection_flow_indices(m; connection=c, node=n, direction=direction(d))
     )
 end
 
-"""
-    _constraint_user_constraint_node_state_indices(uc, t)
-
-Gather the `node_state` variable indices appearing in `add_constraint_user_constraint!`.
-"""
-function _constraint_user_constraint_node_state_indices(m, uc, t, s=anything)
-    (
-        ind
-        for n in node__user_constraint(user_constraint=uc)
-        for ind in node_state_indices(m; node=n, t=t, stochastic_scenario=s)
-    )
+function _constraint_user_constraint_node_state_indices(m, uc)
+    (ind for n in node__user_constraint(user_constraint=uc) for ind in node_state_indices(m; node=n))
 end
 
-
-
-"""
-    _constraint_user_constraint_units_invested_indices(uc, t)
-
-Gather the `units_invested` variable indices appearing in `add_constraint_user_constraint!`.
-"""
-function _constraint_user_constraint_units_invested_indices(m, uc, t, s=anything)
-    (
-        ind
-        for u in unit__user_constraint(user_constraint=uc)
-        for ind in units_invested_available_indices(m; unit=u, t=t, stochastic_scenario=s)
-    )
+function _constraint_user_constraint_units_invested_indices(m, uc)
+    (ind for u in unit__user_constraint(user_constraint=uc) for ind in units_invested_available_indices(m; unit=u))
 end
 
-
-"""
-    _constraint_user_constraint_connections_invested_indices(uc, t)
-
-Gather the `connections_invested` variable indices appearing in `add_constraint_user_constraint!`.
-"""
-function _constraint_user_constraint_connections_invested_indices(m, uc, t, s=anything)
+function _constraint_user_constraint_connections_invested_indices(m, uc)
     (
         ind
         for c in connection__user_constraint(user_constraint=uc)
-        for ind in connections_invested_available_indices(m; connection=c, t=t, stochastic_scenario=s)
+        for ind in connections_invested_available_indices(m; connection=c)
     )
 end
 
-"""
-    _constraint_user_constraint_storages_invested_indices(uc, t)
-
-Gather the `storages_invested` variable indices appearing in `add_constraint_user_constraint!`.
-"""
-function _constraint_user_constraint_storages_invested_indices(m, uc, t, s=anything)
-    (
-        ind
-        for n in node__user_constraint(user_constraint=uc)
-        for ind in storages_invested_available_indices(m; node=n, t=t, stochastic_scenario=s)
-    )
+function _constraint_user_constraint_storages_invested_indices(m, uc)
+    (ind for n in node__user_constraint(user_constraint=uc) for ind in storages_invested_available_indices(m; node=n))
 end
 
-
-"""
-    _constraint_user_constraint_node_stochastic_time_indices(m, uc, t)
-
-Gather the `node_stochastic_time_indices` indices appearing in `add_constraint_user_constraint!`.
-"""
-function _constraint_user_constraint_node_stochastic_time_indices(m, uc, t, s=anything)
-    (
-        ind
-        for n in node__user_constraint(user_constraint=uc)
-        for ind in node_stochastic_time_indices(m; node=n, t=t, stochastic_scenario=s)
-    )
-end
-
-"""
-    _constraint_user_constraint_indices(m, uc, t)
-
-Gather the `unit_flow`, `units_on`, `connection_flow`, `node_state` variables appearing in `add_constraint_user_constraint!`
-"""
-function _constraint_user_constraint_indices(m, uc, t=anything)
-    t = t_in_t(m; t_long=t)
-    Iterators.flatten((
-        _constraint_user_constraint_unit_flow_indices(m, uc, t),
-        _constraint_user_constraint_units_on_indices(m, uc, t),
-        _constraint_user_constraint_connection_flow_indices(m, uc, t),
-        _constraint_user_constraint_node_state_indices(m, uc, t),
-        _constraint_user_constraint_node_stochastic_time_indices(m, uc, t),
-        _constraint_user_constraint_units_invested_indices(m, uc, t),
-        _constraint_user_constraint_connections_invested_indices(m, uc, t),
-        _constraint_user_constraint_storages_invested_indices(m, uc, t)
-    ))
-end
-
-function _constraint_user_constraint_scenarios(m, uc, t=anything)
-    t = t_in_t(m; t_long=t)
-    (
-        s
-        for s in stochastic_scenario()
-        if !isempty(
-            _constraint_user_constraint_unit_flow_indices(m, uc, t, s)
-        )
-        || !isempty(
-            _constraint_user_constraint_units_on_indices(m, uc, t, s)
-        )
-        || !isempty(
-            _constraint_user_constraint_connection_flow_indices(m, uc, t, s)
-        )
-        || !isempty(
-            _constraint_user_constraint_node_state_indices(m, uc, t, s)
-        )
-        || !isempty(
-            _constraint_user_constraint_node_stochastic_time_indices(m, uc, t, s)
-        )
-        || !isempty(
-            _constraint_user_constraint_units_invested_indices(m, uc, t, s)
-        )
-        || !isempty(
-            _constraint_user_constraint_connections_invested_indices(m, uc, t, s)
-        )
-        || !isempty(
-            _constraint_user_constraint_storages_invested_indices(m, uc, t, s)
-        )
-    )
+function _constraint_user_constraint_node_stochastic_time_indices(m, uc)
+    (ind for n in node__user_constraint(user_constraint=uc) for ind in node_stochastic_time_indices(m; node=n))
 end

--- a/src/data_structure/stochastic_structure.jl
+++ b/src/data_structure/stochastic_structure.jl
@@ -261,10 +261,22 @@ function generate_stochastic_structure!(m::Model)
     _generate_active_stochastic_paths(m)
 end
 
+function active_stochastic_paths(m, indices::Vector)
+    active_stochastic_paths(m, (x.stochastic_scenario for x in indices))
+end
 function active_stochastic_paths(m, active_scenarios)
-    active_scenarios = collect(Object, active_scenarios)
+    active_stochastic_paths(m, collect(Object, active_scenarios))
+end
+function active_stochastic_paths(m, active_scenarios::Vector{Object})
+    _active_stochastic_paths(m, unique!(active_scenarios))
+end
+function active_stochastic_paths(m, active_scenarios::Set{Object})
+    _active_stochastic_paths(m, active_scenarios)
+end
+
+function _active_stochastic_paths(m, unique_active_scenarios)
     full_stochastic_paths = m.ext[:spineopt].stochastic_structure[:full_stochastic_paths]
-    unique(intersect(path, active_scenarios) for path in full_stochastic_paths)
+    unique(intersect(path, unique_active_scenarios) for path in full_stochastic_paths)
 end
 
 function stochastic_time_indices(

--- a/src/data_structure/stochastic_structure.jl
+++ b/src/data_structure/stochastic_structure.jl
@@ -28,7 +28,7 @@ struct StochasticPathFinder
 end
 
 struct StochasticScenarioSet
-    scenarios::Dict{Object,Dict{TimeSlice,Array{Object}}}
+    scenarios::Dict{Object,Dict{TimeSlice,Vector{Object}}}
 end
 
 """
@@ -36,7 +36,7 @@ end
 
 Find the unique combinations of `active_scenarios` along valid stochastic paths.
 """
-function (h::StochasticPathFinder)(active_scenarios::Union{Array{T,1},T}) where {T}
+function (h::StochasticPathFinder)(active_scenarios::Union{Vector{T},T}) where {T}
     # TODO: cache these
     unique(intersect(path, active_scenarios) for path in h.full_stochastic_paths)
 end
@@ -300,14 +300,15 @@ function connection_investment_stochastic_time_indices(
     t=anything,
 )
     unique(
-        (connection=conn, stochastic_scenario=s, t=t1) for (conn, t1) in connection_investment_time_indices(
-            m;
-            connection=connection,
-            temporal_block=temporal_block,
-            t=t,
+        (connection=conn, stochastic_scenario=s, t=t1)
+        for (conn, t1) in connection_investment_time_indices(
+            m; connection=connection, temporal_block=temporal_block, t=t,
         )
-        for ss in connection__investment_stochastic_structure(connection=conn)
-        if ss in model__stochastic_structure(model=m.ext[:spineopt].instance)
+        for (m_, ss) in model__stochastic_structure(
+            model=m.ext[:spineopt].instance,
+            stochastic_structure=connection__investment_stochastic_structure(connection=conn),
+            _compact=false,
+        )
         for s in _stochastic_scenario_set(m, ss, t1, stochastic_scenario)
     )
 end

--- a/src/data_structure/stochastic_structure.jl
+++ b/src/data_structure/stochastic_structure.jl
@@ -38,7 +38,7 @@ Find the unique combinations of `active_scenarios` along valid stochastic paths.
 """
 function (h::StochasticPathFinder)(active_scenarios::Union{Array{T,1},T}) where {T}
     # TODO: cache these
-    unique(map(path -> intersect(path, active_scenarios), h.full_stochastic_paths))
+    unique(intersect(path, active_scenarios) for path in h.full_stochastic_paths)
 end
 
 function (h::StochasticScenarioSet)(stoch_struct::Object, t::TimeSlice, scenario)
@@ -68,7 +68,10 @@ function _find_root_scenarios(m::Model)
 end
 function _find_root_scenarios(m::Model, stochastic_structure::Object)
     all_scenarios = stochastic_structure__stochastic_scenario(
-        stochastic_structure=intersect(model__stochastic_structure(model=m.ext[:spineopt].instance), stochastic_structure),
+        stochastic_structure=intersect(
+            model__stochastic_structure(model=m.ext[:spineopt].instance),
+            stochastic_structure
+        )
     )
     setdiff(all_scenarios, _find_children(anything))
 end
@@ -189,7 +192,7 @@ end
 """
     _generate_stochastic_scenario_set(m::Model, all_stochastic_dags)
 
-Generate the `_generate_stochastic_scenario_set` for all defined `stochastic_structures`.
+Generate the `stochastic_scenario_set` for all defined `stochastic_structures`.
 """
 function _generate_stochastic_scenario_set(m::Model, all_stochastic_dags)
     m.ext[:spineopt].stochastic_structure[:stochastic_scenario_set] = StochasticScenarioSet(
@@ -209,7 +212,9 @@ function stochastic_time_indices(
 )
     unique(
         (stochastic_scenario=s, t=t)
-        for (m_, tb) in model__temporal_block(model=m.ext[:spineopt].instance, temporal_block=temporal_block, _compact=false)
+        for (m_, tb) in model__temporal_block(
+            model=m.ext[:spineopt].instance, temporal_block=temporal_block, _compact=false
+        )
         for (m_, ss) in model__stochastic_structure(model=m.ext[:spineopt].instance, _compact=false)
         for t in time_slice(m; temporal_block=members(tb), t=t)
         for s in _stochastic_scenario_set(m, ss, t, stochastic_scenario)

--- a/src/data_structure/temporal_structure.jl
+++ b/src/data_structure/temporal_structure.jl
@@ -280,15 +280,15 @@ function _generate_time_slice_relationships!(m::Model)
     t_follows_t_mapping = Dict(
         t => to_time_slice(m, t=TimeSlice(end_(t), end_(t) + Minute(1))) for t in all_time_slices
     )
-    t_overlaps_t_maping = Dict(t => to_time_slice(m, t=t) for t in all_time_slices)
-    t_overlaps_t_excl_mapping = Dict(t => setdiff(overlapping_t, t) for (t, overlapping_t) in t_overlaps_t_maping)
+    t_overlaps_t_mapping = Dict(t => to_time_slice(m, t=t) for t in all_time_slices)
+    t_overlaps_t_excl_mapping = Dict(t => setdiff(overlapping_t, t) for (t, overlapping_t) in t_overlaps_t_mapping)
     t_before_t_tuples = unique(
         (t_before, t_after)
         for (t_before, following) in t_follows_t_mapping for t_after in following if before(t_before, t_after)
     )
     t_in_t_tuples = unique(
         (t_short, t_long)
-        for (t_short, overlapping) in t_overlaps_t_maping for t_long in overlapping if iscontained(t_short, t_long)
+        for (t_short, overlapping) in t_overlaps_t_mapping for t_long in overlapping if iscontained(t_short, t_long)
     )
     t_in_t_excl_tuples = [(t_short, t_long) for (t_short, t_long) in t_in_t_tuples if t_short != t_long]
     # Create the function-like objects
@@ -296,7 +296,7 @@ function _generate_time_slice_relationships!(m::Model)
     temp_struct[:t_before_t] = RelationshipClass(:t_before_t, [:t_before, :t_after], t_before_t_tuples)
     temp_struct[:t_in_t] = RelationshipClass(:t_in_t, [:t_short, :t_long], t_in_t_tuples)
     temp_struct[:t_in_t_excl] = RelationshipClass(:t_in_t_excl, [:t_short, :t_long], t_in_t_excl_tuples)
-    temp_struct[:t_overlaps_t] = TOverlapsT(t_overlaps_t_maping)
+    temp_struct[:t_overlaps_t] = TOverlapsT(t_overlaps_t_mapping)
     temp_struct[:t_overlaps_t_excl] = TOverlapsT(t_overlaps_t_excl_mapping)
 end
 

--- a/src/data_structure/temporal_structure.jl
+++ b/src/data_structure/temporal_structure.jl
@@ -36,9 +36,11 @@ struct TimeSliceSet
         # Find eventual gaps in between temporal blocks
         solids = [(first(time_slices), last(time_slices)) for time_slices in values(block_time_slices)]
         sort!(solids)
-        gap_bounds = ((last_, next_first)
-                      for ((first_, last_), (next_first, next_last)) in zip(solids[1:(end - 1)], solids[2:end])
-                          if end_(last_) < start(next_first))
+        gap_bounds = (
+            (last_, next_first)
+            for ((first_, last_), (next_first, next_last)) in zip(solids[1:(end - 1)], solids[2:end])
+            if end_(last_) < start(next_first)
+        )
         gaps = [TimeSlice(end_(last_), start(next_first)) for (last_, next_first) in gap_bounds]
         # NOTE: By convention, the last time slice in the preceding block becomes the 'bridge'
         bridges = [last_ for (last_, next_first) in gap_bounds]
@@ -62,9 +64,9 @@ An `Array` of time slices *in the model*.
 (h::TimeSliceSet)(; temporal_block=anything, t=anything) = h(temporal_block, t)
 (h::TimeSliceSet)(::Anything, ::Anything) = h.time_slices
 (h::TimeSliceSet)(temporal_block::Object, ::Anything) = h.block_time_slices[temporal_block]
-(h::TimeSliceSet)(::Anything, s) = s
-(h::TimeSliceSet)(temporal_block::Object, s) = TimeSlice[t for t in s if temporal_block in blocks(t)]
-(h::TimeSliceSet)(temporal_blocks::Array{T,1}, s) where {T} = TimeSlice[t for blk in temporal_blocks for t in h(blk, s)]
+(h::TimeSliceSet)(::Anything, t) = t
+(h::TimeSliceSet)(temporal_block::Object, t) = TimeSlice[s for s in t if temporal_block in blocks(s)]
+(h::TimeSliceSet)(temporal_blocks::Array{T,1}, t) where {T} = TimeSlice[s for blk in temporal_blocks for s in h(blk, t)]
 
 """
     (::TOverlapsT)(t::Union{TimeSlice,Array{TimeSlice,1}})
@@ -72,20 +74,7 @@ An `Array` of time slices *in the model*.
 A list of time slices that have some time in common with `t` or any time slice in `t`.
 """
 function (h::TOverlapsT)(t::Union{TimeSlice,Array{TimeSlice,1}})
-    unique(overlapping_t
-    for s in t for overlapping_t in get(h.mapping, s, ()))
-end
-
-"""
-    _roll_time_slice_set!(t_set::TimeSliceSet, forward::Union{Period,CompoundPeriod})
-
-Roll a `TimeSliceSet` in time by a period specified by `forward`.
-"""
-function _roll_time_slice_set!(t_set::TimeSliceSet, forward::Union{Period,CompoundPeriod})
-    roll!.(t_set.time_slices, forward)
-    roll!.(values(t_set.gap_bridger.gaps), forward)
-    roll!.(values(t_set.gap_bridger.bridges), forward)
-    nothing
+    unique(overlapping_t for s in t for overlapping_t in get(h.mapping, s, ()))
 end
 
 """
@@ -357,7 +346,18 @@ function _to_time_slice(target::Array{TimeSlice,1}, source::Array{TimeSlice,1}, 
 end
 _to_time_slice(time_slices::Array{TimeSlice,1}, t::TimeSlice) = _to_time_slice(time_slices, time_slices, t)
 
-# API
+"""
+    _roll_time_slice_set!(t_set::TimeSliceSet, forward::Union{Period,CompoundPeriod})
+
+Roll a `TimeSliceSet` in time by a period specified by `forward`.
+"""
+function _roll_time_slice_set!(t_set::TimeSliceSet, forward::Union{Period,CompoundPeriod})
+    roll!.(t_set.time_slices, forward)
+    roll!.(values(t_set.gap_bridger.gaps), forward)
+    roll!.(values(t_set.gap_bridger.bridges), forward)
+    nothing
+end
+
 """
     generate_temporal_structure!(m::Model)
 

--- a/src/util/misc.jl
+++ b/src/util/misc.jl
@@ -70,7 +70,7 @@ macro fetch(expr)
     esc(Expr(:(=), keys, values))
 end
 
-# override `get` and `getindex` so we can access our dicts with a `Tuple` instead of the actual `NamedTuple`
+# override `get` and `getindex` so we can access our variable dicts with a `Tuple` instead of the actual `NamedTuple`
 function Base.get(d::Dict{K,V}, key::Tuple{Vararg{ObjectLike}}, default) where {J,K<:RelationshipLike{J},V}
     Base.get(d, NamedTuple{J}(key), default)
 end

--- a/src/util/misc.jl
+++ b/src/util/misc.jl
@@ -119,6 +119,19 @@ function expr_sum(iter; init::Number)
     result
 end
 
+function expr_avg(iter; init::Number)
+    result = AffExpr(init)
+    isempty(iter) && return result
+    result += first(iter)  # NOTE: This is so result has the right type, e.g., `GenericAffExpr{Call,VariableRef}`
+    k = 1
+    for item in Iterators.drop(iter, 1)
+        add_to_expression!(result, item)
+        k += 1
+    end
+    result / k
+end
+
+
 """
     _index_in(ind::NamedTuple; kwargs...)
 

--- a/src/util/misc.jl
+++ b/src/util/misc.jl
@@ -70,7 +70,7 @@ macro fetch(expr)
     esc(Expr(:(=), keys, values))
 end
 
-# override `get` and `getindex` so we can access our variable dicts with a `Tuple` instead of the actual `NamedTuple`
+# override `get` and `getindex` so we can access our dicts with a `Tuple` instead of the actual `NamedTuple`
 function Base.get(d::Dict{K,V}, key::Tuple{Vararg{ObjectLike}}, default) where {J,K<:RelationshipLike{J},V}
     Base.get(d, NamedTuple{J}(key), default)
 end

--- a/src/variables/variable_node_pressure.jl
+++ b/src/variables/variable_node_pressure.jl
@@ -32,16 +32,16 @@ function node_pressure_indices(
     t=anything,
     temporal_block=temporal_block(representative_periods_mapping=nothing),
 )
-    inds = NamedTuple{(:node, :stochastic_scenario, :t),Tuple{Object,Object,TimeSlice}}[
-        (node=n, stochastic_scenario=s, t=t) for (n, s, t) in node_stochastic_time_indices(
+    unique(
+        (node=n, stochastic_scenario=s, t=t)
+        for (n, s, t) in node_stochastic_time_indices(
             m;
             node=intersect(members(node), SpineOpt.node(has_pressure=true)),
             stochastic_scenario=stochastic_scenario,
             t=t,
             temporal_block=temporal_block,
         )
-    ]
-    unique!(inds)
+    )
 end
 
 """
@@ -52,6 +52,11 @@ Add `node_pressure` variables to model `m`.
 function add_variable_node_pressure!(m::Model)
     t0 = start(current_window(m))
     add_variable!(
-        m, :node_pressure, node_pressure_indices; lb=Constant(0), fix_value=fix_node_pressure, initial_value=initial_node_pressure
+        m,
+        :node_pressure,
+        node_pressure_indices;
+        lb=Constant(0),
+        fix_value=fix_node_pressure,
+        initial_value=initial_node_pressure
     )
 end

--- a/src/variables/variable_unit_flow.jl
+++ b/src/variables/variable_unit_flow.jl
@@ -50,6 +50,25 @@ function unit_flow_indices(
     )
 end
 
+function unit_flow_time_indices(
+    m::Model;
+    unit=anything,
+    node=anything,
+    direction=anything,
+    t=anything,
+    temporal_block=temporal_block(representative_periods_mapping=nothing),
+)
+    unit = members(unit)
+    node = members(node)
+    unique(
+        (unit=u, node=n, direction=d, stochastic_scenario=s, t=t)
+        for (u, n, d, tb) in unit__node__direction__temporal_block(
+            unit=unit, node=node, direction=direction, temporal_block=temporal_block, _compact=false
+        )
+        for (n, t) in node_time_indices(m; node=n, temporal_block=tb, t=t)
+    )
+end
+
 """
     add_variable_unit_flow!(m::Model)
 

--- a/test/constraints/constraint_connection.jl
+++ b/test/constraints/constraint_connection.jl
@@ -161,8 +161,16 @@
         relationships = [["connection__node__node", [ "connection_ca", "node_c", "node_a"]]]
         fixed_pressure_constant_1_raw = [60.315, 64.993, 69.359, 0.0, 42.783, 37.252, 0.0, 0.0, 45.406]
         fixed_pressure_constant_0_raw = [53.422, 58.652, 63.456, 0.0, 32.348, 24.57, 0.0, 0.0, 35.745]
-        fixed_pressure_constant_1_ = Dict(("connection_ca", "node_c","node_a") => Dict("type" => "array", "value_type" => "float", "data" => PyVector(fixed_pressure_constant_1_raw)))
-        fixed_pressure_constant_0_ = Dict(("connection_ca", "node_c","node_a") => Dict("type" => "array", "value_type" => "float", "data" => PyVector(fixed_pressure_constant_0_raw)))
+        fixed_pressure_constant_1_ = Dict(
+            ("connection_ca", "node_c","node_a") => Dict(
+                "type" => "array", "value_type" => "float", "data" => PyVector(fixed_pressure_constant_1_raw)
+            )
+        )
+        fixed_pressure_constant_0_ = Dict(
+            ("connection_ca", "node_c","node_a") => Dict(
+                "type" => "array", "value_type" => "float", "data" => PyVector(fixed_pressure_constant_0_raw)
+            )
+        )
         _load_test_data(url_in, test_data)
         object_parameter_values = [
             ["node", "node_a", "has_pressure", has_pressure["node_a"]],
@@ -170,12 +178,26 @@
             ["connection", "connection_ca", "has_binary_gas_flow", binary["connection_ca"]],
             ["model", "instance", "big_m", bigm["instance"]],
         ]
-        relationship_parameter_values =
-            [["connection__node__node", ["connection_ca", "node_c","node_a"], "fixed_pressure_constant_1", fixed_pressure_constant_1_[("connection_ca", "node_c","node_a")]],
-            ["connection__node__node", ["connection_ca", "node_c","node_a"], "fixed_pressure_constant_0", fixed_pressure_constant_0_[("connection_ca", "node_c","node_a")]]
+        relationship_parameter_values = [
+            [
+                "connection__node__node",
+                ["connection_ca", "node_c","node_a"],
+                "fixed_pressure_constant_1",
+                fixed_pressure_constant_1_[("connection_ca", "node_c","node_a")]
+            ],
+            [
+                "connection__node__node",
+                ["connection_ca", "node_c","node_a"],
+                "fixed_pressure_constant_0",
+                fixed_pressure_constant_0_[("connection_ca", "node_c","node_a")]
             ]
-        SpineInterface.import_data(url_in; object_parameter_values=object_parameter_values, relationship_parameter_values=relationship_parameter_values, relationships=relationships)
-
+        ]
+        SpineInterface.import_data(
+            url_in;
+            object_parameter_values=object_parameter_values,
+            relationship_parameter_values=relationship_parameter_values,
+            relationships=relationships
+        )
         m = run_spineopt(url_in; log_level=0, optimize=false)
         var_connection_flow = m.ext[:spineopt].variables[:connection_flow]
         var_binary_flow = m.ext[:spineopt].variables[:binary_gas_connection_flow]
@@ -285,13 +307,21 @@
             ["node", "node_c", "has_voltage_angle", has_volt_ang["node_c"]],
             ["node", "node_a", "has_voltage_angle", has_volt_ang["node_a"]],
         ]
-        relationship_parameter_values =
+        relationship_parameter_values = [
             [
-            ["connection__node__node", ["connection_ca", "node_a","node_c"], "fix_ratio_out_in_connection_flow", fix_ratio_out_in[("connection_ca", "node_a","node_c")]],
+                "connection__node__node",
+                ["connection_ca", "node_a","node_c"],
+                "fix_ratio_out_in_connection_flow",
+                fix_ratio_out_in[("connection_ca", "node_a","node_c")]
             ]
+        ]
         _load_test_data(url_in, test_data)
-        SpineInterface.import_data(url_in; object_parameter_values=object_parameter_values, relationship_parameter_values=relationship_parameter_values, relationships=relationships)
-
+        SpineInterface.import_data(
+            url_in;
+            object_parameter_values=object_parameter_values,
+            relationship_parameter_values=relationship_parameter_values,
+            relationships=relationships
+        )
         m = run_spineopt(url_in; log_level=0, optimize=false)
         var_connection_flow = m.ext[:spineopt].variables[:connection_flow]
         var_voltage_angle = m.ext[:spineopt].variables[:node_voltage_angle]
@@ -341,18 +371,15 @@
         ]
         relationship_parameter_values =
             [["connection__from_node", ["connection_ab", "node_a"], "connection_capacity", connection_capacity]]
-
         SpineInterface.import_data(
             url_in;
             object_parameter_values=object_parameter_values,
             relationships=relationships,
             relationship_parameter_values=relationship_parameter_values,
         )
-
         m = run_spineopt(url_in; log_level=0, optimize=false)
         var_connection_flow = m.ext[:spineopt].variables[:connection_flow]
         var_connections_invested_available = m.ext[:spineopt].variables[:connections_invested_available]
-
         constraint = m.ext[:spineopt].constraints[:connection_flow_capacity]
         @test length(constraint) == 2
         scenarios = (stochastic_scenario(:parent), stochastic_scenario(:child))
@@ -666,7 +693,6 @@
             ["connection__investment_stochastic_structure", ["connection_ab", "stochastic"]],
         ]
         SpineInterface.import_data(url_in; relationships=relationships, object_parameter_values=object_parameter_values)
-
         m = run_spineopt(url_in; log_level=0, optimize=false)
         var_connections_invested_available = m.ext[:spineopt].variables[:connections_invested_available]
         var_connections_invested = m.ext[:spineopt].variables[:connections_invested]
@@ -683,9 +709,7 @@
             var_c_inv_1 = var_connections_invested[var_key1...]
             var_c_decom_1 = var_connections_decommissioned[var_key1...]
             @testset for (c, t0, t1) in connection_investment_dynamic_time_indices(
-                m;
-                connection=connection(:connection_ab),
-                t_after=t1,
+                m; connection=connection(:connection_ab), t_after=t1
             )
                 var_key0 = (c, s0, t0)
                 var_c_inv_av0 = get(var_connections_invested_available, var_key0, 0)
@@ -711,7 +735,6 @@
             ["connection__investment_stochastic_structure", ["connection_ab", "stochastic"]],
         ]
         SpineInterface.import_data(url_in; relationships=relationships, object_parameter_values=object_parameter_values)
-
         m, mp = run_spineopt(url_in; log_level=0, optimize=false)
         var_connections_invested_available = m.ext[:spineopt].variables[:connections_invested_available]
         var_connections_invested = m.ext[:spineopt].variables[:connections_invested]
@@ -728,9 +751,7 @@
             var_c_inv_1 = var_connections_invested[var_key1...]
             var_c_decom_1 = var_connections_decommissioned[var_key1...]
             @testset for (c, t0, t1) in connection_investment_dynamic_time_indices(
-                m;
-                connection=connection(:connection_ab),
-                t_after=t1,
+                m; connection=connection(:connection_ab), t_after=t1
             )
                 var_key0 = (c, s0, t0)
                 var_c_inv_av0 = get(var_connections_invested_available, var_key0, 0)
@@ -740,7 +761,6 @@
                 @test _is_constraint_equal(observed_con, expected_con)
             end
         end
-
         var_connections_invested_available = mp.ext[:spineopt].variables[:connections_invested_available]
         var_connections_invested = mp.ext[:spineopt].variables[:connections_invested]
         var_connections_decommissioned = mp.ext[:spineopt].variables[:connections_decommissioned]
@@ -756,9 +776,7 @@
             var_c_inv_1 = var_connections_invested[var_key1...]
             var_c_decom_1 = var_connections_decommissioned[var_key1...]
             @testset for (c, t0, t1) in connection_investment_dynamic_time_indices(
-                mp;
-                connection=connection(:connection_ab),
-                t_after=t1,
+                mp; connection=connection(:connection_ab), t_after=t1
             )
                 var_key0 = (c, s0, t0)
                 var_c_inv_av0 = get(var_connections_invested_available, var_key0, 0)
@@ -784,13 +802,13 @@
                 ["connection__investment_temporal_block", ["connection_ab", "hourly"]],
                 ["connection__investment_stochastic_structure", ["connection_ab", "stochastic"]],
             ]
-            SpineInterface.import_data(url_in; relationships=relationships, object_parameter_values=object_parameter_values)
-
+            SpineInterface.import_data(
+                url_in; relationships=relationships, object_parameter_values=object_parameter_values
+            )
             m = run_spineopt(url_in; log_level=0, optimize=false)
             var_connections_invested_available = m.ext[:spineopt].variables[:connections_invested_available]
             var_connections_invested = m.ext[:spineopt].variables[:connections_invested]
             constraint = m.ext[:spineopt].constraints[:connection_lifetime]
-
             @test length(constraint) == 5
             parent_end = stochastic_scenario_end(
                 stochastic_structure=stochastic_structure(:stochastic),
@@ -842,8 +860,9 @@
                 ["connection__investment_stochastic_structure", ["connection_ab", "stochastic"]],
                 ["connection__investment_stochastic_structure", ["connection_ab", "investments_deterministic"]],
             ]
-            SpineInterface.import_data(url_in; relationships=relationships, object_parameter_values=object_parameter_values)
-
+            SpineInterface.import_data(
+                url_in; relationships=relationships, object_parameter_values=object_parameter_values
+            )
             m, mp = run_spineopt(url_in; log_level=0, optimize=false)
             var_connections_invested_available = m.ext[:spineopt].variables[:connections_invested_available]
             var_connections_invested = m.ext[:spineopt].variables[:connections_invested]
@@ -877,7 +896,6 @@
                 observed_con = constraint_object(constraint[key...])
                 @test _is_constraint_equal(observed_con, expected_con)
             end
-
             var_connections_invested_available = mp.ext[:spineopt].variables[:connections_invested_available]
             var_connections_invested = mp.ext[:spineopt].variables[:connections_invested]
             constraint = mp.ext[:spineopt].constraints[:connection_lifetime]
@@ -920,7 +938,6 @@
             ["connection__investment_stochastic_structure", ["connection_ab", "stochastic"]],
         ]
         SpineInterface.import_data(url_in; relationships=relationships, object_parameter_values=object_parameter_values)
-
         m = run_spineopt(url_in; log_level=0, optimize=false)
         var_connections_invested_available = m.ext[:spineopt].variables[:connections_invested_available]
         constraint = m.ext[:spineopt].constraints[:connections_invested_available]
@@ -951,7 +968,6 @@
             ["connection__investment_stochastic_structure", ["connection_ab", "stochastic"]],
         ]
         SpineInterface.import_data(url_in; relationships=relationships, object_parameter_values=object_parameter_values)
-
         m, mp = run_spineopt(url_in; log_level=0, optimize=false)
         var_connections_invested_available = m.ext[:spineopt].variables[:connections_invested_available]
         constraint = m.ext[:spineopt].constraints[:connections_invested_available]
@@ -991,7 +1007,6 @@
             units_on_coefficient = 20
             units_started_up_coefficient = 35
             demand = 150
-
             objects = [["user_constraint", "constraint_x"], ["unit", "unit_c"]]
             relationships = [
                 ["unit__to_node__user_constraint", ["unit_c", "node_c", "constraint_x"]],
@@ -1023,7 +1038,6 @@
                 object_parameter_values=object_parameter_values,
                 relationship_parameter_values=relationship_parameter_values,
             )
-
             m = run_spineopt(url_in; log_level=0, optimize=false)
             var_unit_flow = m.ext[:spineopt].variables[:unit_flow]
             var_units_on = m.ext[:spineopt].variables[:units_on]
@@ -1031,26 +1045,25 @@
             var_connection_flow = m.ext[:spineopt].variables[:connection_flow]
             var_node_state = m.ext[:spineopt].variables[:node_state]
             constraint = m.ext[:spineopt].constraints[:user_constraint]
-            @test length(constraint) == 2
+            @test length(constraint) == 1
             key_a = (unit(:unit_c), node(:node_c), direction(:to_node))
             key_b = (connection(:connection_ab), node(:node_b), direction(:to_node))
-
             s_parent, s_child = stochastic_scenario(:parent), stochastic_scenario(:child)
             t1h1, t1h2 = time_slice(m; temporal_block=temporal_block(:hourly))
             t2h = time_slice(m; temporal_block=temporal_block(:two_hourly))[1]
             expected_con_ref = SpineOpt.sense_constraint(
                 m,
                 + unit_flow_coefficient
-                * (var_unit_flow[key_a..., s_parent, t1h1] + var_unit_flow[key_a..., s_child, t1h2]) +
-                2 * connection_flow_coefficient * var_connection_flow[key_b..., s_parent, t2h] +
-                units_on_coefficient
-                * (var_units_on[unit(:unit_c), s_parent, t1h1] + var_units_on[unit(:unit_c), s_child, t1h2]) +
-                units_started_up_coefficient * (
-                    var_units_started_up[unit(:unit_c), s_parent, t1h1]
+                * (var_unit_flow[key_a..., s_parent, t1h1] + var_unit_flow[key_a..., s_child, t1h2])
+                + 2 * connection_flow_coefficient * var_connection_flow[key_b..., s_parent, t2h]
+                + units_on_coefficient
+                * (var_units_on[unit(:unit_c), s_parent, t1h1] + var_units_on[unit(:unit_c), s_child, t1h2])
+                + units_started_up_coefficient * (
+                    + var_units_started_up[unit(:unit_c), s_parent, t1h1]
                     + var_units_started_up[unit(:unit_c), s_child, t1h2]
-                ) +
-                2 * node_state_coefficient * var_node_state[node(:node_b), s_parent, t2h] +
-                2 * demand_coefficient * demand,
+                )
+                + 2 * node_state_coefficient * var_node_state[node(:node_b), s_parent, t2h]
+                + 2 * demand_coefficient * demand,
                 Symbol(sense),
                 2 * rhs,
             )

--- a/test/constraints/constraint_connection.jl
+++ b/test/constraints/constraint_connection.jl
@@ -119,11 +119,19 @@
             ["connection", "connection_ca", "has_binary_gas_flow", binary["connection_ca"]],
             ["model", "instance", "big_m", bigm["instance"]],
         ]
-        relationship_parameter_values =
-            [["connection__node__node", ["connection_ca", "node_c","node_a"], "fixed_pressure_constant_1", fixed_pressure_constant_1_[("connection_ca", "node_c","node_a")]]]
+        relationship_parameter_values = [
+            [
+                "connection__node__node",
+                ["connection_ca", "node_c","node_a"],
+                "fixed_pressure_constant_1",
+                fixed_pressure_constant_1_[("connection_ca", "node_c","node_a")]
+            ]
+        ]
         SpineInterface.import_data(
             url_in;
-            object_parameter_values=object_parameter_values, relationship_parameter_values=relationship_parameter_values, relationships=relationships
+            object_parameter_values=object_parameter_values,
+            relationship_parameter_values=relationship_parameter_values,
+            relationships=relationships
         )
         m = run_spineopt(url_in; log_level=0, optimize=false)
         var_connection_flow = m.ext[:spineopt].variables[:connection_flow]

--- a/test/constraints/constraint_node.jl
+++ b/test/constraints/constraint_node.jl
@@ -87,12 +87,14 @@
             ["model", "instance", "db_mip_solver", "Cbc.jl"],
             ["model", "instance", "db_lp_solver", "Clp.jl"],
         ],
-        :relationship_parameter_values => [[
-            "stochastic_structure__stochastic_scenario",
-            ["stochastic", "parent"],
-            "stochastic_scenario_end",
-            Dict("type" => "duration", "data" => "1h"),
-        ]],
+        :relationship_parameter_values => [
+            [
+                "stochastic_structure__stochastic_scenario",
+                ["stochastic", "parent"],
+                "stochastic_scenario_end",
+                Dict("type" => "duration", "data" => "1h"),
+            ]
+        ]
     )
     @testset "constraint_nodal_balance" begin
         _load_test_data(url_in, test_data)
@@ -472,11 +474,7 @@
             ["node", "node_b", "has_pressure", has_pressure["node_b"]],
             ["node", "node_b", "min_node_pressure", min_pressure["node_b"]]
         ]
-        SpineInterface.import_data(
-            url_in;
-            object_parameter_values=object_parameter_values
-        )
-
+        SpineInterface.import_data(url_in; object_parameter_values=object_parameter_values)
         m = run_spineopt(url_in; log_level=0, optimize=false)
         var_node_pressure = m.ext[:spineopt].variables[:node_pressure]
         constraint = m.ext[:spineopt].constraints[:min_node_pressure]

--- a/test/constraints/constraint_unit.jl
+++ b/test/constraints/constraint_unit.jl
@@ -381,7 +381,6 @@
             @test _is_constraint_equal(observed_con, expected_con)
         end
     end
-
     @testset "constraint_total_cumulated_unit_flow" begin
         total_cumulated_flow_bound = 100
         senses_by_prefix = Dict("min" => >=, "max" => <=)
@@ -649,7 +648,9 @@
                 vars_u_sd = [var_units_shut_down[unit(:unit_ab), s, t] for (s, t) in zip(s_set, t_set)]
                 var_ns_su_key = (unit(:unit_ab), node(:node_a), s, t)
                 var_ns_su = var_nonspin_units_started_up[var_ns_su_key...]
-                expected_con = @build_constraint(number_of_units + var_u_inv_av - var_u_on >= sum(vars_u_sd) + var_ns_su)
+                expected_con = @build_constraint(
+                    number_of_units + var_u_inv_av - var_u_on >= sum(vars_u_sd) + var_ns_su
+                )
                 con_key = (unit(:unit_ab), path, t)
                 observed_con = constraint_object(constraint[con_key...])
                 @test _is_constraint_equal(observed_con, expected_con)
@@ -1417,7 +1418,7 @@
             var_units_on = m.ext[:spineopt].variables[:units_on]
             var_units_started_up = m.ext[:spineopt].variables[:units_started_up]
             constraint = m.ext[:spineopt].constraints[:user_constraint]
-            @test length(constraint) == 2
+            @test length(constraint) == 1
             key_a = (unit(:unit_ab), node(:node_a), direction(:from_node))
             key_b = (unit(:unit_ab), node(:node_b), direction(:to_node))
             s_parent, s_child = stochastic_scenario(:parent), stochastic_scenario(:child)
@@ -1483,7 +1484,7 @@
             var_units_on = m.ext[:spineopt].variables[:units_on]
             var_units_started_up = m.ext[:spineopt].variables[:units_started_up]
             constraint = m.ext[:spineopt].constraints[:user_constraint]
-            @test length(constraint) == 2
+            @test length(constraint) == 1
             key_a = (unit(:unit_ab), node(:node_a), direction(:from_node))
             key_b = (unit(:unit_ab), node(:node_b), direction(:to_node))
             s_parent, s_child = stochastic_scenario(:parent), stochastic_scenario(:child)
@@ -1531,7 +1532,6 @@
             relationships=relationships,
             relationship_parameter_values=relationship_parameter_values,
         )
-
         m = run_spineopt(url_in; log_level=0, optimize=false)
         var_unit_flow = m.ext[:spineopt].variables[:unit_flow]
         var_unit_flow_op = m.ext[:spineopt].variables[:unit_flow_op]
@@ -1546,12 +1546,13 @@
         t1h1, t1h2 = time_slice(m; temporal_block=temporal_block(:hourly))
         t2h = time_slice(m; temporal_block=temporal_block(:two_hourly))[1]
         expected_con = @build_constraint(
-            + var_unit_flow[key_a..., s_parent, t1h1] + var_unit_flow[key_a..., s_child, t1h2] ==
-            2 * sum(inc_hrs[i] * var_unit_flow_op[key_b..., i, s_parent, t2h] for i in 1:3) +
-            unit_idle_heat_rate
-            * (var_units_on[unit(:unit_ab), s_parent, t1h1] + var_units_on[unit(:unit_ab), s_child, t1h2]) +
-            unit_start_flow * (
-                var_units_started_up[unit(:unit_ab), s_parent, t1h1]
+            + var_unit_flow[key_a..., s_parent, t1h1] + var_unit_flow[key_a..., s_child, t1h2]
+            ==
+            + 2 * sum(inc_hrs[i] * var_unit_flow_op[key_b..., i, s_parent, t2h] for i in 1:3)
+            + unit_idle_heat_rate
+            * (var_units_on[unit(:unit_ab), s_parent, t1h1] + var_units_on[unit(:unit_ab), s_child, t1h2])
+            + unit_start_flow * (
+                + var_units_started_up[unit(:unit_ab), s_parent, t1h1]
                 + var_units_started_up[unit(:unit_ab), s_child, t1h2]
             )
         )

--- a/test/constraints/constraint_user_constraint.jl
+++ b/test/constraints/constraint_user_constraint.jl
@@ -111,7 +111,6 @@
             storages_invested_available_coefficient = 12
             connection_flow_coefficient_b = 13
             connection_flow_coefficient_c = 14
-
             objects = [["user_constraint", "constraint_x"]]
             relationships = [
                 ["unit__from_node__user_constraint", ["unit_ab", "node_a", "constraint_x"]],
@@ -150,7 +149,6 @@
                 object_parameter_values=object_parameter_values,
                 relationship_parameter_values=relationship_parameter_values,
             )
-            
             m = run_spineopt(url_in; log_level=0, optimize=false)
             var_unit_flow = m.ext[:spineopt].variables[:unit_flow]
             var_connection_flow = m.ext[:spineopt].variables[:connection_flow]
@@ -163,71 +161,61 @@
             var_connections_invested_available = m.ext[:spineopt].variables[:connections_invested_available]
             var_storages_invested = m.ext[:spineopt].variables[:storages_invested]
             var_storages_invested_available = m.ext[:spineopt].variables[:storages_invested_available]
-            
             constraint = m.ext[:spineopt].constraints[:user_constraint]
-
-            @test length(constraint) == 2
+            @test length(constraint) == 1
             key_uf_a = (unit(:unit_ab), node(:node_a), direction(:from_node))
             key_uf_b = (unit(:unit_ab), node(:node_b), direction(:to_node))
             key_cf_b = (connection(:connection_bc), node(:node_b), direction(:from_node))
             key_cf_c = (connection(:connection_bc), node(:node_c), direction(:to_node))
-
             s_parent, s_child = stochastic_scenario(:parent), stochastic_scenario(:child)
             t1h1, t1h2, t1h3, t1h4 = time_slice(m; temporal_block=temporal_block(:hourly))
             t2h1, t2h2 = time_slice(m; temporal_block=temporal_block(:two_hourly))
             t4h1 = time_slice(m; temporal_block=temporal_block(:investments_four_hourly))[1]
-            
             expected_con_ref = SpineOpt.sense_constraint(
                 m,
                 + 4 * units_invested_coefficient * var_units_invested[unit(:unit_ab), s_parent, t4h1]
-                + 4 * units_invested_available_coefficient * var_units_invested_available[unit(:unit_ab), s_parent, t4h1]
-                + 4 * connections_invested_coefficient * var_connections_invested[connection(:connection_bc), s_parent, t4h1]
-                + 4 * connections_invested_available_coefficient * var_connections_invested_available[connection(:connection_bc), s_parent, t4h1]
-                
+                + 4 * units_invested_available_coefficient
+                    * var_units_invested_available[unit(:unit_ab), s_parent, t4h1]
+                + 4 * connections_invested_coefficient
+                    * var_connections_invested[connection(:connection_bc), s_parent, t4h1]
+                + 4 * connections_invested_available_coefficient
+                    * var_connections_invested_available[connection(:connection_bc), s_parent, t4h1]
                 + 2 * storages_invested_coefficient * (
                     + var_storages_invested[node(:node_c), s_parent, t2h1]
                     + var_storages_invested[node(:node_c), s_parent, t2h2]
                 )
-
                 + 2 * storages_invested_available_coefficient * (
                     + var_storages_invested_available[node(:node_c), s_parent, t2h1]
                     + var_storages_invested_available[node(:node_c), s_parent, t2h2]
                 )
-                
                 + 2 * units_on_coefficient * (
                     + var_units_on[unit(:unit_ab), s_parent, t2h1]
                     + var_units_on[unit(:unit_ab), s_child, t2h2] 
                 )
-
                 + 2 * units_started_up_coefficient * (
                     + var_units_started_up[unit(:unit_ab), s_parent, t2h1]
                     + var_units_started_up[unit(:unit_ab), s_child, t2h2] 
                 )
-                
                 + unit_flow_coefficient_a * (
                     + var_unit_flow[key_uf_a..., s_parent, t1h1]
                     + var_unit_flow[key_uf_a..., s_child, t1h2]
                     + var_unit_flow[key_uf_a..., s_child, t1h3]
                     + var_unit_flow[key_uf_a..., s_child, t1h4]
                 )
-
                 + 2 * unit_flow_coefficient_b * (
                     + var_unit_flow[key_uf_b..., s_parent, t2h1]
                     + var_unit_flow[key_uf_b..., s_parent, t2h2]
                 )
-
                 + 2 * connection_flow_coefficient_b * (
                     + var_connection_flow[key_cf_b..., s_parent, t2h1]
                     + var_connection_flow[key_cf_b..., s_parent, t2h2]
                 )
-
                 + connection_flow_coefficient_c * (
                     + var_connection_flow[key_cf_c..., s_parent, t1h1]
                     + var_connection_flow[key_cf_c..., s_parent, t1h2]
                     + var_connection_flow[key_cf_c..., s_parent, t1h3]
                     + var_connection_flow[key_cf_c..., s_parent, t1h4]
                 )
-
                 + node_state_coefficient * (
                     + var_node_state[node(:node_c), s_parent, t1h1]
                     + var_node_state[node(:node_c), s_parent, t1h2]
@@ -271,7 +259,7 @@ end
         :object_parameter_values => [
             ["model", "instance", "model_start", Dict("type" => "date_time", "data" => "2000-01-01T00:00:00")],
             ["model", "instance", "model_end", Dict("type" => "date_time", "data" => "2000-01-02T00:00:00")],
-            #["model", "instance", "roll_forward", Dict("type" => "duration", "data" => "6h")],
+            ["model", "instance", "roll_forward", Dict("type" => "duration", "data" => "6h")],
             ["model", "instance", "duration_unit", "hour"],
             ["model", "instance", "model_type", "spineopt_standard"],
             ["temporal_block", "6hquarterly", "resolution", Dict("type" => "duration", "data" => "15m")],


### PR DESCRIPTION
This PR tries to optimize/clarify the process of collecting indices for constraints. It does the best to avoid double-diping into the variable_indices functions to collect temporal indices first and stochastic indices next. Whenever possible, temporal and stochastic indices are collected in the same pass. Part of this is supported by a new function coming to SpineInterface called `t_lowest_resolution_sets`.

Re #586

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Release notes have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted nicely
- [x] Unit tests pass
