### PR TITLE
Support fixing values using map

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,5 +17,5 @@ Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 SpineInterface = "0cda1612-498a-11e9-3c92-77fa82595a4f"
 
 [compat]
-SpineInterface = "0.10.3"
+SpineInterface = "0.10.5"
 julia = "^1.2"

--- a/Project.toml
+++ b/Project.toml
@@ -17,5 +17,5 @@ Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 SpineInterface = "0cda1612-498a-11e9-3c92-77fa82595a4f"
 
 [compat]
-SpineInterface = "0.10.5"
+SpineInterface = "0.10.6"
 julia = "^1.2"

--- a/src/data_structure/temporal_structure.jl
+++ b/src/data_structure/temporal_structure.jl
@@ -368,11 +368,11 @@ Preprocess the temporal structure for SpineOpt from the provided input data.
 Runs a number of functions processing different aspects of the temporal structure in sequence.
 """
 function generate_temporal_structure!(m::Model)
-    _generate_current_window!(m::Model)
-    _generate_time_slice!(m::Model)
-    _generate_output_time_slices!(m::Model)
-    _generate_time_slice_relationships!(m::Model)
-    _generate_representative_time_slice!(m::Model)
+    _generate_current_window!(m)
+    _generate_time_slice!(m)
+    _generate_output_time_slices!(m)
+    _generate_time_slice_relationships!(m)
+    _generate_representative_time_slice!(m)
 end
 
 """

