### PR TITLE
Simplify fixing integers vars

### DIFF
--- a/src/data_structure/benders_data.jl
+++ b/src/data_structure/benders_data.jl
@@ -86,14 +86,8 @@ function _save_sp_marginal_values!(m, var_name, benders_param_name, obj_cls, win
 end
 
 function _save_sp_objective_value!(m, win_weight, tail=false)
-    increment = if tail
-        sum(
-            JuMP.value(realize(beyond_window)) for (_iw, beyond_window) in values(m.ext[:spineopt].objective_terms);
-            init=0
-        )
-    else
-        sum(values(m.ext[:spineopt].values[:total_costs]); init=0)
-    end
+    key = tail ? :total_costs_tail : :total_costs
+    increment = sum(values(m.ext[:spineopt].values[key]); init=0)
     total_sp_obj_val = sp_objective_value_bi(benders_iteration=current_bi, _default=0) + win_weight * increment
     add_object_parameter_values!(
         benders_iteration, Dict(current_bi => Dict(:sp_objective_value_bi => parameter_value(total_sp_obj_val)))

--- a/src/util/promise.jl
+++ b/src/util/promise.jl
@@ -29,7 +29,7 @@ struct ReducedCostPromise <: AbstractPromise
     value::JuMP.VariableRef
 end
 
-realize(x::DualPromise) = has_duals(owner_model(x.value)) ? dual(x.value) : nothing
-realize(x::ReducedCostPromise) = has_duals(owner_model(x.value)) ? reduced_cost(x.value) : nothing
+realize(x::DualPromise) = has_duals(owner_model(x.value)) ? dual(x.value) : 0.0
+realize(x::ReducedCostPromise) = has_duals(owner_model(x.value)) ? reduced_cost(x.value) : 0.0
 
 Base.:+(x::X, y::Y) where {X<:AbstractPromise,Y<:AbstractPromise} = Call(+, x, y)


### PR DESCRIPTION
We simplify fixing integer variables by using the fact that the model is a copy, and other stuff, hopefully making it faster.

Also, we set the default value for dual() and reduced_cost() of a promise to zero, so benders doesn't break when the dual is not feasible. Instead, the marginal value will be zero which will impact in the cut for that iteration, and hopefully the algorithm will be able to keep improving the next iteration.

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted according to SpineOpt's style
- [x] Unit tests pass
