### PR TITLE
resolve duration comparison conflicts

### DIFF
--- a/src/constraints/constraint_unit_flow_capacity.jl
+++ b/src/constraints/constraint_unit_flow_capacity.jl
@@ -217,8 +217,7 @@ function _unit_capacity_constraint_subpaths(path, u, t0, t)
     t_flow_duration = end_(t) - start(t)
     for s in path
         mut = min_up_time(unit=u, analysis_time=t0, stochastic_scenario=s, t=t, _default=nothing)
-        mut = align_variant_duration_unit(mut, start(t))
-        mut_gt_dur = mut === nothing || mut > t_flow_duration
+        mut_gt_dur = mut === nothing || (mut -> align_variant_duration_unit(mut, start(t))) > t_flow_duration
         if last_mut_gt_dur !== nothing && mut_gt_dur !== last_mut_gt_dur
             # Outcome change, store current subpath and start a new one
             push!(all_subpaths, (current_subpath, _parts_by_case(last_mut_gt_dur)))

--- a/src/constraints/constraint_unit_flow_capacity.jl
+++ b/src/constraints/constraint_unit_flow_capacity.jl
@@ -217,6 +217,9 @@ function _unit_capacity_constraint_subpaths(path, u, t0, t)
     t_flow_duration = end_(t) - start(t)
     for s in path
         mut = min_up_time(unit=u, analysis_time=t0, stochastic_scenario=s, t=t, _default=nothing)
+        if mut isa Month || mut isa Year
+            mut = align_variant_duration_unit(mut, t)
+        end
         mut_gt_dur = mut === nothing || mut > t_flow_duration
         if last_mut_gt_dur !== nothing && mut_gt_dur !== last_mut_gt_dur
             # Outcome change, store current subpath and start a new one

--- a/src/constraints/constraint_unit_flow_capacity.jl
+++ b/src/constraints/constraint_unit_flow_capacity.jl
@@ -217,7 +217,7 @@ function _unit_capacity_constraint_subpaths(path, u, t0, t)
     t_flow_duration = end_(t) - start(t)
     for s in path
         mut = min_up_time(unit=u, analysis_time=t0, stochastic_scenario=s, t=t, _default=nothing)
-        mut_gt_dur = mut === nothing || (mut -> align_variant_duration_unit(mut, start(t))) > t_flow_duration
+        mut_gt_dur = mut === nothing || align_variant_duration_unit(mut, start(t)) > t_flow_duration
         if last_mut_gt_dur !== nothing && mut_gt_dur !== last_mut_gt_dur
             # Outcome change, store current subpath and start a new one
             push!(all_subpaths, (current_subpath, _parts_by_case(last_mut_gt_dur)))

--- a/src/constraints/constraint_unit_flow_capacity.jl
+++ b/src/constraints/constraint_unit_flow_capacity.jl
@@ -217,9 +217,7 @@ function _unit_capacity_constraint_subpaths(path, u, t0, t)
     t_flow_duration = end_(t) - start(t)
     for s in path
         mut = min_up_time(unit=u, analysis_time=t0, stochastic_scenario=s, t=t, _default=nothing)
-        if mut isa Month || mut isa Year
-            mut = align_variant_duration_unit(mut, t)
-        end
+        mut = align_variant_duration_unit(mut, start(t))
         mut_gt_dur = mut === nothing || mut > t_flow_duration
         if last_mut_gt_dur !== nothing && mut_gt_dur !== last_mut_gt_dur
             # Outcome change, store current subpath and start a new one

--- a/src/util/misc.jl
+++ b/src/util/misc.jl
@@ -212,3 +212,28 @@ window_sum_duration(m, x::Number, window; init=0) = x * duration(window) + init
 
 window_sum(ts::TimeSeries, window; init=0) = sum(v for (t, v) in ts if iscontained(t, window) && !isnan(v); init=init)
 window_sum(x::Number, window; init=0) = x + init
+
+
+"""
+    align_variant_duration_unit(_duration::Union{Month, Year}, t::TimeSlice)
+
+When a duration value `_duration` is of the unit `Month` or `Year`, 
+this function turns the duration into `Day`s counting from the start DateTime of the given `t`.
+
+# Examples
+    _duration = Month(2)
+    t = TimeSlice(DateTime(2018, 2, 1), DateTime(2018, 3, 31))
+    if _duration isa Month || _duration isa Year
+        new_duration = align_variant_duration_unit(_duration, t)
+    end
+--> new_duration: 59 days == Day(59)
+--> new_duration == Day(59): true
+
+This convertion is needed for comparing a duration of `Month` or `Year` with 
+one of `Day`, `Hour` or finer units, which is not allowed because the former units are variant.
+"""
+function align_variant_duration_unit(_duration::Union{Month, Year}, t::TimeSlice)
+    #TODO: the value of `_duration` is assumed to be an integer. A warning should be given.
+    #TODO: new format to record durations would be benefitial, e.g. 3M2d1h.
+    return Day(start(t) + _duration - start(t))
+end


### PR DESCRIPTION
Turn a duration of `Month` or `Year` into `Day` anchored to the "active" `TimeSlice` used by the function that needs the duration.

Fixes #838

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted according to SpineOpt's style
- [x] Unit tests pass
