### PR TITLE
Remove docs on economic lifetime, ramping, and reserves

### DIFF
--- a/docs/src/mathematical_formulation/constraints.md
+++ b/docs/src/mathematical_formulation/constraints.md
@@ -366,7 +366,7 @@ This constraint can be extended to the use of nonspinning reserves. See [also](@
 
 
 #### Ramping and reserve constraints
-(Comment 2023-05-03: Currently under development)
+(Comment 2023-05-12: Currently under development)
 
 #### [Splitting unit flows into ramps](@id constraint_split_ramps)
 (Comment 2023-05-12: Currently under development)


### PR DESCRIPTION
## Checklist before merging
- [x] Documentation is up-to-date
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted according to SpineOpt's style
- [x] Unit tests pass
