### PR TITLE
Cut history more properly

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,5 +17,5 @@ Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 SpineInterface = "0cda1612-498a-11e9-3c92-77fa82595a4f"
 
 [compat]
-SpineInterface = "0.11.2"
+SpineInterface = "0.11.3"
 julia = "^1.2"

--- a/src/run_spineopt_benders.jl
+++ b/src/run_spineopt_benders.jl
@@ -207,5 +207,5 @@ function _unfix_history!(m::Model)
     end
 end
 
-_unfix(v::VariableRef) = unfix(v)
+_unfix(v::VariableRef) = is_fixed(v) && unfix(v)
 _unfix(::Call) = nothing

--- a/test/data_structure/temporal_structure.jl
+++ b/test/data_structure/temporal_structure.jl
@@ -422,11 +422,11 @@ function _test_history()
         block_a = temporal_block(:block_a)
         block_b = temporal_block(:block_b)
         expected_history_time_slice = [
-            TimeSlice(DateTime(1999, 12, 31, 20), DateTime(1999, 12, 31, 21), block_a, block_b; duration_unit=Hour),
+            TimeSlice(DateTime(1999, 12, 31, 20), DateTime(1999, 12, 31, 21), block_b, block_a; duration_unit=Hour),
             TimeSlice(DateTime(1999, 12, 31, 21), DateTime(1999, 12, 31, 22), block_a; duration_unit=Hour),
             TimeSlice(DateTime(1999, 12, 31, 21), DateTime(1999, 12, 31, 23), block_b; duration_unit=Hour),
             TimeSlice(DateTime(1999, 12, 31, 22), DateTime(1999, 12, 31, 23), block_a; duration_unit=Hour),
-            TimeSlice(DateTime(1999, 12, 31, 23), DateTime(2000, 1, 1, 00), block_a, block_b; duration_unit=Hour),
+            TimeSlice(DateTime(1999, 12, 31, 23), DateTime(2000, 1, 1, 00), block_b, block_a; duration_unit=Hour),
         ]
         @test length(history_time_slice(m)) === 5
         @testset for (te, to) in zip(expected_history_time_slice, history_time_slice(m))


### PR DESCRIPTION
Excluding time slices that go beyond the window to create the history was excluding important time slices. We now include all time slices but make sure none spans beyond...

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted according to SpineOpt's style
- [x] Unit tests pass
