### PR TITLE
Fix cuts, end of master problem window and sp costs calculation

### DIFF
--- a/src/constraints/constraint_mp_any_invested_cuts.jl
+++ b/src/constraints/constraint_mp_any_invested_cuts.jl
@@ -42,9 +42,13 @@ function add_constraint_mp_any_invested_cuts!(m::Model)
                     + units_invested_available[u, s, t]
                     - internal_fix_units_invested_available(unit=u, stochastic_scenario=s, t=t)
                 )
-                * units_on_mv(unit=u, stochastic_scenario=s, t=t)
+                * sum(
+                    Iterators.filter(
+                        !isnan, units_on_mv(unit=u, stochastic_scenario=s, t=t) for t in t_overlaps_t(m; t=t)
+                    );
+                    init=0
+                )
                 for (u, s, t) in units_invested_available_indices(m)
-                if !isnan(units_on_mv(unit=u, stochastic_scenario=s, t=t));
                 init=0,
             )
             # operating cost benefit from investments in connections
@@ -53,9 +57,15 @@ function add_constraint_mp_any_invested_cuts!(m::Model)
                     + connections_invested_available[c, s, t]
                     - internal_fix_connections_invested_available(connection=c, stochastic_scenario=s, t=t)
                 )
-                * connections_invested_available_mv(connection=c, stochastic_scenario=s, t=t)
+                * sum(
+                    Iterators.filter(
+                        !isnan,
+                        connections_invested_available_mv(connection=c, stochastic_scenario=s, t=t)
+                        for t in t_overlaps_t(m; t=t)
+                    );
+                    init=0
+                )
                 for (c, s, t) in connections_invested_available_indices(m)
-                if !isnan(connections_invested_available_mv(connection=c, stochastic_scenario=s, t=t));
                 init=0,
             )
             # operating cost benefit from investments in storages
@@ -64,9 +74,15 @@ function add_constraint_mp_any_invested_cuts!(m::Model)
                     + storages_invested_available[n, s, t]
                     - internal_fix_storages_invested_available(node=n, stochastic_scenario=s, t=t)
                 )
+                * sum(
+                    Iterators.filter(
+                        !isnan,
+                        storages_invested_available_mv(node=n, stochastic_scenario=s, t=t) for t in t_overlaps_t(m; t=t)
+                    );
+                    init=0
+                )
                 * storages_invested_available_mv(node=n, stochastic_scenario=s, t=t)
                 for (n, s, t) in storages_invested_available_indices(m)
-                if !isnan(storages_invested_available_mv(node=n, stochastic_scenario=s, t=t));
                 init=0,
             )
         )

--- a/src/data_structure/benders_data.jl
+++ b/src/data_structure/benders_data.jl
@@ -86,8 +86,11 @@ function _save_sp_marginal_values!(m, var_name, benders_param_name, obj_cls, win
 end
 
 function _save_sp_objective_value!(m, win_weight, tail=false)
-    in_window_obj_val = sum(values(m.ext[:spineopt].values[:total_costs]), init=0)
-    increment = tail ? value(realize(total_costs(m, anything))) - in_window_obj_val : in_window_obj_val
+    increment = if tail
+        sum(_value(realize(beyond_window)) for (_iw, beyond_window) in values(m.ext[:spineopt].objective_terms); init=0)
+    else
+        sum(values(m.ext[:spineopt].values[:total_costs]); init=0)
+    end
     total_sp_obj_val = sp_objective_value_bi(benders_iteration=current_bi, _default=0) + win_weight * increment
     add_object_parameter_values!(
         benders_iteration, Dict(current_bi => Dict(:sp_objective_value_bi => parameter_value(total_sp_obj_val)))

--- a/src/data_structure/temporal_structure.jl
+++ b/src/data_structure/temporal_structure.jl
@@ -438,7 +438,8 @@ function generate_master_temporal_structure!(m::Model, m_mp::Model)
         end
     end
     unique!(sort!(mp_time_slices))
-    mp_start, mp_end = start(first(mp_time_slices)), end_(last(mp_time_slices))
+    mp_start = start(first(mp_time_slices))
+    mp_end = end_(current_window(m))
     m_mp.ext[:spineopt].temporal_structure[:current_window] = TimeSlice(mp_start, mp_end, duration_unit=dur_unit)
     _do_generate_time_slice!(m_mp, mp_start, mp_end, mp_time_slices)
     _generate_output_time_slices!(m_mp)

--- a/src/run_spineopt_standard.jl
+++ b/src/run_spineopt_standard.jl
@@ -414,9 +414,6 @@ function _save_objective_values!(m::Model)
     nothing
 end
 
-_value(v::GenericAffExpr) = JuMP.value(v)
-_value(v) = v
-
 function _calculate_duals(m; log_level=3)
     if has_duals(m)
         _save_marginal_values!(m)

--- a/src/util/misc.jl
+++ b/src/util/misc.jl
@@ -183,3 +183,7 @@ struct Constant
 end
 
 Base.getindex(c::Constant, _x) = Call(c.value)
+
+_value(v::GenericAffExpr) = JuMP.value(v)
+_value(v) = v
+


### PR DESCRIPTION
The benders cuts were wrong whenever the investments resolution was different than the operations resolution. For example is investments was one year and operations one hour, the marginal value was the average over the year instead of the sum. So it was only accounting for the benefit of one hour in average in operation, rather than the cumulated benefit over all the hours in the year.

Plus, the master model end was wrong whenever there was a lookahead. This caused the history to be wrong, granting free investments during the history period.

Last, the sp objective was considering the invesments costs, which is wrong.

## Checklist before merging
- [ ] Documentation is up-to-date
- [ ] Unit tests have been added/updated accordingly
- [ ] Code has been formatted according to SpineOpt's style
- [ ] Unit tests pass
