### PR TITLE
Update reserve tutorial link in documentation

### DIFF
--- a/docs/src/advanced_concepts/ramping.md
+++ b/docs/src/advanced_concepts/ramping.md
@@ -75,7 +75,7 @@ Which now restricts the flow of the unit into that node to 15% of its capacity.
 So if you're using node groups for the sole purpose of constraining flow ramps, you should set the balance type of the group to `balance_type_none`.
 
 
-## [Ramping with reserves](id ramping-reserves-illustrative-example)
+## [Ramping with reserves](@id ramping-reserves-illustrative-example)
 
 If a unit is set to provide reserves, then it should be able to provide that reserve within one [duration\_unit](@ref).
 For this reason, reserve provision must be accounted for within ramp constraints.

--- a/docs/src/advanced_concepts/reserves.md
+++ b/docs/src/advanced_concepts/reserves.md
@@ -2,7 +2,7 @@
 
 SpineOpt provides a way to include reserve provision in a model by creating reserve nodes. Reserve provision is different from regular operations as it involves withholding capacity, rather than producing a certain commodity (e.g., energy).
 
-This section covers the reserve concepts, but we highly recommend checking out the tutorial on reserves for a more thorough understanding of how the model is set up. You can find the [`tutorial on reserves`](@ref reserves-tutorial).
+This section covers the reserve concepts, but we highly recommend checking out the tutorial on reserves for a more thorough understanding of how the model is set up. You can find the [reserves tutorial](@ref reserves-tutorial).
 
 ## Defining a reserve node
 
@@ -15,9 +15,9 @@ To define a reserve node, the following parameters have to be defined for the re
 
 ## Defining a reserve group
 
-The reserve group definition allows the creation of a [`unit flow capacity constraint`](@ref constraint_unit_flow_capacity) where all the unit flows to different commodities, including the reserve provision, are considered to limit the maximum unit capacity.
+The reserve group definition allows the creation of a [unit flow capacity constraint](../mathematical_formulation/constraints.md#constraint_unit_flow_capacity) where all the unit flows to different commodities, including the reserve provision, are considered to limit the maximum unit capacity.
 
-The definition of the reserve group also allows the creation of [`minimum operating point`](@ref constraint_minimum_operating_point), [`ramp up`](@ref constraint_ramp_up), and [`ramp down`](@ref constraint_ramp_down) constraints, considering flows and reserve provisions.
+The definition of the reserve group also allows the creation of [minimum operating point](../mathematical_formulation/constraints.md#constraint_minimum_operating_point), [ramp up](../mathematical_formulation/constraints.md#constraint_ramp_up), and [ramp down](../mathematical_formulation/constraints.md#constraint_ramp_down) constraints, considering flows and reserve provisions.
 
 The relationship between the unit and the node group (i.e., [unit\_\_to\_node](@ref) or [unit\_\_from\_node](@ref)) is essential to define the parameters needed for the constraints (e.g., [unit\_capacity](@ref), [minimum\_operating\_point](@ref), [ramp\_up\_limit](@ref), or [ramp\_down\_limit](@ref)).
 
@@ -25,11 +25,11 @@ The relationship between the unit and the node group (i.e., [unit\_\_to\_node](@
 
 In this example, we will consider a unit that can provide upward and downward reserves, along with producing electricity. Therefore, the model needs to consider both characteristics of electricity production and reserve provision in the constraints.
 
-Let's take a look to the [`unit flow capacity constraint`](@ref constraint_unit_flow_capacity) and the [`minimum operating point`](@ref constraint_minimum_operating_point). For the illustrative example of ramping constraints and reserves, please visit the [`illustrative example of the reserve section`](@ref ramping-reserves-illustrative-example).
+Let's take a look to the [unit flow capacity constraint](../mathematical_formulation/constraints.md#constraint_unit_flow_capacity) and the [minimum operating point](../mathematical_formulation/constraints.md#constraint_minimum_operating_point). For the illustrative example of ramping constraints and reserves, please visit the [illustrative example of the reserve section](@ref ramping-reserves-illustrative-example).
 
 ### Unit flow capacity constraint with reserve
 
-Assuming the following parameters, we are considering a fully flexible unit taking into account the definition of the [`unit flow capacity constraint`](@ref constraint_unit_flow_capacity):
+Assuming the following parameters, we are considering a fully flexible unit taking into account the definition of the [unit flow capacity constraint](../mathematical_formulation/constraints.md#constraint_unit_flow_capacity):
 
 * `unit_capacity`  : **100**
 * `shut_down_limit`: **1**
@@ -45,7 +45,7 @@ Here, we can see that the flow to the electricity node depends on the unit's cap
 
 ### Minimum operating point constraint with reserve
 
-We need to consider the following parameters for the [`minimum operating point`](@ref constraint_minimum_operating_point) constraint:
+We need to consider the following parameters for the [minimum operating point](../mathematical_formulation/constraints.md#constraint_minimum_operating_point) constraint:
 
 * `minimum_operating_point`  : **0.25**
 

--- a/docs/src/tutorial/reserves.md
+++ b/docs/src/tutorial/reserves.md
@@ -1,4 +1,4 @@
-# [Reserve definition tutorial](id reserves-tutorial)
+# [Reserve definition tutorial](@id reserves-tutorial)
 
 This tutorial provides a step-by-step guide to include reserve requirements in a simple energy system with Spine Toolbox for SpineOpt.
 


### PR DESCRIPTION
This pull request updates the reserve tutorial link in the documentation to use the correct markdown syntax.

Fixes #829

## Checklist before merging
- [x] Documentation is up-to-date
- [NA] Unit tests have been added/updated accordingly
- [NA] Code has been formatted according to SpineOpt's style
- [NA] Unit tests pass
