### PR TITLE
Get rid of the unit_availability_factor multiplier

### DIFF
--- a/src/constraints/constraint_mp_any_invested_cuts.jl
+++ b/src/constraints/constraint_mp_any_invested_cuts.jl
@@ -20,8 +20,9 @@
 """
     add_constraint_mp_units_invested_cut!(m::Model)
 
-Adds Benders optimality cuts for the units_available constraint. This tells the master problem the mp_objective
-cost improvement that is possible for an increase in the number of units available for a unit and so on.
+Adds Benders optimality cuts.
+This tells the master problem the improvement of the subproblem objective value that is possible for an increase
+in the number of investments.
 """
 function add_constraint_mp_any_invested_cuts!(m::Model)
     @fetch (

--- a/src/constraints/constraint_units_available.jl
+++ b/src/constraints/constraint_units_available.jl
@@ -33,19 +33,13 @@ function add_constraint_units_available!(m::Model)
                 init=0,
             )
             <=
-            + unit_availability_factor[(unit=u, stochastic_scenario=s, analysis_time=t0, t=t)]
-            * (
-                + number_of_units[(unit=u, stochastic_scenario=s, analysis_time=t0, t=t)] 
-                + expr_sum(
-                    units_invested_available[u, s, t1]
-                    for (u, s, t1) in units_invested_available_indices(
-                        m; unit=u, stochastic_scenario=s, t=t_overlaps_t(m; t=t)
-                    );
-                    # If t_overlaps_t is chosen here, we don't predefine hierarchy; 
-                    # not crucial, as most likely always t_operations < t_investment
-                    # but could be considered in the future
-                    init=0,
-                )
+            + number_of_units[(unit=u, stochastic_scenario=s, analysis_time=t0, t=t)] 
+            + expr_sum(
+                units_invested_available[u, s, t1]
+                for (u, s, t1) in units_invested_available_indices(
+                    m; unit=u, stochastic_scenario=s, t=t_overlaps_t(m; t=t)
+                );
+                init=0,
             )
         )
         for (u, s, t) in constraint_units_available_indices(m)

--- a/src/constraints/constraint_units_invested_available.jl
+++ b/src/constraints/constraint_units_invested_available.jl
@@ -35,6 +35,3 @@ function add_constraint_units_invested_available!(m::Model)
         for (u, s, t) in units_invested_available_indices(m)
     )
 end
-# TODO: units_invested_available or \sum(units_invested)?
-# Candidate units: max amount of units that can be installed over model horizon
-# or max amount of units that can be available at a time?

--- a/src/constraints/constraint_units_on.jl
+++ b/src/constraints/constraint_units_on.jl
@@ -29,9 +29,9 @@ function add_constraint_units_on!(m::Model)
         (unit=u, stochastic_scenario=s, t=t) => @constraint(
             m, 
             + units_on[u, s, t] 
-            * unit_availability_factor[(unit=u, stochastic_scenario=s, analysis_time=t0, t=t)]
             <= 
-            + units_available[u, s, t])
+            + units_available[u, s, t]
+        )
         for (u, s, t) in units_on_indices(m)
     )
 end

--- a/src/objective/renewable_curtailment_costs.jl
+++ b/src/objective/renewable_curtailment_costs.jl
@@ -31,7 +31,8 @@ function renewable_curtailment_costs(m::Model, t_range)
             curtailment_cost[(unit=u, stochastic_scenario=s, analysis_time=t0, t=t_short)]
             * node_stochastic_scenario_weight(m; node=n, stochastic_scenario=s)
             * (
-                units_available[u, s, t_long]
+                + units_available[u, s, t_long]
+                * unit_availability_factor[(unit=u, stochastic_scenario=s, analysis_time=t0, t=t_short)]
                 * unit_capacity[(unit=u, node=n, direction=d, stochastic_scenario=s, analysis_time=t0, t=t_short)]
                 * unit_conv_cap_to_flow[
                     (unit=u, node=n, direction=d, stochastic_scenario=s, analysis_time=t0, t=t_short),

--- a/src/variables/variable_units_available.jl
+++ b/src/variables/variable_units_available.jl
@@ -17,14 +17,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #############################################################################
 
-function units_available_replacement_value(ind)
-    if online_variable_type(unit=ind.unit) == :unit_online_variable_type_none
-        number_of_units[(; ind...)] * unit_availability_factor[(; ind...)]
-    else
-        nothing
-    end
-end
-
 """
     add_variable_units_available!(m::Model)
 
@@ -38,6 +30,6 @@ function add_variable_units_available!(m::Model)
         lb=Constant(0),
         bin=units_on_bin,
         int=units_on_int,
-        replacement_value=units_available_replacement_value,
+        replacement_value=units_on_replacement_value,
     )
 end

--- a/test/constraints/constraint_unit.jl
+++ b/test/constraints/constraint_unit.jl
@@ -127,7 +127,7 @@ function test_constraint_units_on()
             key = (unit(:unit_ab), s, t)
             var_u_on = var_units_on[key...]
             var_u_av = var_units_available[key...]
-            expected_con = @build_constraint(var_u_on * unit_availability_factor <= var_u_av)
+            expected_con = @build_constraint(var_u_on <= var_u_av)
             con_u_on = constraint[key...]
             observed_con = constraint_object(con_u_on)
             @test _is_constraint_equal(observed_con, expected_con)
@@ -162,7 +162,7 @@ function test_constraint_units_available()
             key = (unit(:unit_ab), s, t)
             var_u_av = var_units_available[key...]
             var_u_inv_av = var_units_invested_available[key...]
-            expected_con = @build_constraint(var_u_av <= unit_availability_factor * (number_of_units + var_u_inv_av))
+            expected_con = @build_constraint(var_u_av <= number_of_units + var_u_inv_av)
             con_key = (unit(:unit_ab), s, t)
             con = constraint[con_key...]
             observed_con = constraint_object(con)
@@ -1992,7 +1992,7 @@ function test_unit_online_variable_type_none()
             @test var_u_on isa Call
             @test var_u_avail isa Call
             @test realize(var_u_on) == 1
-            @test realize(var_u_avail) == 0.5
+            @test realize(var_u_avail) == 1
             @test con_u_on === nothing
             @test con_u_avail === nothing
         end


### PR DESCRIPTION
...in constraint_units_on and constraint_units_available.

Fixes #699

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted according to SpineOpt's style
- [x] Unit tests pass
