### PR TITLE
WIP Resolve JuMP `Parameter` and `parameter_value` conflicts

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -19,4 +19,3 @@ SpineInterface = "0cda1612-498a-11e9-3c92-77fa82595a4f"
 [compat]
 SpineInterface = "0.11.6"
 julia = "^1.2"
-JuMP = "< 1.14"

--- a/src/SpineOpt.jl
+++ b/src/SpineOpt.jl
@@ -33,6 +33,9 @@ import DataStructures: OrderedDict
 import Dates: CompoundPeriod
 import LinearAlgebra: BLAS.gemm, LAPACK.getri!, LAPACK.getrf!
 
+# Resolve JuMP and SpineInterface `Parameter` and `parameter_value` conflicts.
+import SpineInterface: Parameter, parameter_value
+
 export run_spineopt
 export rerun_spineopt
 export run_spineopt_kernel!

--- a/src/constraints/constraint_unit_flow_op_bounds.jl
+++ b/src/constraints/constraint_unit_flow_op_bounds.jl
@@ -32,16 +32,16 @@ function add_constraint_unit_flow_op_bounds!(m::Model)
             + unit_flow_op[u, n, d, op, s, t]
             <=
             (
+                ordered_unit_flow_op(unit = u, node=n, direction=d, _default=false) ? 
+                unit_flow_op_active[u, n, d, op, s, t] : units_on[u, s, t]
+            )
+            * (
                 + operating_points[(unit=u, node=n, direction=d, stochastic_scenario=s, analysis_time=t0, i=op)] 
                 - (
                     (op > 1) ? operating_points[
                         (unit=u, node=n, direction=d, stochastic_scenario=s, analysis_time=t0, i=op - 1)
                     ] : 0
                 )
-            )
-            * (
-                ordered_unit_flow_op(unit = u, node=n, direction=d, _default=false) ? 
-                unit_flow_op_active[u, n, d, op, s, t] : units_on[u, s, t]
             )
             * unit_availability_factor[(unit=u, stochastic_scenario=s, analysis_time=t0, t=t)]
             * unit_capacity[(unit=u, node=n, direction=d, stochastic_scenario=s, analysis_time=t0, t=t)]

--- a/src/constraints/constraint_units_available.jl
+++ b/src/constraints/constraint_units_available.jl
@@ -32,15 +32,15 @@ function add_constraint_units_available!(m::Model)
                 units_available[u, s, t] for (u, s, t) in units_on_indices(m; unit=u, stochastic_scenario=s, t=t);
                 init=0,
             )
-            <=
-            + number_of_units[(unit=u, stochastic_scenario=s, analysis_time=t0, t=t)] 
-            + expr_sum(
+            - expr_sum(
                 units_invested_available[u, s, t1]
                 for (u, s, t1) in units_invested_available_indices(
                     m; unit=u, stochastic_scenario=s, t=t_overlaps_t(m; t=t)
                 );
                 init=0,
             )
+            <=
+            number_of_units[(unit=u, stochastic_scenario=s, analysis_time=t0, t=t)] 
         )
         for (u, s, t) in constraint_units_available_indices(m)
     )

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,6 +24,8 @@ using Dates
 using JuMP
 using PyCall
 
+# Resolve JuMP and SpineInterface `Parameter` and `parameter_value` conflicts.
+import SpineInterface: Parameter, parameter_value
 
 import SpineOpt:
     time_slice,


### PR DESCRIPTION
# THIS PULL REQUEST IS STILL A WORK IN PROGRESS! DO NOT MERGE!

This pull request addresses the `Parameter` and `parameter_value` name conflict with SpineInterface in JuMP v1.14 and higher. Resolving the name conflict wasn't terribly difficult, but there are a few odd errors remaining.

Fixes #745 (eventually?)

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted according to SpineOpt's style
- [x] Unit tests pass