--- a/src/run_spineopt_standard.jl
+++ b/src/run_spineopt_standard.jl
@@ -38,7 +38,7 @@ function rerun_spineopt!(
     roll_count = _roll_count(m)
     @log log_level 2 """
     NOTE: We will first build the model for the last optimisation window to make sure it can roll that far.
-    Then we will bring the model to the first window to start solving it.
+    Then we will bring the model back to the first window to start solving it.
     """
     roll_temporal_structure!(m, 1:roll_count)
     init_model!(
@@ -49,6 +49,8 @@ function rerun_spineopt!(
         alternative_objective=alternative_objective
     )
     @timelog log_level 2 "Bringing model to the first window..." roll_temporal_structure!(m, 1:roll_count; rev=true)
+    _update_variable_names!(m)
+    _update_constraint_names!(m)
     try
         run_spineopt_kernel!(
             m,

--- a/src/variables/variable_common.jl
+++ b/src/variables/variable_common.jl
@@ -102,6 +102,7 @@ _base_name(name, ind) = string(name, "[", join(ind, ", "), "]")
 Create a JuMP variable with the input properties.
 """
 function _variable(m, name, ind, bin, int, lb, ub, initial_value, fix_value)
+    ind = (analysis_time=_analysis_time(m), ind...)
     var = @variable(m, base_name = _base_name(name, ind))
     bin !== nothing && bin(ind) && set_binary(var)
     int !== nothing && int(ind) && set_integer(var)

--- a/src/variables/variable_common.jl
+++ b/src/variables/variable_common.jl
@@ -106,10 +106,9 @@ function _variable(m, name, ind, bin, int, lb, ub, initial_value, fix_value)
     var = @variable(m, base_name = _base_name(name, ind))
     bin !== nothing && bin(ind) && set_binary(var)
     int !== nothing && int(ind) && set_integer(var)
-    initial_value_ = initial_value === nothing ? nothing : initial_value(; ind..., _strict=false)
-    initial_value_ === nothing || fix(var, initial_value_)
     lb === nothing || set_lower_bound(var, lb[(; ind..., _strict=false)])
     ub === nothing || set_upper_bound(var, ub[(; ind..., _strict=false)])
+    initial_value === nothing || fix(var, initial_value[(; ind..., _strict=false)])
     fix_value === nothing || fix(var, fix_value[(; ind..., _strict=false)])
     var
 end

--- a/test/run_spineopt.jl
+++ b/test/run_spineopt.jl
@@ -95,6 +95,7 @@ function _test_rolling()
             relationship_parameter_values=relationship_parameter_values,
         )
         @testset for write_as_roll in (0, 1, 2, 3, 5, 8, 13, 21, 24)
+            rm(file_path_out; force=true)
             m = run_spineopt(url_in, url_out; log_level=0, write_as_roll=write_as_roll)
             con = m.ext[:spineopt].constraints[:unit_flow_capacity]
             using_spinedb(url_out, Y)
@@ -156,6 +157,7 @@ function _test_rolling_with_updating_data()
             object_parameter_values=object_parameter_values,
             relationship_parameter_values=relationship_parameter_values,
         )
+        rm(file_path_out; force=true)
         m = run_spineopt(url_in, url_out; log_level=0)
         con = m.ext[:spineopt].constraints[:unit_flow_capacity]
         using_spinedb(url_out, Y)
@@ -211,6 +213,7 @@ function _test_rolling_with_unused_dummy_stochastic_data()
             object_parameter_values=object_parameter_values,
             relationship_parameter_values=relationship_parameter_values,
         )
+        rm(file_path_out; force=true)
         m = run_spineopt(url_in, url_out; log_level=0)
         con = m.ext[:spineopt].constraints[:unit_flow_capacity]
         using_spinedb(url_out, Y)
@@ -251,7 +254,7 @@ function _test_rolling_without_varying_terms()
             object_parameter_values=object_parameter_values,
             relationship_parameter_values=relationship_parameter_values,
         )
-
+        rm(file_path_out; force=true)
         m = run_spineopt(url_in, url_out; log_level=0)
         con = m.ext[:spineopt].constraints[:unit_flow_capacity]
         using_spinedb(url_out, Y)
@@ -389,6 +392,7 @@ function _test_dont_overwrite_results_on_rolling()
             relationship_parameter_values=relationship_parameter_values,
             on_conflict=:replace
         )
+        rm(file_path_out; force=true)
         m = run_spineopt(url_in, url_out; log_level=0, update_names=true)
         using_spinedb(url_out, Y)
         flow_key = (
@@ -469,6 +473,7 @@ function _test_write_inputs()
             relationships=relationships,
             object_parameter_values=object_parameter_values,
         )
+        rm(file_path_out; force=true)
         run_spineopt(url_in, url_out; log_level=0)
         using_spinedb(url_out, Y)
         key = (report=Y.report(:report_x), node=Y.node(:node_b), stochastic_scenario=Y.stochastic_scenario(:parent))
@@ -498,6 +503,7 @@ function _test_write_inputs_overlapping_temporal_blocks()
             relationships=relationships,
             object_parameter_values=object_parameter_values,
         )
+        rm(file_path_out; force=true)
         run_spineopt(url_in, url_out; log_level=0)
         using_spinedb(url_out, Y)
         key = (report=Y.report(:report_x), node=Y.node(:node_b), stochastic_scenario=Y.stochastic_scenario(:parent))
@@ -524,6 +530,7 @@ function _test_output_resolution_for_an_input()
                 relationships=relationships,
                 object_parameter_values=object_parameter_values,
             )
+            rm(file_path_out; force=true)
             run_spineopt(url_in, url_out; log_level=0, filters=Dict())
             using_spinedb(url_out, Y)
             key = (report=Y.report(:report_x), node=Y.node(:node_b), stochastic_scenario=Y.stochastic_scenario(:parent))
@@ -833,13 +840,17 @@ function _test_fix_unit_flow_with_rolling()
         ]
         values = [1, NaN, 2, NaN, 3, NaN]
         fix_unit_flow_ = unparse_db_value(TimeSeries(indexes, values, false, false))
-        object_parameter_values = [["node", "node_b", "balance_type", "balance_type_none"]]
+        object_parameter_values = [
+            ["node", "node_b", "balance_type", "balance_type_none"],
+            ["model", "instance", "roll_forward", unparse_db_value(Hour(6))],
+        ]
         relationship_parameter_values = [["unit__to_node", ["unit_ab", "node_b"], "fix_unit_flow", fix_unit_flow_]]
         SpineInterface.import_data(
             url_in;
             object_parameter_values=object_parameter_values,
             relationship_parameter_values=relationship_parameter_values
         )
+        rm(file_path_out; force=true)
         m = run_spineopt(url_in, url_out)
         using_spinedb(url_out, Y)
         @testset for ind in indices(Y.unit_flow)
@@ -848,6 +859,55 @@ function _test_fix_unit_flow_with_rolling()
                 exp_v = isnan(values[i]) ? 0 : values[i]
                 @test exp_v == v
             end
+        end
+    end
+end
+
+function _test_fix_node_state_using_map_with_rolling()
+    @testset "fix_node_state_using_map_with_rolling" begin
+        url_in, url_out, file_path_out = _test_run_spineopt_setup()
+        rf = 2
+        look_ahead = 4  # Higher than the roll forward so it's more interesting
+        # Note that block end needs to set to Hour(look_ahead + 1) for things to work!
+        ucap = 10  # Can be anything
+        indexes = collect(DateTime("2000-01-01T00:00:00"):Hour(rf):DateTime("2000-01-01T23:00:00"))
+        values = []
+        for (k, t0) in enumerate(indexes)
+            t = t0 + Hour(look_ahead)
+            v = Hour(t - indexes[1]).value * ucap
+            val = if k == 1
+                TimeSeries([indexes[1], indexes[1] + Hour(1), t], [0, NaN, v])
+            else
+                TimeSeries([t], [v])
+            end
+            push!(values, val)
+        end
+        for (k, v) in zip(indexes, values) @show k, collect(v) end
+        fix_node_state_ = unparse_db_value(Map(indexes, values))
+        objects = [["output", "node_state"]]
+        relationships = [["report__output", ["report_x", "node_state"]]]
+        object_parameter_values = [
+            ["node", "node_b", "has_state", true],
+            ["node", "node_b", "fix_node_state", fix_node_state_],
+            ["model", "instance", "roll_forward", unparse_db_value(Hour(rf))],
+            ["temporal_block", "hourly", "block_end", unparse_db_value(Hour(look_ahead + 1))],
+        ]
+        relationship_parameter_values = [
+            ["unit__to_node", ["unit_ab", "node_b"], "unit_capacity", ucap]
+        ]
+        SpineInterface.import_data(
+            url_in;
+            objects=objects,
+            relationships=relationships,
+            object_parameter_values=object_parameter_values,
+            relationship_parameter_values=relationship_parameter_values
+        )
+        rm(file_path_out; force=true)
+        m = run_spineopt(url_in, url_out; log_level=0)
+        using_spinedb(url_out, Y)
+        @testset for (t, v) in Y.node_state(; node=Y.node(:node_b))
+            exp_v = Hour(t - indexes[1]).value * ucap
+            @test exp_v == v
         end
     end
 end
@@ -871,4 +931,5 @@ end
     _test_dual_values()
     _test_dual_values_with_two_time_indices()
     _test_fix_unit_flow_with_rolling()
+    _test_fix_node_state_using_map_with_rolling()
 end


### PR DESCRIPTION
Re #650

We just fix some issues with using Maps to specify fix_[variable_name] parameter values. It was almost there but needed one extra line of code to include the analysis time in the call to the parameter when fixing the value; as well as one extra line in SpineInterface to interpret nothing as NaN (as the indication that the variable is free in a time-range)

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted according to SpineOpt's style
- [x] Unit tests pass
