### PR TITLE
Fix installation links in the docs

### DIFF
--- a/docs/src/getting_started/installation.md
+++ b/docs/src/getting_started/installation.md
@@ -8,8 +8,8 @@ This package requires Julia 1.2 or later.
 
 
 If you haven't yet installed the tools yet, please follow the installation guides: 
-- For Spine Toolbox: https://github.com/spine-tools/SpineOpt.jl#installation
-- For SpineOpt: https://github.com/spine-tools/Spine-Toolbox#installation
+- For Spine Toolbox: <https://github.com/spine-tools/Spine-Toolbox#installation>
+- For SpineOpt: <https://github.com/spine-tools/SpineOpt.jl#installation>
 
 If you are not sure whether you have the latest version, please upgrade to ensure compatibility with this guide.
 - For Spine Toolbox:


### PR DESCRIPTION
The links for Spine Toolbox and SpineOpt were inverted

Fixes NA

## Checklist before merging
- [x] Documentation is up-to-date
- [x] ~Unit tests have been added/updated accordingly~
- [x] ~Code has been formatted according to SpineOpt's style~
- [x] ~Unit tests pass~
