### PR TITLE
Remove PyCall dependency to run_spineopt with a Dict

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SpineOpt"
 uuid = "0d8fc150-4032-4b6e-9540-20efcb304861"
 authors = ["Spine Project consortium <spine_info@vtt.fi>"]
-version = "0.7.0"
+version = "0.7.1"
 
 [deps]
 Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"
@@ -17,5 +17,5 @@ Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 SpineInterface = "0cda1612-498a-11e9-3c92-77fa82595a4f"
 
 [compat]
-SpineInterface = "0.12.1"
+SpineInterface = "0.12.2"
 julia = "^1.2"

--- a/examples/reserves.json
+++ b/examples/reserves.json
@@ -1,69 +1,352 @@
 {
-    "object_classes": [
+    "alternatives": [
         [
-            "commodity",
-            "A good or product that can be consumed, produced, traded. E.g., electricity, oil, gas, water...",
-            281473533932880
-        ],
-        [
-            "connection",
-            "A transfer of commodities between nodes. E.g. electricity line, gas pipeline...",
-            280378317271233
-        ],
-        [
-            "investment_group",
-            "A group of investments that need to be done together.",
-            281105609585860
-        ],
+            "Base",
+            "Base alternative"
+        ]
+    ],
+    "objects": [
         [
             "model",
-            "An instance of SpineOpt, that specifies general parameters such as the temporal horizon.",
-            281107035648412
+            "simple",
+            null
         ],
         [
             "node",
-            "A universal aggregator of commodify flows over units and connections, with storage capabilities.",
-            280740554077951
+            "electricity_node",
+            null
+        ],
+        [
+            "node",
+            "fuel_node",
+            null
+        ],
+        [
+            "node",
+            "upward_reserve_group",
+            null
+        ],
+        [
+            "node",
+            "upward_reserve_node",
+            null
         ],
         [
             "output",
-            "A variable name from SpineOpt that can be included in a report.",
-            280743406202948
+            "binary_gas_connection_flow",
+            null
+        ],
+        [
+            "output",
+            "connection_avg_intact_throughflow",
+            null
+        ],
+        [
+            "output",
+            "connection_avg_throughflow",
+            null
+        ],
+        [
+            "output",
+            "connection_flow",
+            null
+        ],
+        [
+            "output",
+            "connection_flow_costs",
+            null
+        ],
+        [
+            "output",
+            "connection_intact_flow",
+            null
+        ],
+        [
+            "output",
+            "connection_investment_costs",
+            null
+        ],
+        [
+            "output",
+            "connections_decommissioned",
+            null
+        ],
+        [
+            "output",
+            "connections_invested",
+            null
+        ],
+        [
+            "output",
+            "connections_invested_available",
+            null
+        ],
+        [
+            "output",
+            "contingency_is_binding",
+            null
+        ],
+        [
+            "output",
+            "fixed_om_costs",
+            null
+        ],
+        [
+            "output",
+            "fuel_costs",
+            null
+        ],
+        [
+            "output",
+            "mga_objective",
+            null
+        ],
+        [
+            "output",
+            "mp_objective_lowerbound",
+            null
+        ],
+        [
+            "output",
+            "node_injection",
+            null
+        ],
+        [
+            "output",
+            "node_pressure",
+            null
+        ],
+        [
+            "output",
+            "node_slack_neg",
+            null
+        ],
+        [
+            "output",
+            "node_slack_pos",
+            null
+        ],
+        [
+            "output",
+            "node_state",
+            null
+        ],
+        [
+            "output",
+            "node_voltage_angle",
+            null
+        ],
+        [
+            "output",
+            "nonspin_ramp_down_unit_flow",
+            null
+        ],
+        [
+            "output",
+            "nonspin_ramp_up_unit_flow",
+            null
+        ],
+        [
+            "output",
+            "nonspin_units_shut_down",
+            null
+        ],
+        [
+            "output",
+            "nonspin_units_started_up",
+            null
+        ],
+        [
+            "output",
+            "objective_penalties",
+            null
+        ],
+        [
+            "output",
+            "ramp_costs",
+            null
+        ],
+        [
+            "output",
+            "ramp_down_unit_flow",
+            null
+        ],
+        [
+            "output",
+            "ramp_up_unit_flow",
+            null
+        ],
+        [
+            "output",
+            "relative_optimality_gap",
+            null
+        ],
+        [
+            "output",
+            "renewable_curtailment_costs",
+            null
+        ],
+        [
+            "output",
+            "res_proc_costs",
+            null
+        ],
+        [
+            "output",
+            "shut_down_costs",
+            null
+        ],
+        [
+            "output",
+            "shut_down_unit_flow",
+            null
+        ],
+        [
+            "output",
+            "start_up_costs",
+            null
+        ],
+        [
+            "output",
+            "start_up_unit_flow",
+            null
+        ],
+        [
+            "output",
+            "storage_investment_costs",
+            null
+        ],
+        [
+            "output",
+            "storages_decommissioned",
+            null
+        ],
+        [
+            "output",
+            "storages_invested",
+            null
+        ],
+        [
+            "output",
+            "storages_invested_available",
+            null
+        ],
+        [
+            "output",
+            "taxes",
+            null
+        ],
+        [
+            "output",
+            "total_costs",
+            null
+        ],
+        [
+            "output",
+            "unit_flow",
+            null
+        ],
+        [
+            "output",
+            "unit_flow_op",
+            null
+        ],
+        [
+            "output",
+            "unit_flow_op_active",
+            null
+        ],
+        [
+            "output",
+            "unit_investment_costs",
+            null
+        ],
+        [
+            "output",
+            "units_available",
+            null
+        ],
+        [
+            "output",
+            "units_invested",
+            null
+        ],
+        [
+            "output",
+            "units_invested_available",
+            null
+        ],
+        [
+            "output",
+            "units_mothballed",
+            null
+        ],
+        [
+            "output",
+            "units_on",
+            null
+        ],
+        [
+            "output",
+            "units_on_costs",
+            null
+        ],
+        [
+            "output",
+            "units_shut_down",
+            null
+        ],
+        [
+            "output",
+            "units_started_up",
+            null
+        ],
+        [
+            "output",
+            "variable_om_costs",
+            null
         ],
         [
             "report",
-            "A results report from a particular SpineOpt run, including the value of specific variables.",
-            281108461711708
-        ],
-        [
-            "settings",
-            "Internal SpineOpt settings. We kindly advise not to mess with this one.",
-            280375465144798
+            "report1",
+            null
         ],
         [
             "stochastic_scenario",
-            "A scenario for stochastic optimisation in SpineOpt.",
-            280743389491710
+            "realization",
+            null
         ],
         [
             "stochastic_structure",
-            "A group of stochastic scenarios that represent a structure.",
-            281470681806146
+            "deterministic",
+            null
         ],
         [
             "temporal_block",
-            "A length of time with a particular resolution.",
-            280376891207703
+            "flat",
+            null
         ],
         [
             "unit",
-            "A conversion of one/many comodities between nodes.",
-            281470681805429
+            "power_plant_a",
+            null
         ],
         [
-            "user_constraint",
-            "A generic data-driven custom constraint.",
-            281473533931636
+            "unit",
+            "power_plant_b",
+            null
+        ]
+    ],
+    "object_groups": [
+        [
+            "node",
+            "upward_reserve_group",
+            "electricity_node"
+        ],
+        [
+            "node",
+            "upward_reserve_group",
+            "upward_reserve_node"
         ]
     ],
     "relationship_classes": [
@@ -75,6 +358,16 @@
             ],
             "Defines the `nodes` the `connection` can take input from, and holds most `connection_flow` variable specific parameters.",
             280378317271897
+        ],
+        [
+            "connection__from_node__investment_group",
+            [
+                "connection",
+                "node",
+                "investment_group"
+            ],
+            "Indicates which connection capacities are included in the capacity invested available of an investment group",
+            null
         ],
         [
             "connection__from_node__user_constraint",
@@ -131,6 +424,16 @@
             ],
             "Defines the `nodes` the `connection` can output to, and holds most `connection_flow` variable specific parameters.",
             280378317271898
+        ],
+        [
+            "connection__to_node__investment_group",
+            [
+                "connection",
+                "node",
+                "investment_group"
+            ],
+            "Indicates which connection capacities are included in the capacity invested available of an investment group",
+            null
         ],
         [
             "connection__to_node__user_constraint",
@@ -332,6 +635,16 @@
             281470681805657
         ],
         [
+            "unit__from_node__investment_group",
+            [
+                "unit",
+                "node",
+                "investment_group"
+            ],
+            "Indicates which unit capacities are included in the capacity invested available of an investment group",
+            null
+        ],
+        [
             "unit__from_node__user_constraint",
             [
                 "unit",
@@ -388,6 +701,16 @@
             281470681805658
         ],
         [
+            "unit__to_node__investment_group",
+            [
+                "unit",
+                "node",
+                "investment_group"
+            ],
+            "Indicates which unit capacities are included in the capacity invested available of an investment group",
+            null
+        ],
+        [
             "unit__to_node__user_constraint",
             [
                 "unit",
@@ -425,288 +748,6 @@
             null
         ]
     ],
-    "parameter_value_lists": [
-        [
-            "balance_type_list",
-            "balance_type_group"
-        ],
-        [
-            "balance_type_list",
-            "balance_type_node"
-        ],
-        [
-            "balance_type_list",
-            "balance_type_none"
-        ],
-        [
-            "boolean_value_list",
-            false
-        ],
-        [
-            "boolean_value_list",
-            true
-        ],
-        [
-            "commodity_physics_list",
-            "commodity_physics_lodf"
-        ],
-        [
-            "commodity_physics_list",
-            "commodity_physics_none"
-        ],
-        [
-            "commodity_physics_list",
-            "commodity_physics_ptdf"
-        ],
-        [
-            "connection_investment_variable_type_list",
-            "connection_investment_variable_type_continuous"
-        ],
-        [
-            "connection_investment_variable_type_list",
-            "connection_investment_variable_type_integer"
-        ],
-        [
-            "connection_type_list",
-            "connection_type_lossless_bidirectional"
-        ],
-        [
-            "connection_type_list",
-            "connection_type_normal"
-        ],
-        [
-            "constraint_sense_list",
-            "<="
-        ],
-        [
-            "constraint_sense_list",
-            "=="
-        ],
-        [
-            "constraint_sense_list",
-            ">="
-        ],
-        [
-            "db_lp_solver_list",
-            "KNITRO.jl"
-        ],
-        [
-            "db_lp_solver_list",
-            "CDCS.jl"
-        ],
-        [
-            "db_lp_solver_list",
-            "CDDLib.jl"
-        ],
-        [
-            "db_lp_solver_list",
-            "Clp.jl"
-        ],
-        [
-            "db_lp_solver_list",
-            "COSMO.jl"
-        ],
-        [
-            "db_lp_solver_list",
-            "CPLEX.jl"
-        ],
-        [
-            "db_lp_solver_list",
-            "CSDP.jl"
-        ],
-        [
-            "db_lp_solver_list",
-            "ECOS.jl"
-        ],
-        [
-            "db_lp_solver_list",
-            "Xpress.jl"
-        ],
-        [
-            "db_lp_solver_list",
-            "GLPK.jl"
-        ],
-        [
-            "db_lp_solver_list",
-            "Gurobi.jl"
-        ],
-        [
-            "db_lp_solver_list",
-            "HiGHS.jl"
-        ],
-        [
-            "db_lp_solver_list",
-            "Hypatia.jl"
-        ],
-        [
-            "db_lp_solver_list",
-            "Ipopt.jl"
-        ],
-        [
-            "db_lp_solver_list",
-            "MadNLP.jl"
-        ],
-        [
-            "db_lp_solver_list",
-            "MosekTools.jl"
-        ],
-        [
-            "db_lp_solver_list",
-            "NLopt.jl"
-        ],
-        [
-            "db_lp_solver_list",
-            "OSQP.jl"
-        ],
-        [
-            "db_lp_solver_list",
-            "ProxSDP.jl"
-        ],
-        [
-            "db_lp_solver_list",
-            "SCIP.jl"
-        ],
-        [
-            "db_lp_solver_list",
-            "SCS.jl"
-        ],
-        [
-            "db_lp_solver_list",
-            "SDPA.jl"
-        ],
-        [
-            "db_lp_solver_list",
-            "SDPNAL.jl"
-        ],
-        [
-            "db_lp_solver_list",
-            "SDPT3.jl"
-        ],
-        [
-            "db_lp_solver_list",
-            "SeDuMi.jl"
-        ],
-        [
-            "db_mip_solver_list",
-            "KNITRO.jl"
-        ],
-        [
-            "db_mip_solver_list",
-            "Cbc.jl"
-        ],
-        [
-            "db_mip_solver_list",
-            "CPLEX.jl"
-        ],
-        [
-            "db_mip_solver_list",
-            "HiGHS.jl"
-        ],
-        [
-            "db_mip_solver_list",
-            "Xpress.jl"
-        ],
-        [
-            "db_mip_solver_list",
-            "GLPK.jl"
-        ],
-        [
-            "db_mip_solver_list",
-            "Gurobi.jl"
-        ],
-        [
-            "db_mip_solver_list",
-            "Juniper.jl"
-        ],
-        [
-            "db_mip_solver_list",
-            "MosekTools.jl"
-        ],
-        [
-            "db_mip_solver_list",
-            "SCIP.jl"
-        ],
-        [
-            "duration_unit_list",
-            "hour"
-        ],
-        [
-            "duration_unit_list",
-            "minute"
-        ],
-        [
-            "model_type_list",
-            "spineopt_benders"
-        ],
-        [
-            "model_type_list",
-            "spineopt_standard"
-        ],
-        [
-            "model_type_list",
-            "spineopt_other"
-        ],
-        [
-            "model_type_list",
-            "spineopt_mga"
-        ],
-        [
-            "node_opf_type_list",
-            "node_opf_type_normal"
-        ],
-        [
-            "node_opf_type_list",
-            "node_opf_type_reference"
-        ],
-        [
-            "unit_investment_variable_type_list",
-            "unit_investment_variable_type_continuous"
-        ],
-        [
-            "unit_investment_variable_type_list",
-            "unit_investment_variable_type_integer"
-        ],
-        [
-            "unit_online_variable_type_list",
-            "unit_online_variable_type_binary"
-        ],
-        [
-            "unit_online_variable_type_list",
-            "unit_online_variable_type_integer"
-        ],
-        [
-            "unit_online_variable_type_list",
-            "unit_online_variable_type_linear"
-        ],
-        [
-            "unit_online_variable_type_list",
-            "unit_online_variable_type_none"
-        ],
-        [
-            "variable_type_list",
-            "variable_type_binary"
-        ],
-        [
-            "variable_type_list",
-            "variable_type_continuous"
-        ],
-        [
-            "variable_type_list",
-            "variable_type_integer"
-        ],
-        [
-            "write_mps_file_list",
-            "write_mps_always"
-        ],
-        [
-            "write_mps_file_list",
-            "write_mps_never"
-        ],
-        [
-            "write_mps_file_list",
-            "write_mps_on_no_solve"
-        ]
-    ],
     "object_parameters": [
         [
             "commodity",
@@ -721,6 +762,13 @@
             "commodity_physics_none",
             "commodity_physics_list",
             "Defines if the `commodity` follows lodf or ptdf physics."
+        ],
+        [
+            "commodity",
+            "commodity_physics_duration",
+            null,
+            null,
+            "For how long the `commodity_physics` should apply relative to the start of the window."
         ],
         [
             "commodity",
@@ -752,6 +800,13 @@
         ],
         [
             "connection",
+            "benders_starting_connections_invested",
+            null,
+            null,
+            "Fixes the number of connections invested during the first Benders iteration"
+        ],
+        [
+            "connection",
             "candidate_connections",
             null,
             null,
@@ -760,7 +815,7 @@
         [
             "connection",
             "connection_availability_factor",
-            1.0,
+            1,
             null,
             "Availability of the `connection`, acting as a multiplier on its `connection_capacity`. Typically between 0-1."
         ],
@@ -905,6 +960,41 @@
             "If false, the object is excluded from the model if the tool filter object activity control is specified"
         ],
         [
+            "investment_group",
+            "equal_investments",
+            false,
+            "boolean_value_list",
+            "Whether all entities in the group must have the same investment decision."
+        ],
+        [
+            "investment_group",
+            "maximum_capacity_invested_available",
+            null,
+            null,
+            "Upper bound on the capacity invested available in the group at any point in time."
+        ],
+        [
+            "investment_group",
+            "maximum_entities_invested_available",
+            null,
+            null,
+            "Upper bound on the number of entities invested available in the group at any point in time."
+        ],
+        [
+            "investment_group",
+            "minimum_capacity_invested_available",
+            null,
+            null,
+            "Lower bound on the capacity invested available in the group at any point in time."
+        ],
+        [
+            "investment_group",
+            "minimum_entities_invested_available",
+            null,
+            null,
+            "Lower bound on the number of entities invested available in the group at any point in time."
+        ],
+        [
             "model",
             "big_m",
             1000000,
@@ -922,14 +1012,23 @@
             "model",
             "db_lp_solver_options",
             {
-                "type": "map",
-                "index_type": "str",
                 "data": [
+                    [
+                        "Clp.jl",
+                        {
+                            "data": [
+                                [
+                                    "LogLevel",
+                                    0
+                                ]
+                            ],
+                            "type": "map",
+                            "index_type": "str"
+                        }
+                    ],
                     [
                         "HiGHS.jl",
                         {
-                            "type": "map",
-                            "index_type": "str",
                             "data": [
                                 [
                                     "presolve",
@@ -939,23 +1038,14 @@
                                     "time_limit",
                                     300.01
                                 ]
-                            ]
-                        }
-                    ],
-                    [
-                        "Clp.jl",
-                        {
+                            ],
                             "type": "map",
-                            "index_type": "str",
-                            "data": [
-                                [
-                                    "LogLevel",
-                                    0.0
-                                ]
-                            ]
+                            "index_type": "str"
                         }
                     ]
-                ]
+                ],
+                "type": "map",
+                "index_type": "str"
             },
             null,
             "Map parameter containing LP solver option name option value pairs. See solver documentation for supported solver options"
@@ -971,65 +1061,65 @@
             "model",
             "db_mip_solver_options",
             {
-                "type": "map",
-                "index_type": "str",
                 "data": [
-                    [
-                        "HiGHS.jl",
-                        {
-                            "type": "map",
-                            "index_type": "str",
-                            "data": [
-                                [
-                                    "presolve",
-                                    "on"
-                                ],
-                                [
-                                    "mip_rel_gap",
-                                    0.01
-                                ],
-                                [
-                                    "threads",
-                                    0.0
-                                ],
-                                [
-                                    "time_limit",
-                                    300.01
-                                ]
-                            ]
-                        }
-                    ],
-                    [
-                        "Cbc.jl",
-                        {
-                            "type": "map",
-                            "index_type": "str",
-                            "data": [
-                                [
-                                    "ratioGap",
-                                    0.01
-                                ],
-                                [
-                                    "logLevel",
-                                    0.0
-                                ]
-                            ]
-                        }
-                    ],
                     [
                         "CPLEX.jl",
                         {
-                            "type": "map",
-                            "index_type": "str",
                             "data": [
                                 [
                                     "CPX_PARAM_EPGAP",
                                     0.01
                                 ]
-                            ]
+                            ],
+                            "type": "map",
+                            "index_type": "str"
+                        }
+                    ],
+                    [
+                        "Cbc.jl",
+                        {
+                            "data": [
+                                [
+                                    "logLevel",
+                                    0
+                                ],
+                                [
+                                    "ratioGap",
+                                    0.01
+                                ]
+                            ],
+                            "type": "map",
+                            "index_type": "str"
+                        }
+                    ],
+                    [
+                        "HiGHS.jl",
+                        {
+                            "data": [
+                                [
+                                    "mip_rel_gap",
+                                    0.01
+                                ],
+                                [
+                                    "presolve",
+                                    "on"
+                                ],
+                                [
+                                    "threads",
+                                    0
+                                ],
+                                [
+                                    "time_limit",
+                                    300.01
+                                ]
+                            ],
+                            "type": "map",
+                            "index_type": "str"
                         }
                     ]
-                ]
+                ],
+                "type": "map",
+                "index_type": "str"
             },
             null,
             "Map parameter containing MIP solver option name option value pairs for MIP. See solver documentation for supported solver options"
@@ -1058,7 +1148,7 @@
         [
             "model",
             "max_iterations",
-            10.0,
+            10,
             null,
             "Specifies the maximum number of iterations for the model. Currently only used for the master problem within a decomposed structure"
         ],
@@ -1078,10 +1168,17 @@
         ],
         [
             "model",
+            "min_iterations",
+            1,
+            null,
+            "Specifies the minimum number of iterations for the model. Currently only used for the master problem within a decomposed structure"
+        ],
+        [
+            "model",
             "model_end",
             {
-                "type": "date_time",
-                "data": "2000-01-02T00:00:00"
+                "data": "2000-01-02T00:00:00.0",
+                "type": "date_time"
             },
             null,
             "Defines the last timestamp to be modelled. Rolling optimization terminates after passing this point."
@@ -1090,8 +1187,8 @@
             "model",
             "model_start",
             {
-                "type": "date_time",
-                "data": "2000-01-01T00:00:00"
+                "data": "2000-01-01T00:00:00.0",
+                "type": "date_time"
             },
             null,
             "Defines the first timestamp to be modelled. Relative `temporal_blocks` refer to this value for their start and end."
@@ -1154,6 +1251,13 @@
         ],
         [
             "node",
+            "benders_starting_storages_invested",
+            null,
+            null,
+            "Fixes the number of storages invested during the first Benders iteration"
+        ],
+        [
+            "node",
             "candidate_storages",
             null,
             null,
@@ -1162,7 +1266,7 @@
         [
             "node",
             "demand",
-            0.0,
+            0,
             null,
             "Demand for the `commodity` of a `node`. Energy gains can be represented using negative `demand`."
         ],
@@ -1211,14 +1315,14 @@
         [
             "node",
             "frac_state_loss",
-            0.0,
+            0,
             null,
             "Self-discharge coefficient for `node_state` variables. Effectively, represents the *loss power per unit of state*."
         ],
         [
             "node",
             "fractional_demand",
-            0.0,
+            0,
             null,
             "The fraction of a `node` group's `demand` applied for the `node` in question."
         ],
@@ -1372,14 +1476,14 @@
         [
             "node",
             "node_state_min",
-            0.0,
+            0,
             null,
             "The minimum permitted value for a `node_state` variable."
         ],
         [
             "node",
             "state_coeff",
-            1.0,
+            1,
             null,
             "Represents the `commodity` content of a `node_state` variable in respect to the `unit_flow` and `connection_flow` variables. Essentially, acts as a coefficient on the `node_state` variable in the `:node_injection` constraint."
         ],
@@ -1484,7 +1588,7 @@
         [
             "settings",
             "version",
-            8,
+            10,
             null,
             "Current version of the SpineOpt data structure. Modify it at your own risk (but please don't)."
         ],
@@ -1534,8 +1638,8 @@
             "temporal_block",
             "resolution",
             {
-                "type": "duration",
-                "data": "1h"
+                "data": "1h",
+                "type": "duration"
             },
             null,
             "Temporal resolution of the `temporal_block`. Essentially, divides the period between `block_start` and `block_end` into `TimeSlices` with the input `resolution`."
@@ -1543,9 +1647,16 @@
         [
             "temporal_block",
             "weight",
-            1.0,
+            1,
             null,
             "Weighting factor of the temporal block associated with the objective function"
+        ],
+        [
+            "unit",
+            "benders_starting_units_invested",
+            null,
+            null,
+            "Fixes the number of units invested during the first Benders iteration"
         ],
         [
             "unit",
@@ -1655,7 +1766,7 @@
         [
             "unit",
             "number_of_units",
-            1.0,
+            1,
             null,
             "Denotes the number of 'sub units' aggregated to form the modelled `unit`."
         ],
@@ -1683,7 +1794,7 @@
         [
             "unit",
             "unit_availability_factor",
-            1.0,
+            1,
             null,
             "Availability of the `unit`, acting as a multiplier on its `unit_capacity`. Typically between 0-1."
         ],
@@ -1767,9 +1878,160 @@
         [
             "user_constraint",
             "right_hand_side",
-            0.0,
+            0,
             null,
             "The right-hand side, constant term in a `user_constraint`. Can be time-dependent and used e.g. for complicated efficiency approximations."
+        ],
+        [
+            "user_constraint",
+            "user_constraint_slack_penalty",
+            null,
+            null,
+            "A penalty for violating a user constraint."
+        ]
+    ],
+    "relationship_parameter_values": [
+        [
+            "unit__from_node",
+            [
+                "power_plant_a",
+                "fuel_node"
+            ],
+            "vom_cost",
+            25,
+            "Base"
+        ],
+        [
+            "unit__from_node",
+            [
+                "power_plant_b",
+                "fuel_node"
+            ],
+            "vom_cost",
+            50,
+            "Base"
+        ],
+        [
+            "unit__node__node",
+            [
+                "power_plant_a",
+                "electricity_node",
+                "fuel_node"
+            ],
+            "fix_ratio_out_in_unit_flow",
+            0.7,
+            "Base"
+        ],
+        [
+            "unit__node__node",
+            [
+                "power_plant_b",
+                "electricity_node",
+                "fuel_node"
+            ],
+            "fix_ratio_out_in_unit_flow",
+            0.8,
+            "Base"
+        ],
+        [
+            "unit__to_node",
+            [
+                "power_plant_a",
+                "electricity_node"
+            ],
+            "unit_capacity",
+            100,
+            "Base"
+        ],
+        [
+            "unit__to_node",
+            [
+                "power_plant_a",
+                "upward_reserve_group"
+            ],
+            "ramp_up_limit",
+            1,
+            "Base"
+        ],
+        [
+            "unit__to_node",
+            [
+                "power_plant_a",
+                "upward_reserve_group"
+            ],
+            "unit_capacity",
+            100,
+            "Base"
+        ],
+        [
+            "unit__to_node",
+            [
+                "power_plant_a",
+                "upward_reserve_node"
+            ],
+            "reserve_procurement_cost",
+            5,
+            "Base"
+        ],
+        [
+            "unit__to_node",
+            [
+                "power_plant_a",
+                "upward_reserve_node"
+            ],
+            "unit_capacity",
+            100,
+            "Base"
+        ],
+        [
+            "unit__to_node",
+            [
+                "power_plant_b",
+                "electricity_node"
+            ],
+            "unit_capacity",
+            200,
+            "Base"
+        ],
+        [
+            "unit__to_node",
+            [
+                "power_plant_b",
+                "upward_reserve_group"
+            ],
+            "ramp_up_limit",
+            1,
+            "Base"
+        ],
+        [
+            "unit__to_node",
+            [
+                "power_plant_b",
+                "upward_reserve_group"
+            ],
+            "unit_capacity",
+            200,
+            "Base"
+        ],
+        [
+            "unit__to_node",
+            [
+                "power_plant_b",
+                "upward_reserve_node"
+            ],
+            "reserve_procurement_cost",
+            35,
+            "Base"
+        ],
+        [
+            "unit__to_node",
+            [
+                "power_plant_b",
+                "upward_reserve_node"
+            ],
+            "unit_capacity",
+            200,
+            "Base"
         ]
     ],
     "relationship_parameters": [
@@ -1783,7 +2045,7 @@
         [
             "connection__from_node",
             "connection_conv_cap_to_flow",
-            1.0,
+            1,
             null,
             "Optional coefficient for `connection_capacity` unit conversions in the case that the `connection_capacity` value is incompatible with the desired `connection_flow` units."
         ],
@@ -1881,7 +2143,7 @@
         [
             "connection__from_node__user_constraint",
             "connection_flow_coefficient",
-            0.0,
+            0,
             null,
             "defines the user constraint coefficient on the connection flow variable in the from direction"
         ],
@@ -1896,8 +2158,8 @@
             "connection__node__node",
             "connection_flow_delay",
             {
-                "type": "duration",
-                "data": "0h"
+                "data": "0h",
+                "type": "duration"
             },
             null,
             "Delays the `connection_flows` associated with the latter `node` in respect to the `connection_flows` associated with the first `node`."
@@ -1914,7 +2176,7 @@
             "fix_ratio_out_in_connection_flow",
             null,
             null,
-            "Fix the ratio between the `connection_flow` from the first `node` and the `connection_flow` to the second `node`."
+            "Fix the ratio between an outgoing `connection_flow` to the first `node` and an incoming `connection_flow` from the second `node`."
         ],
         [
             "connection__node__node",
@@ -1935,14 +2197,14 @@
             "max_ratio_out_in_connection_flow",
             null,
             null,
-            "Maximum ratio between the `connection_flow` from the first `node` and the `connection_flow` to the second `node`."
+            "Maximum ratio between an outgoing `connection_flow` to the first `node` and an incoming `connection_flow` from the second `node`."
         ],
         [
             "connection__node__node",
             "min_ratio_out_in_connection_flow",
             null,
             null,
-            "Minimum ratio between the `connection_flow` from the first `node` and the `connection_flow` to the second `node`."
+            "Minimum ratio between an outgoing `connection_flow` to the first `node` and an incoming `connection_flow` from the second `node`."
         ],
         [
             "connection__to_node",
@@ -1954,7 +2216,7 @@
         [
             "connection__to_node",
             "connection_conv_cap_to_flow",
-            1.0,
+            1,
             null,
             "Optional coefficient for `connection_capacity` unit conversions in the case the `connection_capacity` value is incompatible with the desired `connection_flow` units."
         ],
@@ -2052,28 +2314,28 @@
         [
             "connection__to_node__user_constraint",
             "connection_flow_coefficient",
-            0.0,
+            0,
             null,
             "defines the user constraint coefficient on the connection flow variable in the to direction"
         ],
         [
             "connection__user_constraint",
             "connections_invested_available_coefficient",
-            0.0,
+            0,
             null,
             "coefficient of `connections_invested_available` in the specific `user_constraint`"
         ],
         [
             "connection__user_constraint",
             "connections_invested_coefficient",
-            0.0,
+            0,
             null,
             "coefficient of `connections_invested` in the specific `user_constraint`"
         ],
         [
             "node__node",
             "diff_coeff",
-            0.0,
+            0,
             null,
             "Commodity diffusion coefficient between two `nodes`. Effectively, denotes the *diffusion power per unit of state* from the first `node` to the second."
         ],
@@ -2101,28 +2363,28 @@
         [
             "node__user_constraint",
             "demand_coefficient",
-            0.0,
+            0,
             null,
             "coefficient of the specified node's demand in the specified user constraint"
         ],
         [
             "node__user_constraint",
             "node_state_coefficient",
-            0.0,
+            0,
             null,
             "Coefficient of the specified node's state variable in the specified user constraint."
         ],
         [
             "node__user_constraint",
             "storages_invested_available_coefficient",
-            0.0,
+            0,
             null,
             "Coefficient of the specified node's storages invested available variable in the specified user constraint."
         ],
         [
             "node__user_constraint",
             "storages_invested_coefficient",
-            0.0,
+            0,
             null,
             "Coefficient of the specified node's storage investment variable in the specified user constraint."
         ],
@@ -2143,7 +2405,7 @@
         [
             "stochastic_structure__stochastic_scenario",
             "weight_relative_to_parents",
-            1.0,
+            1,
             null,
             "The weight of the `stochastic_scenario` in the objective function relative to its parents."
         ],
@@ -2332,7 +2594,7 @@
         [
             "unit__from_node",
             "min_unit_flow",
-            0.0,
+            0,
             null,
             "Set lower bound of the `unit_flow` variable."
         ],
@@ -2394,6 +2656,20 @@
         ],
         [
             "unit__from_node",
+            "shut_down_limit",
+            null,
+            null,
+            "Max. downward ramp for units shutting down"
+        ],
+        [
+            "unit__from_node",
+            "start_up_limit",
+            null,
+            null,
+            "Maximum ramp-up during startups."
+        ],
+        [
+            "unit__from_node",
             "unit_capacity",
             null,
             null,
@@ -2402,7 +2678,7 @@
         [
             "unit__from_node",
             "unit_conv_cap_to_flow",
-            1.0,
+            1,
             null,
             "Optional coefficient for `unit_capacity` unit conversions in the case the `unit_capacity` value is incompatible with the desired `unit_flow` units."
         ],
@@ -2437,7 +2713,7 @@
         [
             "unit__from_node__user_constraint",
             "unit_flow_coefficient",
-            0.0,
+            0,
             null,
             "Coefficient of a `unit_flow` variable for a custom `user_constraint`."
         ],
@@ -2472,28 +2748,28 @@
         [
             "unit__node__node",
             "fix_units_on_coefficient_in_in",
-            0.0,
+            0,
             null,
             "Optional coefficient for the `units_on` variable impacting the `fix_ratio_in_in_unit_flow` constraint."
         ],
         [
             "unit__node__node",
             "fix_units_on_coefficient_in_out",
-            0.0,
+            0,
             null,
             "Optional coefficient for the `units_on` variable impacting the `fix_ratio_in_out_unit_flow` constraint."
         ],
         [
             "unit__node__node",
             "fix_units_on_coefficient_out_in",
-            0.0,
+            0,
             null,
             "Optional coefficient for the `units_on` variable impacting the `fix_ratio_out_in_unit_flow` constraint."
         ],
         [
             "unit__node__node",
             "fix_units_on_coefficient_out_out",
-            0.0,
+            0,
             null,
             "Optional coefficient for the `units_on` variable impacting the `fix_ratio_out_out_unit_flow` constraint."
         ],
@@ -2528,28 +2804,28 @@
         [
             "unit__node__node",
             "max_units_on_coefficient_in_in",
-            0.0,
+            0,
             null,
             "Optional coefficient for the `units_on` variable impacting the `max_ratio_in_in_unit_flow` constraint."
         ],
         [
             "unit__node__node",
             "max_units_on_coefficient_in_out",
-            0.0,
+            0,
             null,
             "Optional coefficient for the `units_on` variable impacting the `max_ratio_in_out_unit_flow` constraint."
         ],
         [
             "unit__node__node",
             "max_units_on_coefficient_out_in",
-            0.0,
+            0,
             null,
             "Optional coefficient for the `units_on` variable impacting the `max_ratio_out_in_unit_flow` constraint."
         ],
         [
             "unit__node__node",
             "max_units_on_coefficient_out_out",
-            0.0,
+            0,
             null,
             "Optional coefficient for the `units_on` variable impacting the `max_ratio_out_out_unit_flow` constraint."
         ],
@@ -2584,35 +2860,35 @@
         [
             "unit__node__node",
             "min_units_on_coefficient_in_in",
-            0.0,
+            0,
             null,
             "Optional coefficient for the `units_on` variable impacting the `min_ratio_in_in_unit_flow` constraint."
         ],
         [
             "unit__node__node",
             "min_units_on_coefficient_in_out",
-            0.0,
+            0,
             null,
             "Optional coefficient for the `units_on` variable impacting the `min_ratio_in_out_unit_flow` constraint."
         ],
         [
             "unit__node__node",
             "min_units_on_coefficient_out_in",
-            0.0,
+            0,
             null,
             "Optional coefficient for the `units_on` variable impacting the `min_ratio_out_in_unit_flow` constraint."
         ],
         [
             "unit__node__node",
             "min_units_on_coefficient_out_out",
-            0.0,
+            0,
             null,
             "Optional coefficient for the `units_on` variable impacting the `min_ratio_out_out_unit_flow` constraint."
         ],
         [
             "unit__node__node",
             "unit_idle_heat_rate",
-            0.0,
+            0,
             null,
             "Flow from node1 per unit time and per `units_on` that results in no additional flow to node2"
         ],
@@ -2626,7 +2902,7 @@
         [
             "unit__node__node",
             "unit_start_flow",
-            0.0,
+            0,
             null,
             "Flow from node1 that is incurred when a unit is started up."
         ],
@@ -2793,66 +3069,10 @@
         ],
         [
             "unit__to_node",
-            "max_res_shutdown_ramp",
-            null,
-            null,
-            "Maximum non-spinning reserve ramp-down for online units providing reserves during shut-downs"
-        ],
-        [
-            "unit__to_node",
-            "max_res_startup_ramp",
-            null,
-            null,
-            "Maximum non-spinning reserve ramp-up for offline units scheduled for reserve provision"
-        ],
-        [
-            "unit__to_node",
-            "max_shutdown_ramp",
-            null,
-            null,
-            "Maximum ramp-down during shutdowns"
-        ],
-        [
-            "unit__to_node",
-            "max_startup_ramp",
-            null,
-            null,
-            "Maximum ramp-up during startups"
-        ],
-        [
-            "unit__to_node",
             "max_total_cumulated_unit_flow_to_node",
             null,
             null,
             "Bound on the maximum cumulated flows of a unit group to a node group, e.g. total GHG emissions."
-        ],
-        [
-            "unit__to_node",
-            "min_res_shutdown_ramp",
-            null,
-            null,
-            "Minimum non-spinning reserve ramp-down for online units providing reserves during shut-downs"
-        ],
-        [
-            "unit__to_node",
-            "min_res_startup_ramp",
-            null,
-            null,
-            "Minimum non-spinning reserve ramp-up for offline units scheduled for reserve provision"
-        ],
-        [
-            "unit__to_node",
-            "min_shutdown_ramp",
-            null,
-            null,
-            "Minimum ramp-up during startups"
-        ],
-        [
-            "unit__to_node",
-            "min_startup_ramp",
-            null,
-            null,
-            "Minimum ramp-up during startups"
         ],
         [
             "unit__to_node",
@@ -2864,7 +3084,7 @@
         [
             "unit__to_node",
             "min_unit_flow",
-            0.0,
+            0,
             null,
             "Set lower bound of the `unit_flow` variable."
         ],
@@ -2926,6 +3146,20 @@
         ],
         [
             "unit__to_node",
+            "shut_down_limit",
+            null,
+            null,
+            "Maximum ramp-down during shutdowns"
+        ],
+        [
+            "unit__to_node",
+            "start_up_limit",
+            null,
+            null,
+            "Maximum ramp-up during startups"
+        ],
+        [
+            "unit__to_node",
             "unit_capacity",
             null,
             null,
@@ -2934,7 +3168,7 @@
         [
             "unit__to_node",
             "unit_conv_cap_to_flow",
-            1.0,
+            1,
             null,
             "Optional coefficient for `unit_capacity` unit conversions in the case the `unit_capacity` value is incompatible with the desired `unit_flow` units."
         ],
@@ -2969,35 +3203,35 @@
         [
             "unit__to_node__user_constraint",
             "unit_flow_coefficient",
-            0.0,
+            0,
             null,
             "Coefficient of a `unit_flow` variable for a custom `user_constraint`."
         ],
         [
             "unit__user_constraint",
             "units_invested_available_coefficient",
-            0.0,
+            0,
             null,
             "Coefficient of the `units_invested_available` variable in the specified `user_constraint`."
         ],
         [
             "unit__user_constraint",
             "units_invested_coefficient",
-            0.0,
+            0,
             null,
             "Coefficient of the `units_invested` variable in the specified `user_constraint`."
         ],
         [
             "unit__user_constraint",
             "units_on_coefficient",
-            0.0,
+            0,
             null,
             "Coefficient of a `units_on` variable for a custom `user_constraint`."
         ],
         [
             "unit__user_constraint",
             "units_started_up_coefficient",
-            0.0,
+            0,
             null,
             "Coefficient of a `units_started_up` variable for a custom `user_constraint`."
         ],
@@ -3016,331 +3250,2015 @@
             "If false, the object is excluded from the model if the tool filter object activity control is specified"
         ]
     ],
-    "objects": [
+    "tools": [
         [
-            "model",
-            "simple",
-            null
-        ],
+            "object_activity_control",
+            ""
+        ]
+    ],
+    "object_parameter_values": [
         [
             "node",
             "electricity_node",
-            null
+            "demand",
+            150,
+            "Base"
         ],
         [
             "node",
             "fuel_node",
-            null
+            "balance_type",
+            "balance_type_none",
+            "Base"
         ],
         [
             "node",
             "upward_reserve_group",
-            null
+            "balance_type",
+            "balance_type_none",
+            "Base"
         ],
         [
             "node",
             "upward_reserve_node",
-            null
+            "demand",
+            20,
+            "Base"
         ],
         [
-            "output",
-            "binary_gas_connection_flow",
-            null
+            "node",
+            "upward_reserve_node",
+            "is_reserve_node",
+            true,
+            "Base"
         ],
         [
-            "output",
-            "connection_avg_intact_throughflow",
-            null
+            "node",
+            "upward_reserve_node",
+            "nodal_balance_sense",
+            ">=",
+            "Base"
         ],
         [
-            "output",
-            "connection_avg_throughflow",
-            null
-        ],
-        [
-            "output",
-            "connection_flow",
-            null
-        ],
-        [
-            "output",
-            "connection_flow_costs",
-            null
-        ],
-        [
-            "output",
-            "connection_intact_flow",
-            null
-        ],
-        [
-            "output",
-            "connection_investment_costs",
-            null
-        ],
-        [
-            "output",
-            "connections_decommissioned",
-            null
-        ],
-        [
-            "output",
-            "connections_invested",
-            null
-        ],
-        [
-            "output",
-            "connections_invested_available",
-            null
-        ],
-        [
-            "output",
-            "contingency_is_binding",
-            null
-        ],
-        [
-            "output",
-            "fixed_om_costs",
-            null
-        ],
-        [
-            "output",
-            "fuel_costs",
-            null
-        ],
-        [
-            "output",
-            "mga_objective",
-            null
-        ],
-        [
-            "output",
-            "mp_objective_lowerbound",
-            null
-        ],
-        [
-            "output",
-            "node_injection",
-            null
-        ],
-        [
-            "output",
-            "node_pressure",
-            null
-        ],
-        [
-            "output",
-            "node_slack_neg",
-            null
-        ],
-        [
-            "output",
-            "node_slack_pos",
-            null
-        ],
-        [
-            "output",
-            "node_state",
-            null
-        ],
-        [
-            "output",
-            "node_voltage_angle",
-            null
-        ],
-        [
-            "output",
-            "nonspin_ramp_down_unit_flow",
-            null
-        ],
-        [
-            "output",
-            "nonspin_ramp_up_unit_flow",
-            null
-        ],
-        [
-            "output",
-            "nonspin_units_shut_down",
-            null
-        ],
-        [
-            "output",
-            "nonspin_units_started_up",
-            null
-        ],
-        [
-            "output",
-            "objective_penalties",
-            null
-        ],
-        [
-            "output",
-            "ramp_costs",
-            null
-        ],
-        [
-            "output",
-            "ramp_down_unit_flow",
-            null
-        ],
-        [
-            "output",
-            "ramp_up_unit_flow",
-            null
-        ],
-        [
-            "output",
-            "renewable_curtailment_costs",
-            null
-        ],
-        [
-            "output",
-            "res_proc_costs",
-            null
-        ],
-        [
-            "output",
-            "shut_down_costs",
-            null
-        ],
-        [
-            "output",
-            "shut_down_unit_flow",
-            null
-        ],
-        [
-            "output",
-            "start_up_costs",
-            null
-        ],
-        [
-            "output",
-            "start_up_unit_flow",
-            null
-        ],
-        [
-            "output",
-            "storage_investment_costs",
-            null
-        ],
-        [
-            "output",
-            "storages_decommissioned",
-            null
-        ],
-        [
-            "output",
-            "storages_invested",
-            null
-        ],
-        [
-            "output",
-            "storages_invested_available",
-            null
-        ],
-        [
-            "output",
-            "taxes",
-            null
-        ],
-        [
-            "output",
-            "total_costs",
-            null
-        ],
-        [
-            "output",
-            "unit_flow",
-            null
-        ],
-        [
-            "output",
-            "unit_flow_op",
-            null
-        ],
-        [
-            "output",
-            "unit_flow_op_active",
-            null
-        ],
-        [
-            "output",
-            "unit_investment_costs",
-            null
-        ],
-        [
-            "output",
-            "units_available",
-            null
-        ],
-        [
-            "output",
-            "units_invested",
-            null
-        ],
-        [
-            "output",
-            "units_invested_available",
-            null
-        ],
-        [
-            "output",
-            "units_mothballed",
-            null
-        ],
-        [
-            "output",
-            "units_on",
-            null
-        ],
-        [
-            "output",
-            "units_on_costs",
-            null
-        ],
-        [
-            "output",
-            "units_shut_down",
-            null
-        ],
-        [
-            "output",
-            "units_started_up",
-            null
-        ],
-        [
-            "output",
-            "variable_om_costs",
-            null
-        ],
-        [
-            "report",
-            "report1",
-            null
-        ],
-        [
-            "stochastic_scenario",
-            "realization",
-            null
-        ],
-        [
-            "stochastic_structure",
-            "deterministic",
-            null
+            "node",
+            "upward_reserve_node",
+            "upward_reserve",
+            true,
+            "Base"
         ],
         [
             "temporal_block",
             "flat",
-            null
+            "resolution",
+            {
+                "data": "1D",
+                "type": "duration"
+            },
+            "Base"
+        ]
+    ],
+    "tool_feature_methods": [
+        [
+            "object_activity_control",
+            "commodity",
+            "is_active",
+            [
+                [
+                    116,
+                    114,
+                    117,
+                    101
+                ],
+                null
+            ]
         ],
         [
-            "unit",
-            "power_plant_a",
-            null
+            "object_activity_control",
+            "connection",
+            "is_active",
+            [
+                [
+                    116,
+                    114,
+                    117,
+                    101
+                ],
+                null
+            ]
         ],
         [
+            "object_activity_control",
+            "model",
+            "is_active",
+            [
+                [
+                    116,
+                    114,
+                    117,
+                    101
+                ],
+                null
+            ]
+        ],
+        [
+            "object_activity_control",
+            "node",
+            "is_active",
+            [
+                [
+                    116,
+                    114,
+                    117,
+                    101
+                ],
+                null
+            ]
+        ],
+        [
+            "object_activity_control",
+            "node__stochastic_structure",
+            "is_active",
+            [
+                [
+                    116,
+                    114,
+                    117,
+                    101
+                ],
+                null
+            ]
+        ],
+        [
+            "object_activity_control",
+            "node__temporal_block",
+            "is_active",
+            [
+                [
+                    116,
+                    114,
+                    117,
+                    101
+                ],
+                null
+            ]
+        ],
+        [
+            "object_activity_control",
+            "output",
+            "is_active",
+            [
+                [
+                    116,
+                    114,
+                    117,
+                    101
+                ],
+                null
+            ]
+        ],
+        [
+            "object_activity_control",
+            "report",
+            "is_active",
+            [
+                [
+                    116,
+                    114,
+                    117,
+                    101
+                ],
+                null
+            ]
+        ],
+        [
+            "object_activity_control",
+            "stochastic_scenario",
+            "is_active",
+            [
+                [
+                    116,
+                    114,
+                    117,
+                    101
+                ],
+                null
+            ]
+        ],
+        [
+            "object_activity_control",
+            "stochastic_structure",
+            "is_active",
+            [
+                [
+                    116,
+                    114,
+                    117,
+                    101
+                ],
+                null
+            ]
+        ],
+        [
+            "object_activity_control",
+            "temporal_block",
+            "is_active",
+            [
+                [
+                    116,
+                    114,
+                    117,
+                    101
+                ],
+                null
+            ]
+        ],
+        [
+            "object_activity_control",
             "unit",
-            "power_plant_b",
-            null
+            "is_active",
+            [
+                [
+                    116,
+                    114,
+                    117,
+                    101
+                ],
+                null
+            ]
+        ],
+        [
+            "object_activity_control",
+            "unit__from_node",
+            "is_active",
+            [
+                [
+                    116,
+                    114,
+                    117,
+                    101
+                ],
+                null
+            ]
+        ],
+        [
+            "object_activity_control",
+            "unit__to_node",
+            "is_active",
+            [
+                [
+                    116,
+                    114,
+                    117,
+                    101
+                ],
+                null
+            ]
+        ],
+        [
+            "object_activity_control",
+            "units_on__stochastic_structure",
+            "is_active",
+            [
+                [
+                    116,
+                    114,
+                    117,
+                    101
+                ],
+                null
+            ]
+        ],
+        [
+            "object_activity_control",
+            "units_on__temporal_block",
+            "is_active",
+            [
+                [
+                    116,
+                    114,
+                    117,
+                    101
+                ],
+                null
+            ]
+        ],
+        [
+            "object_activity_control",
+            "user_constraint",
+            "is_active",
+            [
+                [
+                    116,
+                    114,
+                    117,
+                    101
+                ],
+                null
+            ]
+        ]
+    ],
+    "parameter_value_lists": [
+        [
+            "balance_type_list",
+            [
+                [
+                    34,
+                    98,
+                    97,
+                    108,
+                    97,
+                    110,
+                    99,
+                    101,
+                    95,
+                    116,
+                    121,
+                    112,
+                    101,
+                    95,
+                    103,
+                    114,
+                    111,
+                    117,
+                    112,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "balance_type_list",
+            [
+                [
+                    34,
+                    98,
+                    97,
+                    108,
+                    97,
+                    110,
+                    99,
+                    101,
+                    95,
+                    116,
+                    121,
+                    112,
+                    101,
+                    95,
+                    110,
+                    111,
+                    100,
+                    101,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "balance_type_list",
+            [
+                [
+                    34,
+                    98,
+                    97,
+                    108,
+                    97,
+                    110,
+                    99,
+                    101,
+                    95,
+                    116,
+                    121,
+                    112,
+                    101,
+                    95,
+                    110,
+                    111,
+                    110,
+                    101,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "boolean_value_list",
+            [
+                [
+                    102,
+                    97,
+                    108,
+                    115,
+                    101
+                ],
+                null
+            ]
+        ],
+        [
+            "boolean_value_list",
+            [
+                [
+                    116,
+                    114,
+                    117,
+                    101
+                ],
+                null
+            ]
+        ],
+        [
+            "commodity_physics_list",
+            [
+                [
+                    34,
+                    99,
+                    111,
+                    109,
+                    109,
+                    111,
+                    100,
+                    105,
+                    116,
+                    121,
+                    95,
+                    112,
+                    104,
+                    121,
+                    115,
+                    105,
+                    99,
+                    115,
+                    95,
+                    108,
+                    111,
+                    100,
+                    102,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "commodity_physics_list",
+            [
+                [
+                    34,
+                    99,
+                    111,
+                    109,
+                    109,
+                    111,
+                    100,
+                    105,
+                    116,
+                    121,
+                    95,
+                    112,
+                    104,
+                    121,
+                    115,
+                    105,
+                    99,
+                    115,
+                    95,
+                    110,
+                    111,
+                    110,
+                    101,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "commodity_physics_list",
+            [
+                [
+                    34,
+                    99,
+                    111,
+                    109,
+                    109,
+                    111,
+                    100,
+                    105,
+                    116,
+                    121,
+                    95,
+                    112,
+                    104,
+                    121,
+                    115,
+                    105,
+                    99,
+                    115,
+                    95,
+                    112,
+                    116,
+                    100,
+                    102,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "connection_investment_variable_type_list",
+            [
+                [
+                    34,
+                    99,
+                    111,
+                    110,
+                    110,
+                    101,
+                    99,
+                    116,
+                    105,
+                    111,
+                    110,
+                    95,
+                    105,
+                    110,
+                    118,
+                    101,
+                    115,
+                    116,
+                    109,
+                    101,
+                    110,
+                    116,
+                    95,
+                    118,
+                    97,
+                    114,
+                    105,
+                    97,
+                    98,
+                    108,
+                    101,
+                    95,
+                    116,
+                    121,
+                    112,
+                    101,
+                    95,
+                    99,
+                    111,
+                    110,
+                    116,
+                    105,
+                    110,
+                    117,
+                    111,
+                    117,
+                    115,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "connection_investment_variable_type_list",
+            [
+                [
+                    34,
+                    99,
+                    111,
+                    110,
+                    110,
+                    101,
+                    99,
+                    116,
+                    105,
+                    111,
+                    110,
+                    95,
+                    105,
+                    110,
+                    118,
+                    101,
+                    115,
+                    116,
+                    109,
+                    101,
+                    110,
+                    116,
+                    95,
+                    118,
+                    97,
+                    114,
+                    105,
+                    97,
+                    98,
+                    108,
+                    101,
+                    95,
+                    116,
+                    121,
+                    112,
+                    101,
+                    95,
+                    105,
+                    110,
+                    116,
+                    101,
+                    103,
+                    101,
+                    114,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "connection_type_list",
+            [
+                [
+                    34,
+                    99,
+                    111,
+                    110,
+                    110,
+                    101,
+                    99,
+                    116,
+                    105,
+                    111,
+                    110,
+                    95,
+                    116,
+                    121,
+                    112,
+                    101,
+                    95,
+                    108,
+                    111,
+                    115,
+                    115,
+                    108,
+                    101,
+                    115,
+                    115,
+                    95,
+                    98,
+                    105,
+                    100,
+                    105,
+                    114,
+                    101,
+                    99,
+                    116,
+                    105,
+                    111,
+                    110,
+                    97,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "connection_type_list",
+            [
+                [
+                    34,
+                    99,
+                    111,
+                    110,
+                    110,
+                    101,
+                    99,
+                    116,
+                    105,
+                    111,
+                    110,
+                    95,
+                    116,
+                    121,
+                    112,
+                    101,
+                    95,
+                    110,
+                    111,
+                    114,
+                    109,
+                    97,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "constraint_sense_list",
+            [
+                [
+                    34,
+                    60,
+                    61,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "constraint_sense_list",
+            [
+                [
+                    34,
+                    61,
+                    61,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "constraint_sense_list",
+            [
+                [
+                    34,
+                    62,
+                    61,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_lp_solver_list",
+            [
+                [
+                    34,
+                    75,
+                    78,
+                    73,
+                    84,
+                    82,
+                    79,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_lp_solver_list",
+            [
+                [
+                    34,
+                    67,
+                    68,
+                    67,
+                    83,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_lp_solver_list",
+            [
+                [
+                    34,
+                    67,
+                    68,
+                    68,
+                    76,
+                    105,
+                    98,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_lp_solver_list",
+            [
+                [
+                    34,
+                    67,
+                    108,
+                    112,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_lp_solver_list",
+            [
+                [
+                    34,
+                    67,
+                    79,
+                    83,
+                    77,
+                    79,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_lp_solver_list",
+            [
+                [
+                    34,
+                    67,
+                    80,
+                    76,
+                    69,
+                    88,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_lp_solver_list",
+            [
+                [
+                    34,
+                    67,
+                    83,
+                    68,
+                    80,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_lp_solver_list",
+            [
+                [
+                    34,
+                    69,
+                    67,
+                    79,
+                    83,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_lp_solver_list",
+            [
+                [
+                    34,
+                    88,
+                    112,
+                    114,
+                    101,
+                    115,
+                    115,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_lp_solver_list",
+            [
+                [
+                    34,
+                    71,
+                    76,
+                    80,
+                    75,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_lp_solver_list",
+            [
+                [
+                    34,
+                    71,
+                    117,
+                    114,
+                    111,
+                    98,
+                    105,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_lp_solver_list",
+            [
+                [
+                    34,
+                    72,
+                    105,
+                    71,
+                    72,
+                    83,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_lp_solver_list",
+            [
+                [
+                    34,
+                    72,
+                    121,
+                    112,
+                    97,
+                    116,
+                    105,
+                    97,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_lp_solver_list",
+            [
+                [
+                    34,
+                    73,
+                    112,
+                    111,
+                    112,
+                    116,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_lp_solver_list",
+            [
+                [
+                    34,
+                    77,
+                    97,
+                    100,
+                    78,
+                    76,
+                    80,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_lp_solver_list",
+            [
+                [
+                    34,
+                    77,
+                    111,
+                    115,
+                    101,
+                    107,
+                    84,
+                    111,
+                    111,
+                    108,
+                    115,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_lp_solver_list",
+            [
+                [
+                    34,
+                    78,
+                    76,
+                    111,
+                    112,
+                    116,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_lp_solver_list",
+            [
+                [
+                    34,
+                    79,
+                    83,
+                    81,
+                    80,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_lp_solver_list",
+            [
+                [
+                    34,
+                    80,
+                    114,
+                    111,
+                    120,
+                    83,
+                    68,
+                    80,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_lp_solver_list",
+            [
+                [
+                    34,
+                    83,
+                    67,
+                    73,
+                    80,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_lp_solver_list",
+            [
+                [
+                    34,
+                    83,
+                    67,
+                    83,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_lp_solver_list",
+            [
+                [
+                    34,
+                    83,
+                    68,
+                    80,
+                    65,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_lp_solver_list",
+            [
+                [
+                    34,
+                    83,
+                    68,
+                    80,
+                    78,
+                    65,
+                    76,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_lp_solver_list",
+            [
+                [
+                    34,
+                    83,
+                    68,
+                    80,
+                    84,
+                    51,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_lp_solver_list",
+            [
+                [
+                    34,
+                    83,
+                    101,
+                    68,
+                    117,
+                    77,
+                    105,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_mip_solver_list",
+            [
+                [
+                    34,
+                    75,
+                    78,
+                    73,
+                    84,
+                    82,
+                    79,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_mip_solver_list",
+            [
+                [
+                    34,
+                    67,
+                    98,
+                    99,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_mip_solver_list",
+            [
+                [
+                    34,
+                    67,
+                    80,
+                    76,
+                    69,
+                    88,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_mip_solver_list",
+            [
+                [
+                    34,
+                    72,
+                    105,
+                    71,
+                    72,
+                    83,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_mip_solver_list",
+            [
+                [
+                    34,
+                    88,
+                    112,
+                    114,
+                    101,
+                    115,
+                    115,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_mip_solver_list",
+            [
+                [
+                    34,
+                    71,
+                    76,
+                    80,
+                    75,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_mip_solver_list",
+            [
+                [
+                    34,
+                    71,
+                    117,
+                    114,
+                    111,
+                    98,
+                    105,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_mip_solver_list",
+            [
+                [
+                    34,
+                    74,
+                    117,
+                    110,
+                    105,
+                    112,
+                    101,
+                    114,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_mip_solver_list",
+            [
+                [
+                    34,
+                    77,
+                    111,
+                    115,
+                    101,
+                    107,
+                    84,
+                    111,
+                    111,
+                    108,
+                    115,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_mip_solver_list",
+            [
+                [
+                    34,
+                    83,
+                    67,
+                    73,
+                    80,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "duration_unit_list",
+            [
+                [
+                    34,
+                    104,
+                    111,
+                    117,
+                    114,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "duration_unit_list",
+            [
+                [
+                    34,
+                    109,
+                    105,
+                    110,
+                    117,
+                    116,
+                    101,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "model_type_list",
+            [
+                [
+                    34,
+                    115,
+                    112,
+                    105,
+                    110,
+                    101,
+                    111,
+                    112,
+                    116,
+                    95,
+                    98,
+                    101,
+                    110,
+                    100,
+                    101,
+                    114,
+                    115,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "model_type_list",
+            [
+                [
+                    34,
+                    115,
+                    112,
+                    105,
+                    110,
+                    101,
+                    111,
+                    112,
+                    116,
+                    95,
+                    115,
+                    116,
+                    97,
+                    110,
+                    100,
+                    97,
+                    114,
+                    100,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "model_type_list",
+            [
+                [
+                    34,
+                    115,
+                    112,
+                    105,
+                    110,
+                    101,
+                    111,
+                    112,
+                    116,
+                    95,
+                    111,
+                    116,
+                    104,
+                    101,
+                    114,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "model_type_list",
+            [
+                [
+                    34,
+                    115,
+                    112,
+                    105,
+                    110,
+                    101,
+                    111,
+                    112,
+                    116,
+                    95,
+                    109,
+                    103,
+                    97,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "node_opf_type_list",
+            [
+                [
+                    34,
+                    110,
+                    111,
+                    100,
+                    101,
+                    95,
+                    111,
+                    112,
+                    102,
+                    95,
+                    116,
+                    121,
+                    112,
+                    101,
+                    95,
+                    110,
+                    111,
+                    114,
+                    109,
+                    97,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "node_opf_type_list",
+            [
+                [
+                    34,
+                    110,
+                    111,
+                    100,
+                    101,
+                    95,
+                    111,
+                    112,
+                    102,
+                    95,
+                    116,
+                    121,
+                    112,
+                    101,
+                    95,
+                    114,
+                    101,
+                    102,
+                    101,
+                    114,
+                    101,
+                    110,
+                    99,
+                    101,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "unit_investment_variable_type_list",
+            [
+                [
+                    34,
+                    117,
+                    110,
+                    105,
+                    116,
+                    95,
+                    105,
+                    110,
+                    118,
+                    101,
+                    115,
+                    116,
+                    109,
+                    101,
+                    110,
+                    116,
+                    95,
+                    118,
+                    97,
+                    114,
+                    105,
+                    97,
+                    98,
+                    108,
+                    101,
+                    95,
+                    116,
+                    121,
+                    112,
+                    101,
+                    95,
+                    99,
+                    111,
+                    110,
+                    116,
+                    105,
+                    110,
+                    117,
+                    111,
+                    117,
+                    115,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "unit_investment_variable_type_list",
+            [
+                [
+                    34,
+                    117,
+                    110,
+                    105,
+                    116,
+                    95,
+                    105,
+                    110,
+                    118,
+                    101,
+                    115,
+                    116,
+                    109,
+                    101,
+                    110,
+                    116,
+                    95,
+                    118,
+                    97,
+                    114,
+                    105,
+                    97,
+                    98,
+                    108,
+                    101,
+                    95,
+                    116,
+                    121,
+                    112,
+                    101,
+                    95,
+                    105,
+                    110,
+                    116,
+                    101,
+                    103,
+                    101,
+                    114,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "unit_online_variable_type_list",
+            [
+                [
+                    34,
+                    117,
+                    110,
+                    105,
+                    116,
+                    95,
+                    111,
+                    110,
+                    108,
+                    105,
+                    110,
+                    101,
+                    95,
+                    118,
+                    97,
+                    114,
+                    105,
+                    97,
+                    98,
+                    108,
+                    101,
+                    95,
+                    116,
+                    121,
+                    112,
+                    101,
+                    95,
+                    98,
+                    105,
+                    110,
+                    97,
+                    114,
+                    121,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "unit_online_variable_type_list",
+            [
+                [
+                    34,
+                    117,
+                    110,
+                    105,
+                    116,
+                    95,
+                    111,
+                    110,
+                    108,
+                    105,
+                    110,
+                    101,
+                    95,
+                    118,
+                    97,
+                    114,
+                    105,
+                    97,
+                    98,
+                    108,
+                    101,
+                    95,
+                    116,
+                    121,
+                    112,
+                    101,
+                    95,
+                    105,
+                    110,
+                    116,
+                    101,
+                    103,
+                    101,
+                    114,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "unit_online_variable_type_list",
+            [
+                [
+                    34,
+                    117,
+                    110,
+                    105,
+                    116,
+                    95,
+                    111,
+                    110,
+                    108,
+                    105,
+                    110,
+                    101,
+                    95,
+                    118,
+                    97,
+                    114,
+                    105,
+                    97,
+                    98,
+                    108,
+                    101,
+                    95,
+                    116,
+                    121,
+                    112,
+                    101,
+                    95,
+                    108,
+                    105,
+                    110,
+                    101,
+                    97,
+                    114,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "unit_online_variable_type_list",
+            [
+                [
+                    34,
+                    117,
+                    110,
+                    105,
+                    116,
+                    95,
+                    111,
+                    110,
+                    108,
+                    105,
+                    110,
+                    101,
+                    95,
+                    118,
+                    97,
+                    114,
+                    105,
+                    97,
+                    98,
+                    108,
+                    101,
+                    95,
+                    116,
+                    121,
+                    112,
+                    101,
+                    95,
+                    110,
+                    111,
+                    110,
+                    101,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "variable_type_list",
+            [
+                [
+                    34,
+                    118,
+                    97,
+                    114,
+                    105,
+                    97,
+                    98,
+                    108,
+                    101,
+                    95,
+                    116,
+                    121,
+                    112,
+                    101,
+                    95,
+                    98,
+                    105,
+                    110,
+                    97,
+                    114,
+                    121,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "variable_type_list",
+            [
+                [
+                    34,
+                    118,
+                    97,
+                    114,
+                    105,
+                    97,
+                    98,
+                    108,
+                    101,
+                    95,
+                    116,
+                    121,
+                    112,
+                    101,
+                    95,
+                    99,
+                    111,
+                    110,
+                    116,
+                    105,
+                    110,
+                    117,
+                    111,
+                    117,
+                    115,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "variable_type_list",
+            [
+                [
+                    34,
+                    118,
+                    97,
+                    114,
+                    105,
+                    97,
+                    98,
+                    108,
+                    101,
+                    95,
+                    116,
+                    121,
+                    112,
+                    101,
+                    95,
+                    105,
+                    110,
+                    116,
+                    101,
+                    103,
+                    101,
+                    114,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "write_mps_file_list",
+            [
+                [
+                    34,
+                    119,
+                    114,
+                    105,
+                    116,
+                    101,
+                    95,
+                    109,
+                    112,
+                    115,
+                    95,
+                    97,
+                    108,
+                    119,
+                    97,
+                    121,
+                    115,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "write_mps_file_list",
+            [
+                [
+                    34,
+                    119,
+                    114,
+                    105,
+                    116,
+                    101,
+                    95,
+                    109,
+                    112,
+                    115,
+                    95,
+                    110,
+                    101,
+                    118,
+                    101,
+                    114,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "write_mps_file_list",
+            [
+                [
+                    34,
+                    119,
+                    114,
+                    105,
+                    116,
+                    101,
+                    95,
+                    109,
+                    112,
+                    115,
+                    95,
+                    111,
+                    110,
+                    95,
+                    110,
+                    111,
+                    95,
+                    115,
+                    111,
+                    108,
+                    118,
+                    101,
+                    34
+                ],
+                null
+            ]
         ]
     ],
     "relationships": [
@@ -3480,233 +5398,108 @@
             ]
         ]
     ],
-    "object_groups": [
-        [
-            "node",
-            "upward_reserve_group",
-            "electricity_node"
-        ],
-        [
-            "node",
-            "upward_reserve_group",
-            "upward_reserve_node"
-        ]
-    ],
-    "object_parameter_values": [
-        [
-            "node",
-            "electricity_node",
-            "demand",
-            150.0,
-            "Base"
-        ],
-        [
-            "node",
-            "fuel_node",
-            "balance_type",
-            "balance_type_none",
-            "Base"
-        ],
-        [
-            "node",
-            "upward_reserve_group",
-            "balance_type",
-            "balance_type_none",
-            "Base"
-        ],
-        [
-            "node",
-            "upward_reserve_node",
-            "demand",
-            20,
-            "Base"
-        ],
-        [
-            "node",
-            "upward_reserve_node",
-            "is_reserve_node",
-            true,
-            "Base"
-        ],
-        [
-            "node",
-            "upward_reserve_node",
-            "nodal_balance_sense",
-            ">=",
-            "Base"
-        ],
-        [
-            "node",
-            "upward_reserve_node",
-            "upward_reserve",
-            true,
-            "Base"
-        ],
-        [
-            "temporal_block",
-            "flat",
-            "resolution",
-            {
-                "type": "duration",
-                "data": "1D"
-            },
-            "Base"
-        ]
-    ],
-    "relationship_parameter_values": [
-        [
-            "unit__from_node",
-            [
-                "power_plant_a",
-                "fuel_node"
-            ],
-            "vom_cost",
-            25,
-            "Base"
-        ],
-        [
-            "unit__from_node",
-            [
-                "power_plant_b",
-                "fuel_node"
-            ],
-            "vom_cost",
-            50,
-            "Base"
-        ],
-        [
-            "unit__node__node",
-            [
-                "power_plant_a",
-                "electricity_node",
-                "fuel_node"
-            ],
-            "fix_ratio_out_in_unit_flow",
-            0.7,
-            "Base"
-        ],
-        [
-            "unit__node__node",
-            [
-                "power_plant_b",
-                "electricity_node",
-                "fuel_node"
-            ],
-            "fix_ratio_out_in_unit_flow",
-            0.8,
-            "Base"
-        ],
-        [
-            "unit__to_node",
-            [
-                "power_plant_a",
-                "electricity_node"
-            ],
-            "unit_capacity",
-            100,
-            "Base"
-        ],
-        [
-            "unit__to_node",
-            [
-                "power_plant_a",
-                "upward_reserve_group"
-            ],
-            "ramp_up_limit",
-            1,
-            "Base"
-        ],
-        [
-            "unit__to_node",
-            [
-                "power_plant_a",
-                "upward_reserve_group"
-            ],
-            "unit_capacity",
-            100.0,
-            "Base"
-        ],
-        [
-            "unit__to_node",
-            [
-                "power_plant_a",
-                "upward_reserve_node"
-            ],
-            "reserve_procurement_cost",
-            5,
-            "Base"
-        ],
-        [
-            "unit__to_node",
-            [
-                "power_plant_a",
-                "upward_reserve_node"
-            ],
-            "unit_capacity",
-            100,
-            "Base"
-        ],
-        [
-            "unit__to_node",
-            [
-                "power_plant_b",
-                "electricity_node"
-            ],
-            "unit_capacity",
-            200.0,
-            "Base"
-        ],
-        [
-            "unit__to_node",
-            [
-                "power_plant_b",
-                "upward_reserve_group"
-            ],
-            "ramp_up_limit",
-            1,
-            "Base"
-        ],
-        [
-            "unit__to_node",
-            [
-                "power_plant_b",
-                "upward_reserve_group"
-            ],
-            "unit_capacity",
-            200.0,
-            "Base"
-        ],
-        [
-            "unit__to_node",
-            [
-                "power_plant_b",
-                "upward_reserve_node"
-            ],
-            "reserve_procurement_cost",
-            35,
-            "Base"
-        ],
-        [
-            "unit__to_node",
-            [
-                "power_plant_b",
-                "upward_reserve_node"
-            ],
-            "unit_capacity",
-            200.0,
-            "Base"
-        ]
-    ],
-    "alternatives": [
-        [
-            "Base",
-            "Base alternative"
-        ]
-    ],
-    "tools": [
+    "tool_features": [
         [
             "object_activity_control",
-            ""
+            "commodity",
+            "is_active",
+            false
+        ],
+        [
+            "object_activity_control",
+            "connection",
+            "is_active",
+            false
+        ],
+        [
+            "object_activity_control",
+            "model",
+            "is_active",
+            false
+        ],
+        [
+            "object_activity_control",
+            "node",
+            "is_active",
+            false
+        ],
+        [
+            "object_activity_control",
+            "node__stochastic_structure",
+            "is_active",
+            false
+        ],
+        [
+            "object_activity_control",
+            "node__temporal_block",
+            "is_active",
+            false
+        ],
+        [
+            "object_activity_control",
+            "output",
+            "is_active",
+            false
+        ],
+        [
+            "object_activity_control",
+            "report",
+            "is_active",
+            false
+        ],
+        [
+            "object_activity_control",
+            "stochastic_scenario",
+            "is_active",
+            false
+        ],
+        [
+            "object_activity_control",
+            "stochastic_structure",
+            "is_active",
+            false
+        ],
+        [
+            "object_activity_control",
+            "temporal_block",
+            "is_active",
+            false
+        ],
+        [
+            "object_activity_control",
+            "unit",
+            "is_active",
+            false
+        ],
+        [
+            "object_activity_control",
+            "unit__from_node",
+            "is_active",
+            false
+        ],
+        [
+            "object_activity_control",
+            "unit__to_node",
+            "is_active",
+            false
+        ],
+        [
+            "object_activity_control",
+            "units_on__stochastic_structure",
+            "is_active",
+            false
+        ],
+        [
+            "object_activity_control",
+            "units_on__temporal_block",
+            "is_active",
+            false
+        ],
+        [
+            "object_activity_control",
+            "user_constraint",
+            "is_active",
+            false
         ]
     ],
     "features": [
@@ -3813,212 +5606,71 @@
             "boolean_value_list"
         ]
     ],
-    "tool_features": [
+    "object_classes": [
         [
-            "object_activity_control",
             "commodity",
-            "is_active",
-            false
+            "A good or product that can be consumed, produced, traded. E.g., electricity, oil, gas, water...",
+            281473533932880
         ],
         [
-            "object_activity_control",
             "connection",
-            "is_active",
-            false
+            "A transfer of commodities between nodes. E.g. electricity line, gas pipeline...",
+            280378317271233
         ],
         [
-            "object_activity_control",
+            "investment_group",
+            "A group of investments that need to be done together.",
+            281105609585860
+        ],
+        [
             "model",
-            "is_active",
-            false
+            "An instance of SpineOpt, that specifies general parameters such as the temporal horizon.",
+            281107035648412
         ],
         [
-            "object_activity_control",
             "node",
-            "is_active",
-            false
+            "A universal aggregator of commodify flows over units and connections, with storage capabilities.",
+            280740554077951
         ],
         [
-            "object_activity_control",
-            "node__stochastic_structure",
-            "is_active",
-            false
-        ],
-        [
-            "object_activity_control",
-            "node__temporal_block",
-            "is_active",
-            false
-        ],
-        [
-            "object_activity_control",
             "output",
-            "is_active",
-            false
+            "A variable name from SpineOpt that can be included in a report.",
+            280743406202948
         ],
         [
-            "object_activity_control",
             "report",
-            "is_active",
-            false
+            "A results report from a particular SpineOpt run, including the value of specific variables.",
+            281108461711708
         ],
         [
-            "object_activity_control",
+            "settings",
+            "Internal SpineOpt settings. We kindly advise not to mess with this one.",
+            280375465144798
+        ],
+        [
             "stochastic_scenario",
-            "is_active",
-            false
+            "A scenario for stochastic optimisation in SpineOpt.",
+            280743389491710
         ],
         [
-            "object_activity_control",
             "stochastic_structure",
-            "is_active",
-            false
+            "A group of stochastic scenarios that represent a structure.",
+            281470681806146
         ],
         [
-            "object_activity_control",
             "temporal_block",
-            "is_active",
-            false
+            "A length of time with a particular resolution.",
+            280376891207703
         ],
         [
-            "object_activity_control",
             "unit",
-            "is_active",
-            false
+            "A conversion of one/many comodities between nodes.",
+            281470681805429
         ],
         [
-            "object_activity_control",
-            "unit__from_node",
-            "is_active",
-            false
-        ],
-        [
-            "object_activity_control",
-            "unit__to_node",
-            "is_active",
-            false
-        ],
-        [
-            "object_activity_control",
-            "units_on__stochastic_structure",
-            "is_active",
-            false
-        ],
-        [
-            "object_activity_control",
-            "units_on__temporal_block",
-            "is_active",
-            false
-        ],
-        [
-            "object_activity_control",
             "user_constraint",
-            "is_active",
-            false
-        ]
-    ],
-    "tool_feature_methods": [
-        [
-            "object_activity_control",
-            "commodity",
-            "is_active",
-            true
-        ],
-        [
-            "object_activity_control",
-            "connection",
-            "is_active",
-            true
-        ],
-        [
-            "object_activity_control",
-            "model",
-            "is_active",
-            true
-        ],
-        [
-            "object_activity_control",
-            "node",
-            "is_active",
-            true
-        ],
-        [
-            "object_activity_control",
-            "node__stochastic_structure",
-            "is_active",
-            true
-        ],
-        [
-            "object_activity_control",
-            "node__temporal_block",
-            "is_active",
-            true
-        ],
-        [
-            "object_activity_control",
-            "output",
-            "is_active",
-            true
-        ],
-        [
-            "object_activity_control",
-            "report",
-            "is_active",
-            true
-        ],
-        [
-            "object_activity_control",
-            "stochastic_scenario",
-            "is_active",
-            true
-        ],
-        [
-            "object_activity_control",
-            "stochastic_structure",
-            "is_active",
-            true
-        ],
-        [
-            "object_activity_control",
-            "temporal_block",
-            "is_active",
-            true
-        ],
-        [
-            "object_activity_control",
-            "unit",
-            "is_active",
-            true
-        ],
-        [
-            "object_activity_control",
-            "unit__from_node",
-            "is_active",
-            true
-        ],
-        [
-            "object_activity_control",
-            "unit__to_node",
-            "is_active",
-            true
-        ],
-        [
-            "object_activity_control",
-            "units_on__stochastic_structure",
-            "is_active",
-            true
-        ],
-        [
-            "object_activity_control",
-            "units_on__temporal_block",
-            "is_active",
-            true
-        ],
-        [
-            "object_activity_control",
-            "user_constraint",
-            "is_active",
-            true
+            "A generic data-driven custom constraint.",
+            281473533931636
         ]
     ]
 }

--- a/examples/simple_system.json
+++ b/examples/simple_system.json
@@ -1,69 +1,330 @@
 {
-    "object_classes": [
+    "alternatives": [
         [
-            "commodity",
-            "A good or product that can be consumed, produced, traded. E.g., electricity, oil, gas, water...",
-            281473533932880
-        ],
-        [
-            "connection",
-            "A transfer of commodities between nodes. E.g. electricity line, gas pipeline...",
-            280378317271233
-        ],
-        [
-            "investment_group",
-            "A group of investments that need to be done together.",
-            281105609585860
-        ],
+            "Base",
+            "Base alternative"
+        ]
+    ],
+    "objects": [
         [
             "model",
-            "An instance of SpineOpt, that specifies general parameters such as the temporal horizon.",
-            281107035648412
+            "simple",
+            null
         ],
         [
             "node",
-            "A universal aggregator of commodify flows over units and connections, with storage capabilities.",
-            280740554077951
+            "electricity_node",
+            null
+        ],
+        [
+            "node",
+            "fuel_node",
+            null
         ],
         [
             "output",
-            "A variable name from SpineOpt that can be included in a report.",
-            280743406202948
+            "binary_gas_connection_flow",
+            null
+        ],
+        [
+            "output",
+            "connection_avg_intact_throughflow",
+            null
+        ],
+        [
+            "output",
+            "connection_avg_throughflow",
+            null
+        ],
+        [
+            "output",
+            "connection_flow",
+            null
+        ],
+        [
+            "output",
+            "connection_flow_costs",
+            null
+        ],
+        [
+            "output",
+            "connection_intact_flow",
+            null
+        ],
+        [
+            "output",
+            "connection_investment_costs",
+            null
+        ],
+        [
+            "output",
+            "connections_decommissioned",
+            null
+        ],
+        [
+            "output",
+            "connections_invested",
+            null
+        ],
+        [
+            "output",
+            "connections_invested_available",
+            null
+        ],
+        [
+            "output",
+            "contingency_is_binding",
+            null
+        ],
+        [
+            "output",
+            "fixed_om_costs",
+            null
+        ],
+        [
+            "output",
+            "fuel_costs",
+            null
+        ],
+        [
+            "output",
+            "mga_objective",
+            null
+        ],
+        [
+            "output",
+            "mp_objective_lowerbound",
+            null
+        ],
+        [
+            "output",
+            "node_injection",
+            null
+        ],
+        [
+            "output",
+            "node_pressure",
+            null
+        ],
+        [
+            "output",
+            "node_slack_neg",
+            null
+        ],
+        [
+            "output",
+            "node_slack_pos",
+            null
+        ],
+        [
+            "output",
+            "node_state",
+            null
+        ],
+        [
+            "output",
+            "node_voltage_angle",
+            null
+        ],
+        [
+            "output",
+            "nonspin_ramp_down_unit_flow",
+            null
+        ],
+        [
+            "output",
+            "nonspin_ramp_up_unit_flow",
+            null
+        ],
+        [
+            "output",
+            "nonspin_units_shut_down",
+            null
+        ],
+        [
+            "output",
+            "nonspin_units_started_up",
+            null
+        ],
+        [
+            "output",
+            "objective_penalties",
+            null
+        ],
+        [
+            "output",
+            "ramp_costs",
+            null
+        ],
+        [
+            "output",
+            "ramp_down_unit_flow",
+            null
+        ],
+        [
+            "output",
+            "ramp_up_unit_flow",
+            null
+        ],
+        [
+            "output",
+            "relative_optimality_gap",
+            null
+        ],
+        [
+            "output",
+            "renewable_curtailment_costs",
+            null
+        ],
+        [
+            "output",
+            "res_proc_costs",
+            null
+        ],
+        [
+            "output",
+            "shut_down_costs",
+            null
+        ],
+        [
+            "output",
+            "shut_down_unit_flow",
+            null
+        ],
+        [
+            "output",
+            "start_up_costs",
+            null
+        ],
+        [
+            "output",
+            "start_up_unit_flow",
+            null
+        ],
+        [
+            "output",
+            "storage_investment_costs",
+            null
+        ],
+        [
+            "output",
+            "storages_decommissioned",
+            null
+        ],
+        [
+            "output",
+            "storages_invested",
+            null
+        ],
+        [
+            "output",
+            "storages_invested_available",
+            null
+        ],
+        [
+            "output",
+            "taxes",
+            null
+        ],
+        [
+            "output",
+            "total_costs",
+            null
+        ],
+        [
+            "output",
+            "unit_flow",
+            null
+        ],
+        [
+            "output",
+            "unit_flow_op",
+            null
+        ],
+        [
+            "output",
+            "unit_flow_op_active",
+            null
+        ],
+        [
+            "output",
+            "unit_investment_costs",
+            null
+        ],
+        [
+            "output",
+            "units_available",
+            null
+        ],
+        [
+            "output",
+            "units_invested",
+            null
+        ],
+        [
+            "output",
+            "units_invested_available",
+            null
+        ],
+        [
+            "output",
+            "units_mothballed",
+            null
+        ],
+        [
+            "output",
+            "units_on",
+            null
+        ],
+        [
+            "output",
+            "units_on_costs",
+            null
+        ],
+        [
+            "output",
+            "units_shut_down",
+            null
+        ],
+        [
+            "output",
+            "units_started_up",
+            null
+        ],
+        [
+            "output",
+            "variable_om_costs",
+            null
         ],
         [
             "report",
-            "A results report from a particular SpineOpt run, including the value of specific variables.",
-            281108461711708
-        ],
-        [
-            "settings",
-            "Internal SpineOpt settings. We kindly advise not to mess with this one.",
-            280375465144798
+            "report1",
+            null
         ],
         [
             "stochastic_scenario",
-            "A scenario for stochastic optimisation in SpineOpt.",
-            280743389491710
+            "realization",
+            null
         ],
         [
             "stochastic_structure",
-            "A group of stochastic scenarios that represent a structure.",
-            281470681806146
+            "deterministic",
+            null
         ],
         [
             "temporal_block",
-            "A length of time with a particular resolution.",
-            280376891207703
+            "flat",
+            null
         ],
         [
             "unit",
-            "A conversion of one/many comodities between nodes.",
-            281470681805429
+            "power_plant_a",
+            null
         ],
         [
-            "user_constraint",
-            "A generic data-driven custom constraint.",
-            281473533931636
+            "unit",
+            "power_plant_b",
+            null
         ]
     ],
     "relationship_classes": [
@@ -75,6 +336,16 @@
             ],
             "Defines the `nodes` the `connection` can take input from, and holds most `connection_flow` variable specific parameters.",
             280378317271897
+        ],
+        [
+            "connection__from_node__investment_group",
+            [
+                "connection",
+                "node",
+                "investment_group"
+            ],
+            "Indicates which connection capacities are included in the capacity invested available of an investment group",
+            null
         ],
         [
             "connection__from_node__user_constraint",
@@ -131,6 +402,16 @@
             ],
             "Defines the `nodes` the `connection` can output to, and holds most `connection_flow` variable specific parameters.",
             280378317271898
+        ],
+        [
+            "connection__to_node__investment_group",
+            [
+                "connection",
+                "node",
+                "investment_group"
+            ],
+            "Indicates which connection capacities are included in the capacity invested available of an investment group",
+            null
         ],
         [
             "connection__to_node__user_constraint",
@@ -332,6 +613,16 @@
             281470681805657
         ],
         [
+            "unit__from_node__investment_group",
+            [
+                "unit",
+                "node",
+                "investment_group"
+            ],
+            "Indicates which unit capacities are included in the capacity invested available of an investment group",
+            null
+        ],
+        [
             "unit__from_node__user_constraint",
             [
                 "unit",
@@ -388,6 +679,16 @@
             281470681805658
         ],
         [
+            "unit__to_node__investment_group",
+            [
+                "unit",
+                "node",
+                "investment_group"
+            ],
+            "Indicates which unit capacities are included in the capacity invested available of an investment group",
+            null
+        ],
+        [
             "unit__to_node__user_constraint",
             [
                 "unit",
@@ -425,288 +726,6 @@
             null
         ]
     ],
-    "parameter_value_lists": [
-        [
-            "balance_type_list",
-            "balance_type_group"
-        ],
-        [
-            "balance_type_list",
-            "balance_type_node"
-        ],
-        [
-            "balance_type_list",
-            "balance_type_none"
-        ],
-        [
-            "boolean_value_list",
-            false
-        ],
-        [
-            "boolean_value_list",
-            true
-        ],
-        [
-            "commodity_physics_list",
-            "commodity_physics_lodf"
-        ],
-        [
-            "commodity_physics_list",
-            "commodity_physics_none"
-        ],
-        [
-            "commodity_physics_list",
-            "commodity_physics_ptdf"
-        ],
-        [
-            "connection_investment_variable_type_list",
-            "connection_investment_variable_type_continuous"
-        ],
-        [
-            "connection_investment_variable_type_list",
-            "connection_investment_variable_type_integer"
-        ],
-        [
-            "connection_type_list",
-            "connection_type_lossless_bidirectional"
-        ],
-        [
-            "connection_type_list",
-            "connection_type_normal"
-        ],
-        [
-            "constraint_sense_list",
-            "<="
-        ],
-        [
-            "constraint_sense_list",
-            "=="
-        ],
-        [
-            "constraint_sense_list",
-            ">="
-        ],
-        [
-            "db_lp_solver_list",
-            "KNITRO.jl"
-        ],
-        [
-            "db_lp_solver_list",
-            "CDCS.jl"
-        ],
-        [
-            "db_lp_solver_list",
-            "CDDLib.jl"
-        ],
-        [
-            "db_lp_solver_list",
-            "Clp.jl"
-        ],
-        [
-            "db_lp_solver_list",
-            "COSMO.jl"
-        ],
-        [
-            "db_lp_solver_list",
-            "CPLEX.jl"
-        ],
-        [
-            "db_lp_solver_list",
-            "CSDP.jl"
-        ],
-        [
-            "db_lp_solver_list",
-            "ECOS.jl"
-        ],
-        [
-            "db_lp_solver_list",
-            "Xpress.jl"
-        ],
-        [
-            "db_lp_solver_list",
-            "GLPK.jl"
-        ],
-        [
-            "db_lp_solver_list",
-            "Gurobi.jl"
-        ],
-        [
-            "db_lp_solver_list",
-            "HiGHS.jl"
-        ],
-        [
-            "db_lp_solver_list",
-            "Hypatia.jl"
-        ],
-        [
-            "db_lp_solver_list",
-            "Ipopt.jl"
-        ],
-        [
-            "db_lp_solver_list",
-            "MadNLP.jl"
-        ],
-        [
-            "db_lp_solver_list",
-            "MosekTools.jl"
-        ],
-        [
-            "db_lp_solver_list",
-            "NLopt.jl"
-        ],
-        [
-            "db_lp_solver_list",
-            "OSQP.jl"
-        ],
-        [
-            "db_lp_solver_list",
-            "ProxSDP.jl"
-        ],
-        [
-            "db_lp_solver_list",
-            "SCIP.jl"
-        ],
-        [
-            "db_lp_solver_list",
-            "SCS.jl"
-        ],
-        [
-            "db_lp_solver_list",
-            "SDPA.jl"
-        ],
-        [
-            "db_lp_solver_list",
-            "SDPNAL.jl"
-        ],
-        [
-            "db_lp_solver_list",
-            "SDPT3.jl"
-        ],
-        [
-            "db_lp_solver_list",
-            "SeDuMi.jl"
-        ],
-        [
-            "db_mip_solver_list",
-            "KNITRO.jl"
-        ],
-        [
-            "db_mip_solver_list",
-            "Cbc.jl"
-        ],
-        [
-            "db_mip_solver_list",
-            "CPLEX.jl"
-        ],
-        [
-            "db_mip_solver_list",
-            "HiGHS.jl"
-        ],
-        [
-            "db_mip_solver_list",
-            "Xpress.jl"
-        ],
-        [
-            "db_mip_solver_list",
-            "GLPK.jl"
-        ],
-        [
-            "db_mip_solver_list",
-            "Gurobi.jl"
-        ],
-        [
-            "db_mip_solver_list",
-            "Juniper.jl"
-        ],
-        [
-            "db_mip_solver_list",
-            "MosekTools.jl"
-        ],
-        [
-            "db_mip_solver_list",
-            "SCIP.jl"
-        ],
-        [
-            "duration_unit_list",
-            "hour"
-        ],
-        [
-            "duration_unit_list",
-            "minute"
-        ],
-        [
-            "model_type_list",
-            "spineopt_benders"
-        ],
-        [
-            "model_type_list",
-            "spineopt_standard"
-        ],
-        [
-            "model_type_list",
-            "spineopt_other"
-        ],
-        [
-            "model_type_list",
-            "spineopt_mga"
-        ],
-        [
-            "node_opf_type_list",
-            "node_opf_type_normal"
-        ],
-        [
-            "node_opf_type_list",
-            "node_opf_type_reference"
-        ],
-        [
-            "unit_investment_variable_type_list",
-            "unit_investment_variable_type_continuous"
-        ],
-        [
-            "unit_investment_variable_type_list",
-            "unit_investment_variable_type_integer"
-        ],
-        [
-            "unit_online_variable_type_list",
-            "unit_online_variable_type_binary"
-        ],
-        [
-            "unit_online_variable_type_list",
-            "unit_online_variable_type_integer"
-        ],
-        [
-            "unit_online_variable_type_list",
-            "unit_online_variable_type_linear"
-        ],
-        [
-            "unit_online_variable_type_list",
-            "unit_online_variable_type_none"
-        ],
-        [
-            "variable_type_list",
-            "variable_type_binary"
-        ],
-        [
-            "variable_type_list",
-            "variable_type_continuous"
-        ],
-        [
-            "variable_type_list",
-            "variable_type_integer"
-        ],
-        [
-            "write_mps_file_list",
-            "write_mps_always"
-        ],
-        [
-            "write_mps_file_list",
-            "write_mps_never"
-        ],
-        [
-            "write_mps_file_list",
-            "write_mps_on_no_solve"
-        ]
-    ],
     "object_parameters": [
         [
             "commodity",
@@ -721,6 +740,13 @@
             "commodity_physics_none",
             "commodity_physics_list",
             "Defines if the `commodity` follows lodf or ptdf physics."
+        ],
+        [
+            "commodity",
+            "commodity_physics_duration",
+            null,
+            null,
+            "For how long the `commodity_physics` should apply relative to the start of the window."
         ],
         [
             "commodity",
@@ -752,6 +778,13 @@
         ],
         [
             "connection",
+            "benders_starting_connections_invested",
+            null,
+            null,
+            "Fixes the number of connections invested during the first Benders iteration"
+        ],
+        [
+            "connection",
             "candidate_connections",
             null,
             null,
@@ -760,7 +793,7 @@
         [
             "connection",
             "connection_availability_factor",
-            1.0,
+            1,
             null,
             "Availability of the `connection`, acting as a multiplier on its `connection_capacity`. Typically between 0-1."
         ],
@@ -905,6 +938,41 @@
             "If false, the object is excluded from the model if the tool filter object activity control is specified"
         ],
         [
+            "investment_group",
+            "equal_investments",
+            false,
+            "boolean_value_list",
+            "Whether all entities in the group must have the same investment decision."
+        ],
+        [
+            "investment_group",
+            "maximum_capacity_invested_available",
+            null,
+            null,
+            "Upper bound on the capacity invested available in the group at any point in time."
+        ],
+        [
+            "investment_group",
+            "maximum_entities_invested_available",
+            null,
+            null,
+            "Upper bound on the number of entities invested available in the group at any point in time."
+        ],
+        [
+            "investment_group",
+            "minimum_capacity_invested_available",
+            null,
+            null,
+            "Lower bound on the capacity invested available in the group at any point in time."
+        ],
+        [
+            "investment_group",
+            "minimum_entities_invested_available",
+            null,
+            null,
+            "Lower bound on the number of entities invested available in the group at any point in time."
+        ],
+        [
             "model",
             "big_m",
             1000000,
@@ -922,14 +990,23 @@
             "model",
             "db_lp_solver_options",
             {
-                "type": "map",
-                "index_type": "str",
                 "data": [
+                    [
+                        "Clp.jl",
+                        {
+                            "data": [
+                                [
+                                    "LogLevel",
+                                    0
+                                ]
+                            ],
+                            "type": "map",
+                            "index_type": "str"
+                        }
+                    ],
                     [
                         "HiGHS.jl",
                         {
-                            "type": "map",
-                            "index_type": "str",
                             "data": [
                                 [
                                     "presolve",
@@ -939,23 +1016,14 @@
                                     "time_limit",
                                     300.01
                                 ]
-                            ]
-                        }
-                    ],
-                    [
-                        "Clp.jl",
-                        {
+                            ],
                             "type": "map",
-                            "index_type": "str",
-                            "data": [
-                                [
-                                    "LogLevel",
-                                    0.0
-                                ]
-                            ]
+                            "index_type": "str"
                         }
                     ]
-                ]
+                ],
+                "type": "map",
+                "index_type": "str"
             },
             null,
             "Map parameter containing LP solver option name option value pairs. See solver documentation for supported solver options"
@@ -971,65 +1039,65 @@
             "model",
             "db_mip_solver_options",
             {
-                "type": "map",
-                "index_type": "str",
                 "data": [
-                    [
-                        "HiGHS.jl",
-                        {
-                            "type": "map",
-                            "index_type": "str",
-                            "data": [
-                                [
-                                    "presolve",
-                                    "on"
-                                ],
-                                [
-                                    "mip_rel_gap",
-                                    0.01
-                                ],
-                                [
-                                    "threads",
-                                    0.0
-                                ],
-                                [
-                                    "time_limit",
-                                    300.01
-                                ]
-                            ]
-                        }
-                    ],
-                    [
-                        "Cbc.jl",
-                        {
-                            "type": "map",
-                            "index_type": "str",
-                            "data": [
-                                [
-                                    "ratioGap",
-                                    0.01
-                                ],
-                                [
-                                    "logLevel",
-                                    0.0
-                                ]
-                            ]
-                        }
-                    ],
                     [
                         "CPLEX.jl",
                         {
-                            "type": "map",
-                            "index_type": "str",
                             "data": [
                                 [
                                     "CPX_PARAM_EPGAP",
                                     0.01
                                 ]
-                            ]
+                            ],
+                            "type": "map",
+                            "index_type": "str"
+                        }
+                    ],
+                    [
+                        "Cbc.jl",
+                        {
+                            "data": [
+                                [
+                                    "logLevel",
+                                    0
+                                ],
+                                [
+                                    "ratioGap",
+                                    0.01
+                                ]
+                            ],
+                            "type": "map",
+                            "index_type": "str"
+                        }
+                    ],
+                    [
+                        "HiGHS.jl",
+                        {
+                            "data": [
+                                [
+                                    "mip_rel_gap",
+                                    0.01
+                                ],
+                                [
+                                    "presolve",
+                                    "on"
+                                ],
+                                [
+                                    "threads",
+                                    0
+                                ],
+                                [
+                                    "time_limit",
+                                    300.01
+                                ]
+                            ],
+                            "type": "map",
+                            "index_type": "str"
                         }
                     ]
-                ]
+                ],
+                "type": "map",
+                "index_type": "str"
             },
             null,
             "Map parameter containing MIP solver option name option value pairs for MIP. See solver documentation for supported solver options"
@@ -1058,7 +1126,7 @@
         [
             "model",
             "max_iterations",
-            10.0,
+            10,
             null,
             "Specifies the maximum number of iterations for the model. Currently only used for the master problem within a decomposed structure"
         ],
@@ -1078,10 +1146,17 @@
         ],
         [
             "model",
+            "min_iterations",
+            1,
+            null,
+            "Specifies the minimum number of iterations for the model. Currently only used for the master problem within a decomposed structure"
+        ],
+        [
+            "model",
             "model_end",
             {
-                "type": "date_time",
-                "data": "2000-01-02T00:00:00"
+                "data": "2000-01-02T00:00:00.0",
+                "type": "date_time"
             },
             null,
             "Defines the last timestamp to be modelled. Rolling optimization terminates after passing this point."
@@ -1090,8 +1165,8 @@
             "model",
             "model_start",
             {
-                "type": "date_time",
-                "data": "2000-01-01T00:00:00"
+                "data": "2000-01-01T00:00:00.0",
+                "type": "date_time"
             },
             null,
             "Defines the first timestamp to be modelled. Relative `temporal_blocks` refer to this value for their start and end."
@@ -1154,6 +1229,13 @@
         ],
         [
             "node",
+            "benders_starting_storages_invested",
+            null,
+            null,
+            "Fixes the number of storages invested during the first Benders iteration"
+        ],
+        [
+            "node",
             "candidate_storages",
             null,
             null,
@@ -1162,7 +1244,7 @@
         [
             "node",
             "demand",
-            0.0,
+            0,
             null,
             "Demand for the `commodity` of a `node`. Energy gains can be represented using negative `demand`."
         ],
@@ -1211,14 +1293,14 @@
         [
             "node",
             "frac_state_loss",
-            0.0,
+            0,
             null,
             "Self-discharge coefficient for `node_state` variables. Effectively, represents the *loss power per unit of state*."
         ],
         [
             "node",
             "fractional_demand",
-            0.0,
+            0,
             null,
             "The fraction of a `node` group's `demand` applied for the `node` in question."
         ],
@@ -1372,14 +1454,14 @@
         [
             "node",
             "node_state_min",
-            0.0,
+            0,
             null,
             "The minimum permitted value for a `node_state` variable."
         ],
         [
             "node",
             "state_coeff",
-            1.0,
+            1,
             null,
             "Represents the `commodity` content of a `node_state` variable in respect to the `unit_flow` and `connection_flow` variables. Essentially, acts as a coefficient on the `node_state` variable in the `:node_injection` constraint."
         ],
@@ -1484,7 +1566,7 @@
         [
             "settings",
             "version",
-            8,
+            10,
             null,
             "Current version of the SpineOpt data structure. Modify it at your own risk (but please don't)."
         ],
@@ -1534,8 +1616,8 @@
             "temporal_block",
             "resolution",
             {
-                "type": "duration",
-                "data": "1h"
+                "data": "1h",
+                "type": "duration"
             },
             null,
             "Temporal resolution of the `temporal_block`. Essentially, divides the period between `block_start` and `block_end` into `TimeSlices` with the input `resolution`."
@@ -1543,9 +1625,16 @@
         [
             "temporal_block",
             "weight",
-            1.0,
+            1,
             null,
             "Weighting factor of the temporal block associated with the objective function"
+        ],
+        [
+            "unit",
+            "benders_starting_units_invested",
+            null,
+            null,
+            "Fixes the number of units invested during the first Benders iteration"
         ],
         [
             "unit",
@@ -1655,7 +1744,7 @@
         [
             "unit",
             "number_of_units",
-            1.0,
+            1,
             null,
             "Denotes the number of 'sub units' aggregated to form the modelled `unit`."
         ],
@@ -1683,7 +1772,7 @@
         [
             "unit",
             "unit_availability_factor",
-            1.0,
+            1,
             null,
             "Availability of the `unit`, acting as a multiplier on its `unit_capacity`. Typically between 0-1."
         ],
@@ -1767,9 +1856,80 @@
         [
             "user_constraint",
             "right_hand_side",
-            0.0,
+            0,
             null,
             "The right-hand side, constant term in a `user_constraint`. Can be time-dependent and used e.g. for complicated efficiency approximations."
+        ],
+        [
+            "user_constraint",
+            "user_constraint_slack_penalty",
+            null,
+            null,
+            "A penalty for violating a user constraint."
+        ]
+    ],
+    "relationship_parameter_values": [
+        [
+            "unit__from_node",
+            [
+                "power_plant_a",
+                "fuel_node"
+            ],
+            "vom_cost",
+            25,
+            "Base"
+        ],
+        [
+            "unit__from_node",
+            [
+                "power_plant_b",
+                "fuel_node"
+            ],
+            "vom_cost",
+            50,
+            "Base"
+        ],
+        [
+            "unit__node__node",
+            [
+                "power_plant_a",
+                "electricity_node",
+                "fuel_node"
+            ],
+            "fix_ratio_out_in_unit_flow",
+            0.7,
+            "Base"
+        ],
+        [
+            "unit__node__node",
+            [
+                "power_plant_b",
+                "electricity_node",
+                "fuel_node"
+            ],
+            "fix_ratio_out_in_unit_flow",
+            0.8,
+            "Base"
+        ],
+        [
+            "unit__to_node",
+            [
+                "power_plant_a",
+                "electricity_node"
+            ],
+            "unit_capacity",
+            100,
+            "Base"
+        ],
+        [
+            "unit__to_node",
+            [
+                "power_plant_b",
+                "electricity_node"
+            ],
+            "unit_capacity",
+            200,
+            "Base"
         ]
     ],
     "relationship_parameters": [
@@ -1783,7 +1943,7 @@
         [
             "connection__from_node",
             "connection_conv_cap_to_flow",
-            1.0,
+            1,
             null,
             "Optional coefficient for `connection_capacity` unit conversions in the case that the `connection_capacity` value is incompatible with the desired `connection_flow` units."
         ],
@@ -1881,7 +2041,7 @@
         [
             "connection__from_node__user_constraint",
             "connection_flow_coefficient",
-            0.0,
+            0,
             null,
             "defines the user constraint coefficient on the connection flow variable in the from direction"
         ],
@@ -1896,8 +2056,8 @@
             "connection__node__node",
             "connection_flow_delay",
             {
-                "type": "duration",
-                "data": "0h"
+                "data": "0h",
+                "type": "duration"
             },
             null,
             "Delays the `connection_flows` associated with the latter `node` in respect to the `connection_flows` associated with the first `node`."
@@ -1914,7 +2074,7 @@
             "fix_ratio_out_in_connection_flow",
             null,
             null,
-            "Fix the ratio between the `connection_flow` from the first `node` and the `connection_flow` to the second `node`."
+            "Fix the ratio between an outgoing `connection_flow` to the first `node` and an incoming `connection_flow` from the second `node`."
         ],
         [
             "connection__node__node",
@@ -1935,14 +2095,14 @@
             "max_ratio_out_in_connection_flow",
             null,
             null,
-            "Maximum ratio between the `connection_flow` from the first `node` and the `connection_flow` to the second `node`."
+            "Maximum ratio between an outgoing `connection_flow` to the first `node` and an incoming `connection_flow` from the second `node`."
         ],
         [
             "connection__node__node",
             "min_ratio_out_in_connection_flow",
             null,
             null,
-            "Minimum ratio between the `connection_flow` from the first `node` and the `connection_flow` to the second `node`."
+            "Minimum ratio between an outgoing `connection_flow` to the first `node` and an incoming `connection_flow` from the second `node`."
         ],
         [
             "connection__to_node",
@@ -1954,7 +2114,7 @@
         [
             "connection__to_node",
             "connection_conv_cap_to_flow",
-            1.0,
+            1,
             null,
             "Optional coefficient for `connection_capacity` unit conversions in the case the `connection_capacity` value is incompatible with the desired `connection_flow` units."
         ],
@@ -2052,28 +2212,28 @@
         [
             "connection__to_node__user_constraint",
             "connection_flow_coefficient",
-            0.0,
+            0,
             null,
             "defines the user constraint coefficient on the connection flow variable in the to direction"
         ],
         [
             "connection__user_constraint",
             "connections_invested_available_coefficient",
-            0.0,
+            0,
             null,
             "coefficient of `connections_invested_available` in the specific `user_constraint`"
         ],
         [
             "connection__user_constraint",
             "connections_invested_coefficient",
-            0.0,
+            0,
             null,
             "coefficient of `connections_invested` in the specific `user_constraint`"
         ],
         [
             "node__node",
             "diff_coeff",
-            0.0,
+            0,
             null,
             "Commodity diffusion coefficient between two `nodes`. Effectively, denotes the *diffusion power per unit of state* from the first `node` to the second."
         ],
@@ -2101,28 +2261,28 @@
         [
             "node__user_constraint",
             "demand_coefficient",
-            0.0,
+            0,
             null,
             "coefficient of the specified node's demand in the specified user constraint"
         ],
         [
             "node__user_constraint",
             "node_state_coefficient",
-            0.0,
+            0,
             null,
             "Coefficient of the specified node's state variable in the specified user constraint."
         ],
         [
             "node__user_constraint",
             "storages_invested_available_coefficient",
-            0.0,
+            0,
             null,
             "Coefficient of the specified node's storages invested available variable in the specified user constraint."
         ],
         [
             "node__user_constraint",
             "storages_invested_coefficient",
-            0.0,
+            0,
             null,
             "Coefficient of the specified node's storage investment variable in the specified user constraint."
         ],
@@ -2143,7 +2303,7 @@
         [
             "stochastic_structure__stochastic_scenario",
             "weight_relative_to_parents",
-            1.0,
+            1,
             null,
             "The weight of the `stochastic_scenario` in the objective function relative to its parents."
         ],
@@ -2332,7 +2492,7 @@
         [
             "unit__from_node",
             "min_unit_flow",
-            0.0,
+            0,
             null,
             "Set lower bound of the `unit_flow` variable."
         ],
@@ -2394,6 +2554,20 @@
         ],
         [
             "unit__from_node",
+            "shut_down_limit",
+            null,
+            null,
+            "Max. downward ramp for units shutting down"
+        ],
+        [
+            "unit__from_node",
+            "start_up_limit",
+            null,
+            null,
+            "Maximum ramp-up during startups."
+        ],
+        [
+            "unit__from_node",
             "unit_capacity",
             null,
             null,
@@ -2402,7 +2576,7 @@
         [
             "unit__from_node",
             "unit_conv_cap_to_flow",
-            1.0,
+            1,
             null,
             "Optional coefficient for `unit_capacity` unit conversions in the case the `unit_capacity` value is incompatible with the desired `unit_flow` units."
         ],
@@ -2437,7 +2611,7 @@
         [
             "unit__from_node__user_constraint",
             "unit_flow_coefficient",
-            0.0,
+            0,
             null,
             "Coefficient of a `unit_flow` variable for a custom `user_constraint`."
         ],
@@ -2472,28 +2646,28 @@
         [
             "unit__node__node",
             "fix_units_on_coefficient_in_in",
-            0.0,
+            0,
             null,
             "Optional coefficient for the `units_on` variable impacting the `fix_ratio_in_in_unit_flow` constraint."
         ],
         [
             "unit__node__node",
             "fix_units_on_coefficient_in_out",
-            0.0,
+            0,
             null,
             "Optional coefficient for the `units_on` variable impacting the `fix_ratio_in_out_unit_flow` constraint."
         ],
         [
             "unit__node__node",
             "fix_units_on_coefficient_out_in",
-            0.0,
+            0,
             null,
             "Optional coefficient for the `units_on` variable impacting the `fix_ratio_out_in_unit_flow` constraint."
         ],
         [
             "unit__node__node",
             "fix_units_on_coefficient_out_out",
-            0.0,
+            0,
             null,
             "Optional coefficient for the `units_on` variable impacting the `fix_ratio_out_out_unit_flow` constraint."
         ],
@@ -2528,28 +2702,28 @@
         [
             "unit__node__node",
             "max_units_on_coefficient_in_in",
-            0.0,
+            0,
             null,
             "Optional coefficient for the `units_on` variable impacting the `max_ratio_in_in_unit_flow` constraint."
         ],
         [
             "unit__node__node",
             "max_units_on_coefficient_in_out",
-            0.0,
+            0,
             null,
             "Optional coefficient for the `units_on` variable impacting the `max_ratio_in_out_unit_flow` constraint."
         ],
         [
             "unit__node__node",
             "max_units_on_coefficient_out_in",
-            0.0,
+            0,
             null,
             "Optional coefficient for the `units_on` variable impacting the `max_ratio_out_in_unit_flow` constraint."
         ],
         [
             "unit__node__node",
             "max_units_on_coefficient_out_out",
-            0.0,
+            0,
             null,
             "Optional coefficient for the `units_on` variable impacting the `max_ratio_out_out_unit_flow` constraint."
         ],
@@ -2584,35 +2758,35 @@
         [
             "unit__node__node",
             "min_units_on_coefficient_in_in",
-            0.0,
+            0,
             null,
             "Optional coefficient for the `units_on` variable impacting the `min_ratio_in_in_unit_flow` constraint."
         ],
         [
             "unit__node__node",
             "min_units_on_coefficient_in_out",
-            0.0,
+            0,
             null,
             "Optional coefficient for the `units_on` variable impacting the `min_ratio_in_out_unit_flow` constraint."
         ],
         [
             "unit__node__node",
             "min_units_on_coefficient_out_in",
-            0.0,
+            0,
             null,
             "Optional coefficient for the `units_on` variable impacting the `min_ratio_out_in_unit_flow` constraint."
         ],
         [
             "unit__node__node",
             "min_units_on_coefficient_out_out",
-            0.0,
+            0,
             null,
             "Optional coefficient for the `units_on` variable impacting the `min_ratio_out_out_unit_flow` constraint."
         ],
         [
             "unit__node__node",
             "unit_idle_heat_rate",
-            0.0,
+            0,
             null,
             "Flow from node1 per unit time and per `units_on` that results in no additional flow to node2"
         ],
@@ -2626,7 +2800,7 @@
         [
             "unit__node__node",
             "unit_start_flow",
-            0.0,
+            0,
             null,
             "Flow from node1 that is incurred when a unit is started up."
         ],
@@ -2793,66 +2967,10 @@
         ],
         [
             "unit__to_node",
-            "max_res_shutdown_ramp",
-            null,
-            null,
-            "Maximum non-spinning reserve ramp-down for online units providing reserves during shut-downs"
-        ],
-        [
-            "unit__to_node",
-            "max_res_startup_ramp",
-            null,
-            null,
-            "Maximum non-spinning reserve ramp-up for offline units scheduled for reserve provision"
-        ],
-        [
-            "unit__to_node",
-            "max_shutdown_ramp",
-            null,
-            null,
-            "Maximum ramp-down during shutdowns"
-        ],
-        [
-            "unit__to_node",
-            "max_startup_ramp",
-            null,
-            null,
-            "Maximum ramp-up during startups"
-        ],
-        [
-            "unit__to_node",
             "max_total_cumulated_unit_flow_to_node",
             null,
             null,
             "Bound on the maximum cumulated flows of a unit group to a node group, e.g. total GHG emissions."
-        ],
-        [
-            "unit__to_node",
-            "min_res_shutdown_ramp",
-            null,
-            null,
-            "Minimum non-spinning reserve ramp-down for online units providing reserves during shut-downs"
-        ],
-        [
-            "unit__to_node",
-            "min_res_startup_ramp",
-            null,
-            null,
-            "Minimum non-spinning reserve ramp-up for offline units scheduled for reserve provision"
-        ],
-        [
-            "unit__to_node",
-            "min_shutdown_ramp",
-            null,
-            null,
-            "Minimum ramp-up during startups"
-        ],
-        [
-            "unit__to_node",
-            "min_startup_ramp",
-            null,
-            null,
-            "Minimum ramp-up during startups"
         ],
         [
             "unit__to_node",
@@ -2864,7 +2982,7 @@
         [
             "unit__to_node",
             "min_unit_flow",
-            0.0,
+            0,
             null,
             "Set lower bound of the `unit_flow` variable."
         ],
@@ -2926,6 +3044,20 @@
         ],
         [
             "unit__to_node",
+            "shut_down_limit",
+            null,
+            null,
+            "Maximum ramp-down during shutdowns"
+        ],
+        [
+            "unit__to_node",
+            "start_up_limit",
+            null,
+            null,
+            "Maximum ramp-up during startups"
+        ],
+        [
+            "unit__to_node",
             "unit_capacity",
             null,
             null,
@@ -2934,7 +3066,7 @@
         [
             "unit__to_node",
             "unit_conv_cap_to_flow",
-            1.0,
+            1,
             null,
             "Optional coefficient for `unit_capacity` unit conversions in the case the `unit_capacity` value is incompatible with the desired `unit_flow` units."
         ],
@@ -2969,35 +3101,35 @@
         [
             "unit__to_node__user_constraint",
             "unit_flow_coefficient",
-            0.0,
+            0,
             null,
             "Coefficient of a `unit_flow` variable for a custom `user_constraint`."
         ],
         [
             "unit__user_constraint",
             "units_invested_available_coefficient",
-            0.0,
+            0,
             null,
             "Coefficient of the `units_invested_available` variable in the specified `user_constraint`."
         ],
         [
             "unit__user_constraint",
             "units_invested_coefficient",
-            0.0,
+            0,
             null,
             "Coefficient of the `units_invested` variable in the specified `user_constraint`."
         ],
         [
             "unit__user_constraint",
             "units_on_coefficient",
-            0.0,
+            0,
             null,
             "Coefficient of a `units_on` variable for a custom `user_constraint`."
         ],
         [
             "unit__user_constraint",
             "units_started_up_coefficient",
-            0.0,
+            0,
             null,
             "Coefficient of a `units_started_up` variable for a custom `user_constraint`."
         ],
@@ -3016,321 +3148,1980 @@
             "If false, the object is excluded from the model if the tool filter object activity control is specified"
         ]
     ],
-    "objects": [
+    "tools": [
         [
-            "model",
-            "simple",
-            null
-        ],
+            "object_activity_control",
+            ""
+        ]
+    ],
+    "object_parameter_values": [
         [
             "node",
             "electricity_node",
-            null
+            "demand",
+            150,
+            "Base"
         ],
         [
             "node",
             "fuel_node",
-            null
-        ],
-        [
-            "output",
-            "binary_gas_connection_flow",
-            null
-        ],
-        [
-            "output",
-            "connection_avg_intact_throughflow",
-            null
-        ],
-        [
-            "output",
-            "connection_avg_throughflow",
-            null
-        ],
-        [
-            "output",
-            "connection_flow",
-            null
-        ],
-        [
-            "output",
-            "connection_flow_costs",
-            null
-        ],
-        [
-            "output",
-            "connection_intact_flow",
-            null
-        ],
-        [
-            "output",
-            "connection_investment_costs",
-            null
-        ],
-        [
-            "output",
-            "connections_decommissioned",
-            null
-        ],
-        [
-            "output",
-            "connections_invested",
-            null
-        ],
-        [
-            "output",
-            "connections_invested_available",
-            null
-        ],
-        [
-            "output",
-            "contingency_is_binding",
-            null
-        ],
-        [
-            "output",
-            "fixed_om_costs",
-            null
-        ],
-        [
-            "output",
-            "fuel_costs",
-            null
-        ],
-        [
-            "output",
-            "mga_objective",
-            null
-        ],
-        [
-            "output",
-            "mp_objective_lowerbound",
-            null
-        ],
-        [
-            "output",
-            "node_injection",
-            null
-        ],
-        [
-            "output",
-            "node_pressure",
-            null
-        ],
-        [
-            "output",
-            "node_slack_neg",
-            null
-        ],
-        [
-            "output",
-            "node_slack_pos",
-            null
-        ],
-        [
-            "output",
-            "node_state",
-            null
-        ],
-        [
-            "output",
-            "node_voltage_angle",
-            null
-        ],
-        [
-            "output",
-            "nonspin_ramp_down_unit_flow",
-            null
-        ],
-        [
-            "output",
-            "nonspin_ramp_up_unit_flow",
-            null
-        ],
-        [
-            "output",
-            "nonspin_units_shut_down",
-            null
-        ],
-        [
-            "output",
-            "nonspin_units_started_up",
-            null
-        ],
-        [
-            "output",
-            "objective_penalties",
-            null
-        ],
-        [
-            "output",
-            "ramp_costs",
-            null
-        ],
-        [
-            "output",
-            "ramp_down_unit_flow",
-            null
-        ],
-        [
-            "output",
-            "ramp_up_unit_flow",
-            null
-        ],
-        [
-            "output",
-            "renewable_curtailment_costs",
-            null
-        ],
-        [
-            "output",
-            "res_proc_costs",
-            null
-        ],
-        [
-            "output",
-            "shut_down_costs",
-            null
-        ],
-        [
-            "output",
-            "shut_down_unit_flow",
-            null
-        ],
-        [
-            "output",
-            "start_up_costs",
-            null
-        ],
-        [
-            "output",
-            "start_up_unit_flow",
-            null
-        ],
-        [
-            "output",
-            "storage_investment_costs",
-            null
-        ],
-        [
-            "output",
-            "storages_decommissioned",
-            null
-        ],
-        [
-            "output",
-            "storages_invested",
-            null
-        ],
-        [
-            "output",
-            "storages_invested_available",
-            null
-        ],
-        [
-            "output",
-            "taxes",
-            null
-        ],
-        [
-            "output",
-            "total_costs",
-            null
-        ],
-        [
-            "output",
-            "unit_flow",
-            null
-        ],
-        [
-            "output",
-            "unit_flow_op",
-            null
-        ],
-        [
-            "output",
-            "unit_flow_op_active",
-            null
-        ],
-        [
-            "output",
-            "unit_investment_costs",
-            null
-        ],
-        [
-            "output",
-            "units_available",
-            null
-        ],
-        [
-            "output",
-            "units_invested",
-            null
-        ],
-        [
-            "output",
-            "units_invested_available",
-            null
-        ],
-        [
-            "output",
-            "units_mothballed",
-            null
-        ],
-        [
-            "output",
-            "units_on",
-            null
-        ],
-        [
-            "output",
-            "units_on_costs",
-            null
-        ],
-        [
-            "output",
-            "units_shut_down",
-            null
-        ],
-        [
-            "output",
-            "units_started_up",
-            null
-        ],
-        [
-            "output",
-            "variable_om_costs",
-            null
-        ],
-        [
-            "report",
-            "report1",
-            null
-        ],
-        [
-            "stochastic_scenario",
-            "realization",
-            null
-        ],
-        [
-            "stochastic_structure",
-            "deterministic",
-            null
+            "balance_type",
+            "balance_type_none",
+            "Base"
         ],
         [
             "temporal_block",
             "flat",
-            null
+            "resolution",
+            {
+                "data": "1D",
+                "type": "duration"
+            },
+            "Base"
+        ]
+    ],
+    "tool_feature_methods": [
+        [
+            "object_activity_control",
+            "commodity",
+            "is_active",
+            [
+                [
+                    116,
+                    114,
+                    117,
+                    101
+                ],
+                null
+            ]
         ],
         [
-            "unit",
-            "power_plant_a",
-            null
+            "object_activity_control",
+            "connection",
+            "is_active",
+            [
+                [
+                    116,
+                    114,
+                    117,
+                    101
+                ],
+                null
+            ]
         ],
         [
+            "object_activity_control",
+            "model",
+            "is_active",
+            [
+                [
+                    116,
+                    114,
+                    117,
+                    101
+                ],
+                null
+            ]
+        ],
+        [
+            "object_activity_control",
+            "node",
+            "is_active",
+            [
+                [
+                    116,
+                    114,
+                    117,
+                    101
+                ],
+                null
+            ]
+        ],
+        [
+            "object_activity_control",
+            "node__stochastic_structure",
+            "is_active",
+            [
+                [
+                    116,
+                    114,
+                    117,
+                    101
+                ],
+                null
+            ]
+        ],
+        [
+            "object_activity_control",
+            "node__temporal_block",
+            "is_active",
+            [
+                [
+                    116,
+                    114,
+                    117,
+                    101
+                ],
+                null
+            ]
+        ],
+        [
+            "object_activity_control",
+            "output",
+            "is_active",
+            [
+                [
+                    116,
+                    114,
+                    117,
+                    101
+                ],
+                null
+            ]
+        ],
+        [
+            "object_activity_control",
+            "report",
+            "is_active",
+            [
+                [
+                    116,
+                    114,
+                    117,
+                    101
+                ],
+                null
+            ]
+        ],
+        [
+            "object_activity_control",
+            "stochastic_scenario",
+            "is_active",
+            [
+                [
+                    116,
+                    114,
+                    117,
+                    101
+                ],
+                null
+            ]
+        ],
+        [
+            "object_activity_control",
+            "stochastic_structure",
+            "is_active",
+            [
+                [
+                    116,
+                    114,
+                    117,
+                    101
+                ],
+                null
+            ]
+        ],
+        [
+            "object_activity_control",
+            "temporal_block",
+            "is_active",
+            [
+                [
+                    116,
+                    114,
+                    117,
+                    101
+                ],
+                null
+            ]
+        ],
+        [
+            "object_activity_control",
             "unit",
-            "power_plant_b",
-            null
+            "is_active",
+            [
+                [
+                    116,
+                    114,
+                    117,
+                    101
+                ],
+                null
+            ]
+        ],
+        [
+            "object_activity_control",
+            "unit__from_node",
+            "is_active",
+            [
+                [
+                    116,
+                    114,
+                    117,
+                    101
+                ],
+                null
+            ]
+        ],
+        [
+            "object_activity_control",
+            "unit__to_node",
+            "is_active",
+            [
+                [
+                    116,
+                    114,
+                    117,
+                    101
+                ],
+                null
+            ]
+        ],
+        [
+            "object_activity_control",
+            "units_on__stochastic_structure",
+            "is_active",
+            [
+                [
+                    116,
+                    114,
+                    117,
+                    101
+                ],
+                null
+            ]
+        ],
+        [
+            "object_activity_control",
+            "units_on__temporal_block",
+            "is_active",
+            [
+                [
+                    116,
+                    114,
+                    117,
+                    101
+                ],
+                null
+            ]
+        ],
+        [
+            "object_activity_control",
+            "user_constraint",
+            "is_active",
+            [
+                [
+                    116,
+                    114,
+                    117,
+                    101
+                ],
+                null
+            ]
+        ]
+    ],
+    "parameter_value_lists": [
+        [
+            "balance_type_list",
+            [
+                [
+                    34,
+                    98,
+                    97,
+                    108,
+                    97,
+                    110,
+                    99,
+                    101,
+                    95,
+                    116,
+                    121,
+                    112,
+                    101,
+                    95,
+                    103,
+                    114,
+                    111,
+                    117,
+                    112,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "balance_type_list",
+            [
+                [
+                    34,
+                    98,
+                    97,
+                    108,
+                    97,
+                    110,
+                    99,
+                    101,
+                    95,
+                    116,
+                    121,
+                    112,
+                    101,
+                    95,
+                    110,
+                    111,
+                    100,
+                    101,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "balance_type_list",
+            [
+                [
+                    34,
+                    98,
+                    97,
+                    108,
+                    97,
+                    110,
+                    99,
+                    101,
+                    95,
+                    116,
+                    121,
+                    112,
+                    101,
+                    95,
+                    110,
+                    111,
+                    110,
+                    101,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "boolean_value_list",
+            [
+                [
+                    102,
+                    97,
+                    108,
+                    115,
+                    101
+                ],
+                null
+            ]
+        ],
+        [
+            "boolean_value_list",
+            [
+                [
+                    116,
+                    114,
+                    117,
+                    101
+                ],
+                null
+            ]
+        ],
+        [
+            "commodity_physics_list",
+            [
+                [
+                    34,
+                    99,
+                    111,
+                    109,
+                    109,
+                    111,
+                    100,
+                    105,
+                    116,
+                    121,
+                    95,
+                    112,
+                    104,
+                    121,
+                    115,
+                    105,
+                    99,
+                    115,
+                    95,
+                    108,
+                    111,
+                    100,
+                    102,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "commodity_physics_list",
+            [
+                [
+                    34,
+                    99,
+                    111,
+                    109,
+                    109,
+                    111,
+                    100,
+                    105,
+                    116,
+                    121,
+                    95,
+                    112,
+                    104,
+                    121,
+                    115,
+                    105,
+                    99,
+                    115,
+                    95,
+                    110,
+                    111,
+                    110,
+                    101,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "commodity_physics_list",
+            [
+                [
+                    34,
+                    99,
+                    111,
+                    109,
+                    109,
+                    111,
+                    100,
+                    105,
+                    116,
+                    121,
+                    95,
+                    112,
+                    104,
+                    121,
+                    115,
+                    105,
+                    99,
+                    115,
+                    95,
+                    112,
+                    116,
+                    100,
+                    102,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "connection_investment_variable_type_list",
+            [
+                [
+                    34,
+                    99,
+                    111,
+                    110,
+                    110,
+                    101,
+                    99,
+                    116,
+                    105,
+                    111,
+                    110,
+                    95,
+                    105,
+                    110,
+                    118,
+                    101,
+                    115,
+                    116,
+                    109,
+                    101,
+                    110,
+                    116,
+                    95,
+                    118,
+                    97,
+                    114,
+                    105,
+                    97,
+                    98,
+                    108,
+                    101,
+                    95,
+                    116,
+                    121,
+                    112,
+                    101,
+                    95,
+                    99,
+                    111,
+                    110,
+                    116,
+                    105,
+                    110,
+                    117,
+                    111,
+                    117,
+                    115,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "connection_investment_variable_type_list",
+            [
+                [
+                    34,
+                    99,
+                    111,
+                    110,
+                    110,
+                    101,
+                    99,
+                    116,
+                    105,
+                    111,
+                    110,
+                    95,
+                    105,
+                    110,
+                    118,
+                    101,
+                    115,
+                    116,
+                    109,
+                    101,
+                    110,
+                    116,
+                    95,
+                    118,
+                    97,
+                    114,
+                    105,
+                    97,
+                    98,
+                    108,
+                    101,
+                    95,
+                    116,
+                    121,
+                    112,
+                    101,
+                    95,
+                    105,
+                    110,
+                    116,
+                    101,
+                    103,
+                    101,
+                    114,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "connection_type_list",
+            [
+                [
+                    34,
+                    99,
+                    111,
+                    110,
+                    110,
+                    101,
+                    99,
+                    116,
+                    105,
+                    111,
+                    110,
+                    95,
+                    116,
+                    121,
+                    112,
+                    101,
+                    95,
+                    108,
+                    111,
+                    115,
+                    115,
+                    108,
+                    101,
+                    115,
+                    115,
+                    95,
+                    98,
+                    105,
+                    100,
+                    105,
+                    114,
+                    101,
+                    99,
+                    116,
+                    105,
+                    111,
+                    110,
+                    97,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "connection_type_list",
+            [
+                [
+                    34,
+                    99,
+                    111,
+                    110,
+                    110,
+                    101,
+                    99,
+                    116,
+                    105,
+                    111,
+                    110,
+                    95,
+                    116,
+                    121,
+                    112,
+                    101,
+                    95,
+                    110,
+                    111,
+                    114,
+                    109,
+                    97,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "constraint_sense_list",
+            [
+                [
+                    34,
+                    60,
+                    61,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "constraint_sense_list",
+            [
+                [
+                    34,
+                    61,
+                    61,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "constraint_sense_list",
+            [
+                [
+                    34,
+                    62,
+                    61,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_lp_solver_list",
+            [
+                [
+                    34,
+                    75,
+                    78,
+                    73,
+                    84,
+                    82,
+                    79,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_lp_solver_list",
+            [
+                [
+                    34,
+                    67,
+                    68,
+                    67,
+                    83,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_lp_solver_list",
+            [
+                [
+                    34,
+                    67,
+                    68,
+                    68,
+                    76,
+                    105,
+                    98,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_lp_solver_list",
+            [
+                [
+                    34,
+                    67,
+                    108,
+                    112,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_lp_solver_list",
+            [
+                [
+                    34,
+                    67,
+                    79,
+                    83,
+                    77,
+                    79,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_lp_solver_list",
+            [
+                [
+                    34,
+                    67,
+                    80,
+                    76,
+                    69,
+                    88,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_lp_solver_list",
+            [
+                [
+                    34,
+                    67,
+                    83,
+                    68,
+                    80,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_lp_solver_list",
+            [
+                [
+                    34,
+                    69,
+                    67,
+                    79,
+                    83,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_lp_solver_list",
+            [
+                [
+                    34,
+                    88,
+                    112,
+                    114,
+                    101,
+                    115,
+                    115,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_lp_solver_list",
+            [
+                [
+                    34,
+                    71,
+                    76,
+                    80,
+                    75,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_lp_solver_list",
+            [
+                [
+                    34,
+                    71,
+                    117,
+                    114,
+                    111,
+                    98,
+                    105,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_lp_solver_list",
+            [
+                [
+                    34,
+                    72,
+                    105,
+                    71,
+                    72,
+                    83,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_lp_solver_list",
+            [
+                [
+                    34,
+                    72,
+                    121,
+                    112,
+                    97,
+                    116,
+                    105,
+                    97,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_lp_solver_list",
+            [
+                [
+                    34,
+                    73,
+                    112,
+                    111,
+                    112,
+                    116,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_lp_solver_list",
+            [
+                [
+                    34,
+                    77,
+                    97,
+                    100,
+                    78,
+                    76,
+                    80,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_lp_solver_list",
+            [
+                [
+                    34,
+                    77,
+                    111,
+                    115,
+                    101,
+                    107,
+                    84,
+                    111,
+                    111,
+                    108,
+                    115,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_lp_solver_list",
+            [
+                [
+                    34,
+                    78,
+                    76,
+                    111,
+                    112,
+                    116,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_lp_solver_list",
+            [
+                [
+                    34,
+                    79,
+                    83,
+                    81,
+                    80,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_lp_solver_list",
+            [
+                [
+                    34,
+                    80,
+                    114,
+                    111,
+                    120,
+                    83,
+                    68,
+                    80,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_lp_solver_list",
+            [
+                [
+                    34,
+                    83,
+                    67,
+                    73,
+                    80,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_lp_solver_list",
+            [
+                [
+                    34,
+                    83,
+                    67,
+                    83,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_lp_solver_list",
+            [
+                [
+                    34,
+                    83,
+                    68,
+                    80,
+                    65,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_lp_solver_list",
+            [
+                [
+                    34,
+                    83,
+                    68,
+                    80,
+                    78,
+                    65,
+                    76,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_lp_solver_list",
+            [
+                [
+                    34,
+                    83,
+                    68,
+                    80,
+                    84,
+                    51,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_lp_solver_list",
+            [
+                [
+                    34,
+                    83,
+                    101,
+                    68,
+                    117,
+                    77,
+                    105,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_mip_solver_list",
+            [
+                [
+                    34,
+                    75,
+                    78,
+                    73,
+                    84,
+                    82,
+                    79,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_mip_solver_list",
+            [
+                [
+                    34,
+                    67,
+                    98,
+                    99,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_mip_solver_list",
+            [
+                [
+                    34,
+                    67,
+                    80,
+                    76,
+                    69,
+                    88,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_mip_solver_list",
+            [
+                [
+                    34,
+                    72,
+                    105,
+                    71,
+                    72,
+                    83,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_mip_solver_list",
+            [
+                [
+                    34,
+                    88,
+                    112,
+                    114,
+                    101,
+                    115,
+                    115,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_mip_solver_list",
+            [
+                [
+                    34,
+                    71,
+                    76,
+                    80,
+                    75,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_mip_solver_list",
+            [
+                [
+                    34,
+                    71,
+                    117,
+                    114,
+                    111,
+                    98,
+                    105,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_mip_solver_list",
+            [
+                [
+                    34,
+                    74,
+                    117,
+                    110,
+                    105,
+                    112,
+                    101,
+                    114,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_mip_solver_list",
+            [
+                [
+                    34,
+                    77,
+                    111,
+                    115,
+                    101,
+                    107,
+                    84,
+                    111,
+                    111,
+                    108,
+                    115,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_mip_solver_list",
+            [
+                [
+                    34,
+                    83,
+                    67,
+                    73,
+                    80,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "duration_unit_list",
+            [
+                [
+                    34,
+                    104,
+                    111,
+                    117,
+                    114,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "duration_unit_list",
+            [
+                [
+                    34,
+                    109,
+                    105,
+                    110,
+                    117,
+                    116,
+                    101,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "model_type_list",
+            [
+                [
+                    34,
+                    115,
+                    112,
+                    105,
+                    110,
+                    101,
+                    111,
+                    112,
+                    116,
+                    95,
+                    98,
+                    101,
+                    110,
+                    100,
+                    101,
+                    114,
+                    115,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "model_type_list",
+            [
+                [
+                    34,
+                    115,
+                    112,
+                    105,
+                    110,
+                    101,
+                    111,
+                    112,
+                    116,
+                    95,
+                    115,
+                    116,
+                    97,
+                    110,
+                    100,
+                    97,
+                    114,
+                    100,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "model_type_list",
+            [
+                [
+                    34,
+                    115,
+                    112,
+                    105,
+                    110,
+                    101,
+                    111,
+                    112,
+                    116,
+                    95,
+                    111,
+                    116,
+                    104,
+                    101,
+                    114,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "model_type_list",
+            [
+                [
+                    34,
+                    115,
+                    112,
+                    105,
+                    110,
+                    101,
+                    111,
+                    112,
+                    116,
+                    95,
+                    109,
+                    103,
+                    97,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "node_opf_type_list",
+            [
+                [
+                    34,
+                    110,
+                    111,
+                    100,
+                    101,
+                    95,
+                    111,
+                    112,
+                    102,
+                    95,
+                    116,
+                    121,
+                    112,
+                    101,
+                    95,
+                    110,
+                    111,
+                    114,
+                    109,
+                    97,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "node_opf_type_list",
+            [
+                [
+                    34,
+                    110,
+                    111,
+                    100,
+                    101,
+                    95,
+                    111,
+                    112,
+                    102,
+                    95,
+                    116,
+                    121,
+                    112,
+                    101,
+                    95,
+                    114,
+                    101,
+                    102,
+                    101,
+                    114,
+                    101,
+                    110,
+                    99,
+                    101,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "unit_investment_variable_type_list",
+            [
+                [
+                    34,
+                    117,
+                    110,
+                    105,
+                    116,
+                    95,
+                    105,
+                    110,
+                    118,
+                    101,
+                    115,
+                    116,
+                    109,
+                    101,
+                    110,
+                    116,
+                    95,
+                    118,
+                    97,
+                    114,
+                    105,
+                    97,
+                    98,
+                    108,
+                    101,
+                    95,
+                    116,
+                    121,
+                    112,
+                    101,
+                    95,
+                    99,
+                    111,
+                    110,
+                    116,
+                    105,
+                    110,
+                    117,
+                    111,
+                    117,
+                    115,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "unit_investment_variable_type_list",
+            [
+                [
+                    34,
+                    117,
+                    110,
+                    105,
+                    116,
+                    95,
+                    105,
+                    110,
+                    118,
+                    101,
+                    115,
+                    116,
+                    109,
+                    101,
+                    110,
+                    116,
+                    95,
+                    118,
+                    97,
+                    114,
+                    105,
+                    97,
+                    98,
+                    108,
+                    101,
+                    95,
+                    116,
+                    121,
+                    112,
+                    101,
+                    95,
+                    105,
+                    110,
+                    116,
+                    101,
+                    103,
+                    101,
+                    114,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "unit_online_variable_type_list",
+            [
+                [
+                    34,
+                    117,
+                    110,
+                    105,
+                    116,
+                    95,
+                    111,
+                    110,
+                    108,
+                    105,
+                    110,
+                    101,
+                    95,
+                    118,
+                    97,
+                    114,
+                    105,
+                    97,
+                    98,
+                    108,
+                    101,
+                    95,
+                    116,
+                    121,
+                    112,
+                    101,
+                    95,
+                    98,
+                    105,
+                    110,
+                    97,
+                    114,
+                    121,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "unit_online_variable_type_list",
+            [
+                [
+                    34,
+                    117,
+                    110,
+                    105,
+                    116,
+                    95,
+                    111,
+                    110,
+                    108,
+                    105,
+                    110,
+                    101,
+                    95,
+                    118,
+                    97,
+                    114,
+                    105,
+                    97,
+                    98,
+                    108,
+                    101,
+                    95,
+                    116,
+                    121,
+                    112,
+                    101,
+                    95,
+                    105,
+                    110,
+                    116,
+                    101,
+                    103,
+                    101,
+                    114,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "unit_online_variable_type_list",
+            [
+                [
+                    34,
+                    117,
+                    110,
+                    105,
+                    116,
+                    95,
+                    111,
+                    110,
+                    108,
+                    105,
+                    110,
+                    101,
+                    95,
+                    118,
+                    97,
+                    114,
+                    105,
+                    97,
+                    98,
+                    108,
+                    101,
+                    95,
+                    116,
+                    121,
+                    112,
+                    101,
+                    95,
+                    108,
+                    105,
+                    110,
+                    101,
+                    97,
+                    114,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "unit_online_variable_type_list",
+            [
+                [
+                    34,
+                    117,
+                    110,
+                    105,
+                    116,
+                    95,
+                    111,
+                    110,
+                    108,
+                    105,
+                    110,
+                    101,
+                    95,
+                    118,
+                    97,
+                    114,
+                    105,
+                    97,
+                    98,
+                    108,
+                    101,
+                    95,
+                    116,
+                    121,
+                    112,
+                    101,
+                    95,
+                    110,
+                    111,
+                    110,
+                    101,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "variable_type_list",
+            [
+                [
+                    34,
+                    118,
+                    97,
+                    114,
+                    105,
+                    97,
+                    98,
+                    108,
+                    101,
+                    95,
+                    116,
+                    121,
+                    112,
+                    101,
+                    95,
+                    98,
+                    105,
+                    110,
+                    97,
+                    114,
+                    121,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "variable_type_list",
+            [
+                [
+                    34,
+                    118,
+                    97,
+                    114,
+                    105,
+                    97,
+                    98,
+                    108,
+                    101,
+                    95,
+                    116,
+                    121,
+                    112,
+                    101,
+                    95,
+                    99,
+                    111,
+                    110,
+                    116,
+                    105,
+                    110,
+                    117,
+                    111,
+                    117,
+                    115,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "variable_type_list",
+            [
+                [
+                    34,
+                    118,
+                    97,
+                    114,
+                    105,
+                    97,
+                    98,
+                    108,
+                    101,
+                    95,
+                    116,
+                    121,
+                    112,
+                    101,
+                    95,
+                    105,
+                    110,
+                    116,
+                    101,
+                    103,
+                    101,
+                    114,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "write_mps_file_list",
+            [
+                [
+                    34,
+                    119,
+                    114,
+                    105,
+                    116,
+                    101,
+                    95,
+                    109,
+                    112,
+                    115,
+                    95,
+                    97,
+                    108,
+                    119,
+                    97,
+                    121,
+                    115,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "write_mps_file_list",
+            [
+                [
+                    34,
+                    119,
+                    114,
+                    105,
+                    116,
+                    101,
+                    95,
+                    109,
+                    112,
+                    115,
+                    95,
+                    110,
+                    101,
+                    118,
+                    101,
+                    114,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "write_mps_file_list",
+            [
+                [
+                    34,
+                    119,
+                    114,
+                    105,
+                    116,
+                    101,
+                    95,
+                    109,
+                    112,
+                    115,
+                    95,
+                    111,
+                    110,
+                    95,
+                    110,
+                    111,
+                    95,
+                    115,
+                    111,
+                    108,
+                    118,
+                    101,
+                    34
+                ],
+                null
+            ]
         ]
     ],
     "relationships": [
@@ -3426,212 +5217,6 @@
                 "power_plant_b",
                 "electricity_node"
             ]
-        ]
-    ],
-    "object_parameter_values": [
-        [
-            "node",
-            "electricity_node",
-            "demand",
-            150.0,
-            "Base"
-        ],
-        [
-            "node",
-            "fuel_node",
-            "balance_type",
-            "balance_type_none",
-            "Base"
-        ],
-        [
-            "temporal_block",
-            "flat",
-            "resolution",
-            {
-                "type": "duration",
-                "data": "1D"
-            },
-            "Base"
-        ]
-    ],
-    "relationship_parameter_values": [
-        [
-            "unit__from_node",
-            [
-                "power_plant_a",
-                "fuel_node"
-            ],
-            "vom_cost",
-            25,
-            "Base"
-        ],
-        [
-            "unit__from_node",
-            [
-                "power_plant_b",
-                "fuel_node"
-            ],
-            "vom_cost",
-            50,
-            "Base"
-        ],
-        [
-            "unit__node__node",
-            [
-                "power_plant_a",
-                "electricity_node",
-                "fuel_node"
-            ],
-            "fix_ratio_out_in_unit_flow",
-            0.7,
-            "Base"
-        ],
-        [
-            "unit__node__node",
-            [
-                "power_plant_b",
-                "electricity_node",
-                "fuel_node"
-            ],
-            "fix_ratio_out_in_unit_flow",
-            0.8,
-            "Base"
-        ],
-        [
-            "unit__to_node",
-            [
-                "power_plant_a",
-                "electricity_node"
-            ],
-            "unit_capacity",
-            100,
-            "Base"
-        ],
-        [
-            "unit__to_node",
-            [
-                "power_plant_b",
-                "electricity_node"
-            ],
-            "unit_capacity",
-            200.0,
-            "Base"
-        ]
-    ],
-    "alternatives": [
-        [
-            "Base",
-            "Base alternative"
-        ]
-    ],
-    "tools": [
-        [
-            "object_activity_control",
-            ""
-        ]
-    ],
-    "features": [
-        [
-            "commodity",
-            "is_active",
-            "boolean_value_list",
-            "boolean_value_list"
-        ],
-        [
-            "connection",
-            "is_active",
-            "boolean_value_list",
-            "boolean_value_list"
-        ],
-        [
-            "model",
-            "is_active",
-            "boolean_value_list",
-            "boolean_value_list"
-        ],
-        [
-            "node",
-            "is_active",
-            "boolean_value_list",
-            "boolean_value_list"
-        ],
-        [
-            "node__stochastic_structure",
-            "is_active",
-            "boolean_value_list",
-            "boolean_value_list"
-        ],
-        [
-            "node__temporal_block",
-            "is_active",
-            "boolean_value_list",
-            "boolean_value_list"
-        ],
-        [
-            "output",
-            "is_active",
-            "boolean_value_list",
-            "boolean_value_list"
-        ],
-        [
-            "report",
-            "is_active",
-            "boolean_value_list",
-            "boolean_value_list"
-        ],
-        [
-            "stochastic_scenario",
-            "is_active",
-            "boolean_value_list",
-            "boolean_value_list"
-        ],
-        [
-            "stochastic_structure",
-            "is_active",
-            "boolean_value_list",
-            "boolean_value_list"
-        ],
-        [
-            "temporal_block",
-            "is_active",
-            "boolean_value_list",
-            "boolean_value_list"
-        ],
-        [
-            "unit",
-            "is_active",
-            "boolean_value_list",
-            "boolean_value_list"
-        ],
-        [
-            "unit__from_node",
-            "is_active",
-            "boolean_value_list",
-            "boolean_value_list"
-        ],
-        [
-            "unit__to_node",
-            "is_active",
-            "boolean_value_list",
-            "boolean_value_list"
-        ],
-        [
-            "units_on__stochastic_structure",
-            "is_active",
-            "boolean_value_list",
-            "boolean_value_list"
-        ],
-        [
-            "units_on__temporal_block",
-            "is_active",
-            "boolean_value_list",
-            "boolean_value_list"
-        ],
-        [
-            "user_constraint",
-            "is_active",
-            "boolean_value_list",
-            "boolean_value_list"
         ]
     ],
     "tool_features": [
@@ -3738,108 +5323,175 @@
             false
         ]
     ],
-    "tool_feature_methods": [
+    "features": [
         [
-            "object_activity_control",
             "commodity",
             "is_active",
-            true
+            "boolean_value_list",
+            "boolean_value_list"
         ],
         [
-            "object_activity_control",
             "connection",
             "is_active",
-            true
+            "boolean_value_list",
+            "boolean_value_list"
         ],
         [
-            "object_activity_control",
             "model",
             "is_active",
-            true
+            "boolean_value_list",
+            "boolean_value_list"
         ],
         [
-            "object_activity_control",
             "node",
             "is_active",
-            true
+            "boolean_value_list",
+            "boolean_value_list"
         ],
         [
-            "object_activity_control",
             "node__stochastic_structure",
             "is_active",
-            true
+            "boolean_value_list",
+            "boolean_value_list"
         ],
         [
-            "object_activity_control",
             "node__temporal_block",
             "is_active",
-            true
+            "boolean_value_list",
+            "boolean_value_list"
         ],
         [
-            "object_activity_control",
             "output",
             "is_active",
-            true
+            "boolean_value_list",
+            "boolean_value_list"
         ],
         [
-            "object_activity_control",
             "report",
             "is_active",
-            true
+            "boolean_value_list",
+            "boolean_value_list"
         ],
         [
-            "object_activity_control",
             "stochastic_scenario",
             "is_active",
-            true
+            "boolean_value_list",
+            "boolean_value_list"
         ],
         [
-            "object_activity_control",
             "stochastic_structure",
             "is_active",
-            true
+            "boolean_value_list",
+            "boolean_value_list"
         ],
         [
-            "object_activity_control",
             "temporal_block",
             "is_active",
-            true
+            "boolean_value_list",
+            "boolean_value_list"
         ],
         [
-            "object_activity_control",
             "unit",
             "is_active",
-            true
+            "boolean_value_list",
+            "boolean_value_list"
         ],
         [
-            "object_activity_control",
             "unit__from_node",
             "is_active",
-            true
+            "boolean_value_list",
+            "boolean_value_list"
         ],
         [
-            "object_activity_control",
             "unit__to_node",
             "is_active",
-            true
+            "boolean_value_list",
+            "boolean_value_list"
         ],
         [
-            "object_activity_control",
             "units_on__stochastic_structure",
             "is_active",
-            true
+            "boolean_value_list",
+            "boolean_value_list"
         ],
         [
-            "object_activity_control",
             "units_on__temporal_block",
             "is_active",
-            true
+            "boolean_value_list",
+            "boolean_value_list"
         ],
         [
-            "object_activity_control",
             "user_constraint",
             "is_active",
-            true
+            "boolean_value_list",
+            "boolean_value_list"
+        ]
+    ],
+    "object_classes": [
+        [
+            "commodity",
+            "A good or product that can be consumed, produced, traded. E.g., electricity, oil, gas, water...",
+            281473533932880
+        ],
+        [
+            "connection",
+            "A transfer of commodities between nodes. E.g. electricity line, gas pipeline...",
+            280378317271233
+        ],
+        [
+            "investment_group",
+            "A group of investments that need to be done together.",
+            281105609585860
+        ],
+        [
+            "model",
+            "An instance of SpineOpt, that specifies general parameters such as the temporal horizon.",
+            281107035648412
+        ],
+        [
+            "node",
+            "A universal aggregator of commodify flows over units and connections, with storage capabilities.",
+            280740554077951
+        ],
+        [
+            "output",
+            "A variable name from SpineOpt that can be included in a report.",
+            280743406202948
+        ],
+        [
+            "report",
+            "A results report from a particular SpineOpt run, including the value of specific variables.",
+            281108461711708
+        ],
+        [
+            "settings",
+            "Internal SpineOpt settings. We kindly advise not to mess with this one.",
+            280375465144798
+        ],
+        [
+            "stochastic_scenario",
+            "A scenario for stochastic optimisation in SpineOpt.",
+            280743389491710
+        ],
+        [
+            "stochastic_structure",
+            "A group of stochastic scenarios that represent a structure.",
+            281470681806146
+        ],
+        [
+            "temporal_block",
+            "A length of time with a particular resolution.",
+            280376891207703
+        ],
+        [
+            "unit",
+            "A conversion of one/many comodities between nodes.",
+            281470681805429
+        ],
+        [
+            "user_constraint",
+            "A generic data-driven custom constraint.",
+            281473533931636
         ]
     ]
 }

--- a/examples/unit_commitment.json
+++ b/examples/unit_commitment.json
@@ -1,69 +1,330 @@
 {
-    "object_classes": [
+    "alternatives": [
         [
-            "commodity",
-            "A good or product that can be consumed, produced, traded. E.g., electricity, oil, gas, water...",
-            281473533932880
-        ],
-        [
-            "connection",
-            "A transfer of commodities between nodes. E.g. electricity line, gas pipeline...",
-            280378317271233
-        ],
-        [
-            "investment_group",
-            "A group of investments that need to be done together.",
-            281105609585860
-        ],
+            "Base",
+            "Base alternative"
+        ]
+    ],
+    "objects": [
         [
             "model",
-            "An instance of SpineOpt, that specifies general parameters such as the temporal horizon.",
-            281107035648412
+            "simple",
+            null
         ],
         [
             "node",
-            "A universal aggregator of commodify flows over units and connections, with storage capabilities.",
-            280740554077951
+            "electricity_node",
+            null
+        ],
+        [
+            "node",
+            "fuel_node",
+            null
         ],
         [
             "output",
-            "A variable name from SpineOpt that can be included in a report.",
-            280743406202948
+            "binary_gas_connection_flow",
+            null
+        ],
+        [
+            "output",
+            "connection_avg_intact_throughflow",
+            null
+        ],
+        [
+            "output",
+            "connection_avg_throughflow",
+            null
+        ],
+        [
+            "output",
+            "connection_flow",
+            null
+        ],
+        [
+            "output",
+            "connection_flow_costs",
+            null
+        ],
+        [
+            "output",
+            "connection_intact_flow",
+            null
+        ],
+        [
+            "output",
+            "connection_investment_costs",
+            null
+        ],
+        [
+            "output",
+            "connections_decommissioned",
+            null
+        ],
+        [
+            "output",
+            "connections_invested",
+            null
+        ],
+        [
+            "output",
+            "connections_invested_available",
+            null
+        ],
+        [
+            "output",
+            "contingency_is_binding",
+            null
+        ],
+        [
+            "output",
+            "fixed_om_costs",
+            null
+        ],
+        [
+            "output",
+            "fuel_costs",
+            null
+        ],
+        [
+            "output",
+            "mga_objective",
+            null
+        ],
+        [
+            "output",
+            "mp_objective_lowerbound",
+            null
+        ],
+        [
+            "output",
+            "node_injection",
+            null
+        ],
+        [
+            "output",
+            "node_pressure",
+            null
+        ],
+        [
+            "output",
+            "node_slack_neg",
+            null
+        ],
+        [
+            "output",
+            "node_slack_pos",
+            null
+        ],
+        [
+            "output",
+            "node_state",
+            null
+        ],
+        [
+            "output",
+            "node_voltage_angle",
+            null
+        ],
+        [
+            "output",
+            "nonspin_ramp_down_unit_flow",
+            null
+        ],
+        [
+            "output",
+            "nonspin_ramp_up_unit_flow",
+            null
+        ],
+        [
+            "output",
+            "nonspin_units_shut_down",
+            null
+        ],
+        [
+            "output",
+            "nonspin_units_started_up",
+            null
+        ],
+        [
+            "output",
+            "objective_penalties",
+            null
+        ],
+        [
+            "output",
+            "ramp_costs",
+            null
+        ],
+        [
+            "output",
+            "ramp_down_unit_flow",
+            null
+        ],
+        [
+            "output",
+            "ramp_up_unit_flow",
+            null
+        ],
+        [
+            "output",
+            "relative_optimality_gap",
+            null
+        ],
+        [
+            "output",
+            "renewable_curtailment_costs",
+            null
+        ],
+        [
+            "output",
+            "res_proc_costs",
+            null
+        ],
+        [
+            "output",
+            "shut_down_costs",
+            null
+        ],
+        [
+            "output",
+            "shut_down_unit_flow",
+            null
+        ],
+        [
+            "output",
+            "start_up_costs",
+            null
+        ],
+        [
+            "output",
+            "start_up_unit_flow",
+            null
+        ],
+        [
+            "output",
+            "storage_investment_costs",
+            null
+        ],
+        [
+            "output",
+            "storages_decommissioned",
+            null
+        ],
+        [
+            "output",
+            "storages_invested",
+            null
+        ],
+        [
+            "output",
+            "storages_invested_available",
+            null
+        ],
+        [
+            "output",
+            "taxes",
+            null
+        ],
+        [
+            "output",
+            "total_costs",
+            null
+        ],
+        [
+            "output",
+            "unit_flow",
+            null
+        ],
+        [
+            "output",
+            "unit_flow_op",
+            null
+        ],
+        [
+            "output",
+            "unit_flow_op_active",
+            null
+        ],
+        [
+            "output",
+            "unit_investment_costs",
+            null
+        ],
+        [
+            "output",
+            "units_available",
+            null
+        ],
+        [
+            "output",
+            "units_invested",
+            null
+        ],
+        [
+            "output",
+            "units_invested_available",
+            null
+        ],
+        [
+            "output",
+            "units_mothballed",
+            null
+        ],
+        [
+            "output",
+            "units_on",
+            null
+        ],
+        [
+            "output",
+            "units_on_costs",
+            null
+        ],
+        [
+            "output",
+            "units_shut_down",
+            null
+        ],
+        [
+            "output",
+            "units_started_up",
+            null
+        ],
+        [
+            "output",
+            "variable_om_costs",
+            null
         ],
         [
             "report",
-            "A results report from a particular SpineOpt run, including the value of specific variables.",
-            281108461711708
-        ],
-        [
-            "settings",
-            "Internal SpineOpt settings. We kindly advise not to mess with this one.",
-            280375465144798
+            "report1",
+            null
         ],
         [
             "stochastic_scenario",
-            "A scenario for stochastic optimisation in SpineOpt.",
-            280743389491710
+            "realization",
+            null
         ],
         [
             "stochastic_structure",
-            "A group of stochastic scenarios that represent a structure.",
-            281470681806146
+            "deterministic",
+            null
         ],
         [
             "temporal_block",
-            "A length of time with a particular resolution.",
-            280376891207703
+            "flat",
+            null
         ],
         [
             "unit",
-            "A conversion of one/many comodities between nodes.",
-            281470681805429
+            "power_plant_a",
+            null
         ],
         [
-            "user_constraint",
-            "A generic data-driven custom constraint.",
-            281473533931636
+            "unit",
+            "power_plant_b",
+            null
         ]
     ],
     "relationship_classes": [
@@ -75,6 +336,16 @@
             ],
             "Defines the `nodes` the `connection` can take input from, and holds most `connection_flow` variable specific parameters.",
             280378317271897
+        ],
+        [
+            "connection__from_node__investment_group",
+            [
+                "connection",
+                "node",
+                "investment_group"
+            ],
+            "Indicates which connection capacities are included in the capacity invested available of an investment group",
+            null
         ],
         [
             "connection__from_node__user_constraint",
@@ -131,6 +402,16 @@
             ],
             "Defines the `nodes` the `connection` can output to, and holds most `connection_flow` variable specific parameters.",
             280378317271898
+        ],
+        [
+            "connection__to_node__investment_group",
+            [
+                "connection",
+                "node",
+                "investment_group"
+            ],
+            "Indicates which connection capacities are included in the capacity invested available of an investment group",
+            null
         ],
         [
             "connection__to_node__user_constraint",
@@ -332,6 +613,16 @@
             281470681805657
         ],
         [
+            "unit__from_node__investment_group",
+            [
+                "unit",
+                "node",
+                "investment_group"
+            ],
+            "Indicates which unit capacities are included in the capacity invested available of an investment group",
+            null
+        ],
+        [
             "unit__from_node__user_constraint",
             [
                 "unit",
@@ -388,6 +679,16 @@
             281470681805658
         ],
         [
+            "unit__to_node__investment_group",
+            [
+                "unit",
+                "node",
+                "investment_group"
+            ],
+            "Indicates which unit capacities are included in the capacity invested available of an investment group",
+            null
+        ],
+        [
             "unit__to_node__user_constraint",
             [
                 "unit",
@@ -425,288 +726,6 @@
             null
         ]
     ],
-    "parameter_value_lists": [
-        [
-            "balance_type_list",
-            "balance_type_group"
-        ],
-        [
-            "balance_type_list",
-            "balance_type_node"
-        ],
-        [
-            "balance_type_list",
-            "balance_type_none"
-        ],
-        [
-            "boolean_value_list",
-            false
-        ],
-        [
-            "boolean_value_list",
-            true
-        ],
-        [
-            "commodity_physics_list",
-            "commodity_physics_lodf"
-        ],
-        [
-            "commodity_physics_list",
-            "commodity_physics_none"
-        ],
-        [
-            "commodity_physics_list",
-            "commodity_physics_ptdf"
-        ],
-        [
-            "connection_investment_variable_type_list",
-            "connection_investment_variable_type_continuous"
-        ],
-        [
-            "connection_investment_variable_type_list",
-            "connection_investment_variable_type_integer"
-        ],
-        [
-            "connection_type_list",
-            "connection_type_lossless_bidirectional"
-        ],
-        [
-            "connection_type_list",
-            "connection_type_normal"
-        ],
-        [
-            "constraint_sense_list",
-            "<="
-        ],
-        [
-            "constraint_sense_list",
-            "=="
-        ],
-        [
-            "constraint_sense_list",
-            ">="
-        ],
-        [
-            "db_lp_solver_list",
-            "KNITRO.jl"
-        ],
-        [
-            "db_lp_solver_list",
-            "CDCS.jl"
-        ],
-        [
-            "db_lp_solver_list",
-            "CDDLib.jl"
-        ],
-        [
-            "db_lp_solver_list",
-            "Clp.jl"
-        ],
-        [
-            "db_lp_solver_list",
-            "COSMO.jl"
-        ],
-        [
-            "db_lp_solver_list",
-            "CPLEX.jl"
-        ],
-        [
-            "db_lp_solver_list",
-            "CSDP.jl"
-        ],
-        [
-            "db_lp_solver_list",
-            "ECOS.jl"
-        ],
-        [
-            "db_lp_solver_list",
-            "Xpress.jl"
-        ],
-        [
-            "db_lp_solver_list",
-            "GLPK.jl"
-        ],
-        [
-            "db_lp_solver_list",
-            "Gurobi.jl"
-        ],
-        [
-            "db_lp_solver_list",
-            "HiGHS.jl"
-        ],
-        [
-            "db_lp_solver_list",
-            "Hypatia.jl"
-        ],
-        [
-            "db_lp_solver_list",
-            "Ipopt.jl"
-        ],
-        [
-            "db_lp_solver_list",
-            "MadNLP.jl"
-        ],
-        [
-            "db_lp_solver_list",
-            "MosekTools.jl"
-        ],
-        [
-            "db_lp_solver_list",
-            "NLopt.jl"
-        ],
-        [
-            "db_lp_solver_list",
-            "OSQP.jl"
-        ],
-        [
-            "db_lp_solver_list",
-            "ProxSDP.jl"
-        ],
-        [
-            "db_lp_solver_list",
-            "SCIP.jl"
-        ],
-        [
-            "db_lp_solver_list",
-            "SCS.jl"
-        ],
-        [
-            "db_lp_solver_list",
-            "SDPA.jl"
-        ],
-        [
-            "db_lp_solver_list",
-            "SDPNAL.jl"
-        ],
-        [
-            "db_lp_solver_list",
-            "SDPT3.jl"
-        ],
-        [
-            "db_lp_solver_list",
-            "SeDuMi.jl"
-        ],
-        [
-            "db_mip_solver_list",
-            "KNITRO.jl"
-        ],
-        [
-            "db_mip_solver_list",
-            "Cbc.jl"
-        ],
-        [
-            "db_mip_solver_list",
-            "CPLEX.jl"
-        ],
-        [
-            "db_mip_solver_list",
-            "HiGHS.jl"
-        ],
-        [
-            "db_mip_solver_list",
-            "Xpress.jl"
-        ],
-        [
-            "db_mip_solver_list",
-            "GLPK.jl"
-        ],
-        [
-            "db_mip_solver_list",
-            "Gurobi.jl"
-        ],
-        [
-            "db_mip_solver_list",
-            "Juniper.jl"
-        ],
-        [
-            "db_mip_solver_list",
-            "MosekTools.jl"
-        ],
-        [
-            "db_mip_solver_list",
-            "SCIP.jl"
-        ],
-        [
-            "duration_unit_list",
-            "hour"
-        ],
-        [
-            "duration_unit_list",
-            "minute"
-        ],
-        [
-            "model_type_list",
-            "spineopt_benders"
-        ],
-        [
-            "model_type_list",
-            "spineopt_standard"
-        ],
-        [
-            "model_type_list",
-            "spineopt_other"
-        ],
-        [
-            "model_type_list",
-            "spineopt_mga"
-        ],
-        [
-            "node_opf_type_list",
-            "node_opf_type_normal"
-        ],
-        [
-            "node_opf_type_list",
-            "node_opf_type_reference"
-        ],
-        [
-            "unit_investment_variable_type_list",
-            "unit_investment_variable_type_continuous"
-        ],
-        [
-            "unit_investment_variable_type_list",
-            "unit_investment_variable_type_integer"
-        ],
-        [
-            "unit_online_variable_type_list",
-            "unit_online_variable_type_binary"
-        ],
-        [
-            "unit_online_variable_type_list",
-            "unit_online_variable_type_integer"
-        ],
-        [
-            "unit_online_variable_type_list",
-            "unit_online_variable_type_linear"
-        ],
-        [
-            "unit_online_variable_type_list",
-            "unit_online_variable_type_none"
-        ],
-        [
-            "variable_type_list",
-            "variable_type_binary"
-        ],
-        [
-            "variable_type_list",
-            "variable_type_continuous"
-        ],
-        [
-            "variable_type_list",
-            "variable_type_integer"
-        ],
-        [
-            "write_mps_file_list",
-            "write_mps_always"
-        ],
-        [
-            "write_mps_file_list",
-            "write_mps_never"
-        ],
-        [
-            "write_mps_file_list",
-            "write_mps_on_no_solve"
-        ]
-    ],
     "object_parameters": [
         [
             "commodity",
@@ -721,6 +740,13 @@
             "commodity_physics_none",
             "commodity_physics_list",
             "Defines if the `commodity` follows lodf or ptdf physics."
+        ],
+        [
+            "commodity",
+            "commodity_physics_duration",
+            null,
+            null,
+            "For how long the `commodity_physics` should apply relative to the start of the window."
         ],
         [
             "commodity",
@@ -752,6 +778,13 @@
         ],
         [
             "connection",
+            "benders_starting_connections_invested",
+            null,
+            null,
+            "Fixes the number of connections invested during the first Benders iteration"
+        ],
+        [
+            "connection",
             "candidate_connections",
             null,
             null,
@@ -760,7 +793,7 @@
         [
             "connection",
             "connection_availability_factor",
-            1.0,
+            1,
             null,
             "Availability of the `connection`, acting as a multiplier on its `connection_capacity`. Typically between 0-1."
         ],
@@ -905,6 +938,41 @@
             "If false, the object is excluded from the model if the tool filter object activity control is specified"
         ],
         [
+            "investment_group",
+            "equal_investments",
+            false,
+            "boolean_value_list",
+            "Whether all entities in the group must have the same investment decision."
+        ],
+        [
+            "investment_group",
+            "maximum_capacity_invested_available",
+            null,
+            null,
+            "Upper bound on the capacity invested available in the group at any point in time."
+        ],
+        [
+            "investment_group",
+            "maximum_entities_invested_available",
+            null,
+            null,
+            "Upper bound on the number of entities invested available in the group at any point in time."
+        ],
+        [
+            "investment_group",
+            "minimum_capacity_invested_available",
+            null,
+            null,
+            "Lower bound on the capacity invested available in the group at any point in time."
+        ],
+        [
+            "investment_group",
+            "minimum_entities_invested_available",
+            null,
+            null,
+            "Lower bound on the number of entities invested available in the group at any point in time."
+        ],
+        [
             "model",
             "big_m",
             1000000,
@@ -922,14 +990,23 @@
             "model",
             "db_lp_solver_options",
             {
-                "type": "map",
-                "index_type": "str",
                 "data": [
+                    [
+                        "Clp.jl",
+                        {
+                            "data": [
+                                [
+                                    "LogLevel",
+                                    0
+                                ]
+                            ],
+                            "type": "map",
+                            "index_type": "str"
+                        }
+                    ],
                     [
                         "HiGHS.jl",
                         {
-                            "type": "map",
-                            "index_type": "str",
                             "data": [
                                 [
                                     "presolve",
@@ -939,23 +1016,14 @@
                                     "time_limit",
                                     300.01
                                 ]
-                            ]
-                        }
-                    ],
-                    [
-                        "Clp.jl",
-                        {
+                            ],
                             "type": "map",
-                            "index_type": "str",
-                            "data": [
-                                [
-                                    "LogLevel",
-                                    0.0
-                                ]
-                            ]
+                            "index_type": "str"
                         }
                     ]
-                ]
+                ],
+                "type": "map",
+                "index_type": "str"
             },
             null,
             "Map parameter containing LP solver option name option value pairs. See solver documentation for supported solver options"
@@ -971,65 +1039,65 @@
             "model",
             "db_mip_solver_options",
             {
-                "type": "map",
-                "index_type": "str",
                 "data": [
-                    [
-                        "HiGHS.jl",
-                        {
-                            "type": "map",
-                            "index_type": "str",
-                            "data": [
-                                [
-                                    "presolve",
-                                    "on"
-                                ],
-                                [
-                                    "mip_rel_gap",
-                                    0.01
-                                ],
-                                [
-                                    "threads",
-                                    0.0
-                                ],
-                                [
-                                    "time_limit",
-                                    300.01
-                                ]
-                            ]
-                        }
-                    ],
-                    [
-                        "Cbc.jl",
-                        {
-                            "type": "map",
-                            "index_type": "str",
-                            "data": [
-                                [
-                                    "ratioGap",
-                                    0.01
-                                ],
-                                [
-                                    "logLevel",
-                                    0.0
-                                ]
-                            ]
-                        }
-                    ],
                     [
                         "CPLEX.jl",
                         {
-                            "type": "map",
-                            "index_type": "str",
                             "data": [
                                 [
                                     "CPX_PARAM_EPGAP",
                                     0.01
                                 ]
-                            ]
+                            ],
+                            "type": "map",
+                            "index_type": "str"
+                        }
+                    ],
+                    [
+                        "Cbc.jl",
+                        {
+                            "data": [
+                                [
+                                    "logLevel",
+                                    0
+                                ],
+                                [
+                                    "ratioGap",
+                                    0.01
+                                ]
+                            ],
+                            "type": "map",
+                            "index_type": "str"
+                        }
+                    ],
+                    [
+                        "HiGHS.jl",
+                        {
+                            "data": [
+                                [
+                                    "mip_rel_gap",
+                                    0.01
+                                ],
+                                [
+                                    "presolve",
+                                    "on"
+                                ],
+                                [
+                                    "threads",
+                                    0
+                                ],
+                                [
+                                    "time_limit",
+                                    300.01
+                                ]
+                            ],
+                            "type": "map",
+                            "index_type": "str"
                         }
                     ]
-                ]
+                ],
+                "type": "map",
+                "index_type": "str"
             },
             null,
             "Map parameter containing MIP solver option name option value pairs for MIP. See solver documentation for supported solver options"
@@ -1058,7 +1126,7 @@
         [
             "model",
             "max_iterations",
-            10.0,
+            10,
             null,
             "Specifies the maximum number of iterations for the model. Currently only used for the master problem within a decomposed structure"
         ],
@@ -1078,10 +1146,17 @@
         ],
         [
             "model",
+            "min_iterations",
+            1,
+            null,
+            "Specifies the minimum number of iterations for the model. Currently only used for the master problem within a decomposed structure"
+        ],
+        [
+            "model",
             "model_end",
             {
-                "type": "date_time",
-                "data": "2000-01-02T00:00:00"
+                "data": "2000-01-02T00:00:00.0",
+                "type": "date_time"
             },
             null,
             "Defines the last timestamp to be modelled. Rolling optimization terminates after passing this point."
@@ -1090,8 +1165,8 @@
             "model",
             "model_start",
             {
-                "type": "date_time",
-                "data": "2000-01-01T00:00:00"
+                "data": "2000-01-01T00:00:00.0",
+                "type": "date_time"
             },
             null,
             "Defines the first timestamp to be modelled. Relative `temporal_blocks` refer to this value for their start and end."
@@ -1154,6 +1229,13 @@
         ],
         [
             "node",
+            "benders_starting_storages_invested",
+            null,
+            null,
+            "Fixes the number of storages invested during the first Benders iteration"
+        ],
+        [
+            "node",
             "candidate_storages",
             null,
             null,
@@ -1162,7 +1244,7 @@
         [
             "node",
             "demand",
-            0.0,
+            0,
             null,
             "Demand for the `commodity` of a `node`. Energy gains can be represented using negative `demand`."
         ],
@@ -1211,14 +1293,14 @@
         [
             "node",
             "frac_state_loss",
-            0.0,
+            0,
             null,
             "Self-discharge coefficient for `node_state` variables. Effectively, represents the *loss power per unit of state*."
         ],
         [
             "node",
             "fractional_demand",
-            0.0,
+            0,
             null,
             "The fraction of a `node` group's `demand` applied for the `node` in question."
         ],
@@ -1372,14 +1454,14 @@
         [
             "node",
             "node_state_min",
-            0.0,
+            0,
             null,
             "The minimum permitted value for a `node_state` variable."
         ],
         [
             "node",
             "state_coeff",
-            1.0,
+            1,
             null,
             "Represents the `commodity` content of a `node_state` variable in respect to the `unit_flow` and `connection_flow` variables. Essentially, acts as a coefficient on the `node_state` variable in the `:node_injection` constraint."
         ],
@@ -1484,7 +1566,7 @@
         [
             "settings",
             "version",
-            8,
+            10,
             null,
             "Current version of the SpineOpt data structure. Modify it at your own risk (but please don't)."
         ],
@@ -1534,8 +1616,8 @@
             "temporal_block",
             "resolution",
             {
-                "type": "duration",
-                "data": "1h"
+                "data": "1h",
+                "type": "duration"
             },
             null,
             "Temporal resolution of the `temporal_block`. Essentially, divides the period between `block_start` and `block_end` into `TimeSlices` with the input `resolution`."
@@ -1543,9 +1625,16 @@
         [
             "temporal_block",
             "weight",
-            1.0,
+            1,
             null,
             "Weighting factor of the temporal block associated with the objective function"
+        ],
+        [
+            "unit",
+            "benders_starting_units_invested",
+            null,
+            null,
+            "Fixes the number of units invested during the first Benders iteration"
         ],
         [
             "unit",
@@ -1655,7 +1744,7 @@
         [
             "unit",
             "number_of_units",
-            1.0,
+            1,
             null,
             "Denotes the number of 'sub units' aggregated to form the modelled `unit`."
         ],
@@ -1683,7 +1772,7 @@
         [
             "unit",
             "unit_availability_factor",
-            1.0,
+            1,
             null,
             "Availability of the `unit`, acting as a multiplier on its `unit_capacity`. Typically between 0-1."
         ],
@@ -1767,9 +1856,90 @@
         [
             "user_constraint",
             "right_hand_side",
-            0.0,
+            0,
             null,
             "The right-hand side, constant term in a `user_constraint`. Can be time-dependent and used e.g. for complicated efficiency approximations."
+        ],
+        [
+            "user_constraint",
+            "user_constraint_slack_penalty",
+            null,
+            null,
+            "A penalty for violating a user constraint."
+        ]
+    ],
+    "relationship_parameter_values": [
+        [
+            "unit__from_node",
+            [
+                "power_plant_a",
+                "fuel_node"
+            ],
+            "vom_cost",
+            25,
+            "Base"
+        ],
+        [
+            "unit__from_node",
+            [
+                "power_plant_b",
+                "fuel_node"
+            ],
+            "vom_cost",
+            50,
+            "Base"
+        ],
+        [
+            "unit__node__node",
+            [
+                "power_plant_a",
+                "electricity_node",
+                "fuel_node"
+            ],
+            "fix_ratio_out_in_unit_flow",
+            0.7,
+            "Base"
+        ],
+        [
+            "unit__node__node",
+            [
+                "power_plant_b",
+                "electricity_node",
+                "fuel_node"
+            ],
+            "fix_ratio_out_in_unit_flow",
+            0.8,
+            "Base"
+        ],
+        [
+            "unit__to_node",
+            [
+                "power_plant_a",
+                "electricity_node"
+            ],
+            "unit_capacity",
+            100,
+            "Base"
+        ],
+        [
+            "unit__to_node",
+            [
+                "power_plant_b",
+                "electricity_node"
+            ],
+            "minimum_operating_point",
+            0.1,
+            "Base"
+        ],
+        [
+            "unit__to_node",
+            [
+                "power_plant_b",
+                "electricity_node"
+            ],
+            "unit_capacity",
+            200,
+            "Base"
         ]
     ],
     "relationship_parameters": [
@@ -1783,7 +1953,7 @@
         [
             "connection__from_node",
             "connection_conv_cap_to_flow",
-            1.0,
+            1,
             null,
             "Optional coefficient for `connection_capacity` unit conversions in the case that the `connection_capacity` value is incompatible with the desired `connection_flow` units."
         ],
@@ -1881,7 +2051,7 @@
         [
             "connection__from_node__user_constraint",
             "connection_flow_coefficient",
-            0.0,
+            0,
             null,
             "defines the user constraint coefficient on the connection flow variable in the from direction"
         ],
@@ -1896,8 +2066,8 @@
             "connection__node__node",
             "connection_flow_delay",
             {
-                "type": "duration",
-                "data": "0h"
+                "data": "0h",
+                "type": "duration"
             },
             null,
             "Delays the `connection_flows` associated with the latter `node` in respect to the `connection_flows` associated with the first `node`."
@@ -1914,7 +2084,7 @@
             "fix_ratio_out_in_connection_flow",
             null,
             null,
-            "Fix the ratio between the `connection_flow` from the first `node` and the `connection_flow` to the second `node`."
+            "Fix the ratio between an outgoing `connection_flow` to the first `node` and an incoming `connection_flow` from the second `node`."
         ],
         [
             "connection__node__node",
@@ -1935,14 +2105,14 @@
             "max_ratio_out_in_connection_flow",
             null,
             null,
-            "Maximum ratio between the `connection_flow` from the first `node` and the `connection_flow` to the second `node`."
+            "Maximum ratio between an outgoing `connection_flow` to the first `node` and an incoming `connection_flow` from the second `node`."
         ],
         [
             "connection__node__node",
             "min_ratio_out_in_connection_flow",
             null,
             null,
-            "Minimum ratio between the `connection_flow` from the first `node` and the `connection_flow` to the second `node`."
+            "Minimum ratio between an outgoing `connection_flow` to the first `node` and an incoming `connection_flow` from the second `node`."
         ],
         [
             "connection__to_node",
@@ -1954,7 +2124,7 @@
         [
             "connection__to_node",
             "connection_conv_cap_to_flow",
-            1.0,
+            1,
             null,
             "Optional coefficient for `connection_capacity` unit conversions in the case the `connection_capacity` value is incompatible with the desired `connection_flow` units."
         ],
@@ -2052,28 +2222,28 @@
         [
             "connection__to_node__user_constraint",
             "connection_flow_coefficient",
-            0.0,
+            0,
             null,
             "defines the user constraint coefficient on the connection flow variable in the to direction"
         ],
         [
             "connection__user_constraint",
             "connections_invested_available_coefficient",
-            0.0,
+            0,
             null,
             "coefficient of `connections_invested_available` in the specific `user_constraint`"
         ],
         [
             "connection__user_constraint",
             "connections_invested_coefficient",
-            0.0,
+            0,
             null,
             "coefficient of `connections_invested` in the specific `user_constraint`"
         ],
         [
             "node__node",
             "diff_coeff",
-            0.0,
+            0,
             null,
             "Commodity diffusion coefficient between two `nodes`. Effectively, denotes the *diffusion power per unit of state* from the first `node` to the second."
         ],
@@ -2101,28 +2271,28 @@
         [
             "node__user_constraint",
             "demand_coefficient",
-            0.0,
+            0,
             null,
             "coefficient of the specified node's demand in the specified user constraint"
         ],
         [
             "node__user_constraint",
             "node_state_coefficient",
-            0.0,
+            0,
             null,
             "Coefficient of the specified node's state variable in the specified user constraint."
         ],
         [
             "node__user_constraint",
             "storages_invested_available_coefficient",
-            0.0,
+            0,
             null,
             "Coefficient of the specified node's storages invested available variable in the specified user constraint."
         ],
         [
             "node__user_constraint",
             "storages_invested_coefficient",
-            0.0,
+            0,
             null,
             "Coefficient of the specified node's storage investment variable in the specified user constraint."
         ],
@@ -2143,7 +2313,7 @@
         [
             "stochastic_structure__stochastic_scenario",
             "weight_relative_to_parents",
-            1.0,
+            1,
             null,
             "The weight of the `stochastic_scenario` in the objective function relative to its parents."
         ],
@@ -2332,7 +2502,7 @@
         [
             "unit__from_node",
             "min_unit_flow",
-            0.0,
+            0,
             null,
             "Set lower bound of the `unit_flow` variable."
         ],
@@ -2394,6 +2564,20 @@
         ],
         [
             "unit__from_node",
+            "shut_down_limit",
+            null,
+            null,
+            "Max. downward ramp for units shutting down"
+        ],
+        [
+            "unit__from_node",
+            "start_up_limit",
+            null,
+            null,
+            "Maximum ramp-up during startups."
+        ],
+        [
+            "unit__from_node",
             "unit_capacity",
             null,
             null,
@@ -2402,7 +2586,7 @@
         [
             "unit__from_node",
             "unit_conv_cap_to_flow",
-            1.0,
+            1,
             null,
             "Optional coefficient for `unit_capacity` unit conversions in the case the `unit_capacity` value is incompatible with the desired `unit_flow` units."
         ],
@@ -2437,7 +2621,7 @@
         [
             "unit__from_node__user_constraint",
             "unit_flow_coefficient",
-            0.0,
+            0,
             null,
             "Coefficient of a `unit_flow` variable for a custom `user_constraint`."
         ],
@@ -2472,28 +2656,28 @@
         [
             "unit__node__node",
             "fix_units_on_coefficient_in_in",
-            0.0,
+            0,
             null,
             "Optional coefficient for the `units_on` variable impacting the `fix_ratio_in_in_unit_flow` constraint."
         ],
         [
             "unit__node__node",
             "fix_units_on_coefficient_in_out",
-            0.0,
+            0,
             null,
             "Optional coefficient for the `units_on` variable impacting the `fix_ratio_in_out_unit_flow` constraint."
         ],
         [
             "unit__node__node",
             "fix_units_on_coefficient_out_in",
-            0.0,
+            0,
             null,
             "Optional coefficient for the `units_on` variable impacting the `fix_ratio_out_in_unit_flow` constraint."
         ],
         [
             "unit__node__node",
             "fix_units_on_coefficient_out_out",
-            0.0,
+            0,
             null,
             "Optional coefficient for the `units_on` variable impacting the `fix_ratio_out_out_unit_flow` constraint."
         ],
@@ -2528,28 +2712,28 @@
         [
             "unit__node__node",
             "max_units_on_coefficient_in_in",
-            0.0,
+            0,
             null,
             "Optional coefficient for the `units_on` variable impacting the `max_ratio_in_in_unit_flow` constraint."
         ],
         [
             "unit__node__node",
             "max_units_on_coefficient_in_out",
-            0.0,
+            0,
             null,
             "Optional coefficient for the `units_on` variable impacting the `max_ratio_in_out_unit_flow` constraint."
         ],
         [
             "unit__node__node",
             "max_units_on_coefficient_out_in",
-            0.0,
+            0,
             null,
             "Optional coefficient for the `units_on` variable impacting the `max_ratio_out_in_unit_flow` constraint."
         ],
         [
             "unit__node__node",
             "max_units_on_coefficient_out_out",
-            0.0,
+            0,
             null,
             "Optional coefficient for the `units_on` variable impacting the `max_ratio_out_out_unit_flow` constraint."
         ],
@@ -2584,35 +2768,35 @@
         [
             "unit__node__node",
             "min_units_on_coefficient_in_in",
-            0.0,
+            0,
             null,
             "Optional coefficient for the `units_on` variable impacting the `min_ratio_in_in_unit_flow` constraint."
         ],
         [
             "unit__node__node",
             "min_units_on_coefficient_in_out",
-            0.0,
+            0,
             null,
             "Optional coefficient for the `units_on` variable impacting the `min_ratio_in_out_unit_flow` constraint."
         ],
         [
             "unit__node__node",
             "min_units_on_coefficient_out_in",
-            0.0,
+            0,
             null,
             "Optional coefficient for the `units_on` variable impacting the `min_ratio_out_in_unit_flow` constraint."
         ],
         [
             "unit__node__node",
             "min_units_on_coefficient_out_out",
-            0.0,
+            0,
             null,
             "Optional coefficient for the `units_on` variable impacting the `min_ratio_out_out_unit_flow` constraint."
         ],
         [
             "unit__node__node",
             "unit_idle_heat_rate",
-            0.0,
+            0,
             null,
             "Flow from node1 per unit time and per `units_on` that results in no additional flow to node2"
         ],
@@ -2626,7 +2810,7 @@
         [
             "unit__node__node",
             "unit_start_flow",
-            0.0,
+            0,
             null,
             "Flow from node1 that is incurred when a unit is started up."
         ],
@@ -2793,66 +2977,10 @@
         ],
         [
             "unit__to_node",
-            "max_res_shutdown_ramp",
-            null,
-            null,
-            "Maximum non-spinning reserve ramp-down for online units providing reserves during shut-downs"
-        ],
-        [
-            "unit__to_node",
-            "max_res_startup_ramp",
-            null,
-            null,
-            "Maximum non-spinning reserve ramp-up for offline units scheduled for reserve provision"
-        ],
-        [
-            "unit__to_node",
-            "max_shutdown_ramp",
-            null,
-            null,
-            "Maximum ramp-down during shutdowns"
-        ],
-        [
-            "unit__to_node",
-            "max_startup_ramp",
-            null,
-            null,
-            "Maximum ramp-up during startups"
-        ],
-        [
-            "unit__to_node",
             "max_total_cumulated_unit_flow_to_node",
             null,
             null,
             "Bound on the maximum cumulated flows of a unit group to a node group, e.g. total GHG emissions."
-        ],
-        [
-            "unit__to_node",
-            "min_res_shutdown_ramp",
-            null,
-            null,
-            "Minimum non-spinning reserve ramp-down for online units providing reserves during shut-downs"
-        ],
-        [
-            "unit__to_node",
-            "min_res_startup_ramp",
-            null,
-            null,
-            "Minimum non-spinning reserve ramp-up for offline units scheduled for reserve provision"
-        ],
-        [
-            "unit__to_node",
-            "min_shutdown_ramp",
-            null,
-            null,
-            "Minimum ramp-up during startups"
-        ],
-        [
-            "unit__to_node",
-            "min_startup_ramp",
-            null,
-            null,
-            "Minimum ramp-up during startups"
         ],
         [
             "unit__to_node",
@@ -2864,7 +2992,7 @@
         [
             "unit__to_node",
             "min_unit_flow",
-            0.0,
+            0,
             null,
             "Set lower bound of the `unit_flow` variable."
         ],
@@ -2926,6 +3054,20 @@
         ],
         [
             "unit__to_node",
+            "shut_down_limit",
+            null,
+            null,
+            "Maximum ramp-down during shutdowns"
+        ],
+        [
+            "unit__to_node",
+            "start_up_limit",
+            null,
+            null,
+            "Maximum ramp-up during startups"
+        ],
+        [
+            "unit__to_node",
             "unit_capacity",
             null,
             null,
@@ -2934,7 +3076,7 @@
         [
             "unit__to_node",
             "unit_conv_cap_to_flow",
-            1.0,
+            1,
             null,
             "Optional coefficient for `unit_capacity` unit conversions in the case the `unit_capacity` value is incompatible with the desired `unit_flow` units."
         ],
@@ -2969,35 +3111,35 @@
         [
             "unit__to_node__user_constraint",
             "unit_flow_coefficient",
-            0.0,
+            0,
             null,
             "Coefficient of a `unit_flow` variable for a custom `user_constraint`."
         ],
         [
             "unit__user_constraint",
             "units_invested_available_coefficient",
-            0.0,
+            0,
             null,
             "Coefficient of the `units_invested_available` variable in the specified `user_constraint`."
         ],
         [
             "unit__user_constraint",
             "units_invested_coefficient",
-            0.0,
+            0,
             null,
             "Coefficient of the `units_invested` variable in the specified `user_constraint`."
         ],
         [
             "unit__user_constraint",
             "units_on_coefficient",
-            0.0,
+            0,
             null,
             "Coefficient of a `units_on` variable for a custom `user_constraint`."
         ],
         [
             "unit__user_constraint",
             "units_started_up_coefficient",
-            0.0,
+            0,
             null,
             "Coefficient of a `units_started_up` variable for a custom `user_constraint`."
         ],
@@ -3016,321 +3158,2067 @@
             "If false, the object is excluded from the model if the tool filter object activity control is specified"
         ]
     ],
-    "objects": [
+    "tools": [
         [
-            "model",
-            "simple",
-            null
-        ],
+            "object_activity_control",
+            ""
+        ]
+    ],
+    "object_parameter_values": [
         [
             "node",
             "electricity_node",
-            null
+            "demand",
+            {
+                "data": {
+                    "2000-01-01T00:00:00.0": 90.0,
+                    "2000-01-01T01:00:00.0": 90.0,
+                    "2000-01-01T02:00:00.0": 90.0,
+                    "2000-01-01T03:00:00.0": 90.0,
+                    "2000-01-01T04:00:00.0": 90.0,
+                    "2000-01-01T05:00:00.0": 130.0,
+                    "2000-01-01T06:00:00.0": 130.0,
+                    "2000-01-01T07:00:00.0": 130.0,
+                    "2000-01-01T08:00:00.0": 130.0,
+                    "2000-01-01T09:00:00.0": 130.0,
+                    "2000-01-01T10:00:00.0": 50.0,
+                    "2000-01-01T11:00:00.0": 50.0,
+                    "2000-01-01T12:00:00.0": 50.0,
+                    "2000-01-01T13:00:00.0": 50.0,
+                    "2000-01-01T14:00:00.0": 50.0,
+                    "2000-01-01T15:00:00.0": 50.0,
+                    "2000-01-01T16:00:00.0": 130.0,
+                    "2000-01-01T17:00:00.0": 130.0,
+                    "2000-01-01T18:00:00.0": 130.0,
+                    "2000-01-01T19:00:00.0": 130.0,
+                    "2000-01-01T20:00:00.0": 130.0,
+                    "2000-01-01T21:00:00.0": 130.0,
+                    "2000-01-01T22:00:00.0": 130.0,
+                    "2000-01-01T23:00:00.0": 90.0
+                },
+                "type": "time_series",
+                "index": {
+                    "ignore_year": false,
+                    "repeat": false
+                }
+            },
+            "Base"
         ],
         [
             "node",
             "fuel_node",
-            null
-        ],
-        [
-            "output",
-            "binary_gas_connection_flow",
-            null
-        ],
-        [
-            "output",
-            "connection_avg_intact_throughflow",
-            null
-        ],
-        [
-            "output",
-            "connection_avg_throughflow",
-            null
-        ],
-        [
-            "output",
-            "connection_flow",
-            null
-        ],
-        [
-            "output",
-            "connection_flow_costs",
-            null
-        ],
-        [
-            "output",
-            "connection_intact_flow",
-            null
-        ],
-        [
-            "output",
-            "connection_investment_costs",
-            null
-        ],
-        [
-            "output",
-            "connections_decommissioned",
-            null
-        ],
-        [
-            "output",
-            "connections_invested",
-            null
-        ],
-        [
-            "output",
-            "connections_invested_available",
-            null
-        ],
-        [
-            "output",
-            "contingency_is_binding",
-            null
-        ],
-        [
-            "output",
-            "fixed_om_costs",
-            null
-        ],
-        [
-            "output",
-            "fuel_costs",
-            null
-        ],
-        [
-            "output",
-            "mga_objective",
-            null
-        ],
-        [
-            "output",
-            "mp_objective_lowerbound",
-            null
-        ],
-        [
-            "output",
-            "node_injection",
-            null
-        ],
-        [
-            "output",
-            "node_pressure",
-            null
-        ],
-        [
-            "output",
-            "node_slack_neg",
-            null
-        ],
-        [
-            "output",
-            "node_slack_pos",
-            null
-        ],
-        [
-            "output",
-            "node_state",
-            null
-        ],
-        [
-            "output",
-            "node_voltage_angle",
-            null
-        ],
-        [
-            "output",
-            "nonspin_ramp_down_unit_flow",
-            null
-        ],
-        [
-            "output",
-            "nonspin_ramp_up_unit_flow",
-            null
-        ],
-        [
-            "output",
-            "nonspin_units_shut_down",
-            null
-        ],
-        [
-            "output",
-            "nonspin_units_started_up",
-            null
-        ],
-        [
-            "output",
-            "objective_penalties",
-            null
-        ],
-        [
-            "output",
-            "ramp_costs",
-            null
-        ],
-        [
-            "output",
-            "ramp_down_unit_flow",
-            null
-        ],
-        [
-            "output",
-            "ramp_up_unit_flow",
-            null
-        ],
-        [
-            "output",
-            "renewable_curtailment_costs",
-            null
-        ],
-        [
-            "output",
-            "res_proc_costs",
-            null
-        ],
-        [
-            "output",
-            "shut_down_costs",
-            null
-        ],
-        [
-            "output",
-            "shut_down_unit_flow",
-            null
-        ],
-        [
-            "output",
-            "start_up_costs",
-            null
-        ],
-        [
-            "output",
-            "start_up_unit_flow",
-            null
-        ],
-        [
-            "output",
-            "storage_investment_costs",
-            null
-        ],
-        [
-            "output",
-            "storages_decommissioned",
-            null
-        ],
-        [
-            "output",
-            "storages_invested",
-            null
-        ],
-        [
-            "output",
-            "storages_invested_available",
-            null
-        ],
-        [
-            "output",
-            "taxes",
-            null
-        ],
-        [
-            "output",
-            "total_costs",
-            null
-        ],
-        [
-            "output",
-            "unit_flow",
-            null
-        ],
-        [
-            "output",
-            "unit_flow_op",
-            null
-        ],
-        [
-            "output",
-            "unit_flow_op_active",
-            null
-        ],
-        [
-            "output",
-            "unit_investment_costs",
-            null
-        ],
-        [
-            "output",
-            "units_available",
-            null
-        ],
-        [
-            "output",
-            "units_invested",
-            null
-        ],
-        [
-            "output",
-            "units_invested_available",
-            null
-        ],
-        [
-            "output",
-            "units_mothballed",
-            null
-        ],
-        [
-            "output",
-            "units_on",
-            null
-        ],
-        [
-            "output",
-            "units_on_costs",
-            null
-        ],
-        [
-            "output",
-            "units_shut_down",
-            null
-        ],
-        [
-            "output",
-            "units_started_up",
-            null
-        ],
-        [
-            "output",
-            "variable_om_costs",
-            null
-        ],
-        [
-            "report",
-            "report1",
-            null
-        ],
-        [
-            "stochastic_scenario",
-            "realization",
-            null
-        ],
-        [
-            "stochastic_structure",
-            "deterministic",
-            null
+            "balance_type",
+            "balance_type_none",
+            "Base"
         ],
         [
             "temporal_block",
             "flat",
-            null
-        ],
-        [
-            "unit",
-            "power_plant_a",
-            null
+            "resolution",
+            {
+                "data": "1h",
+                "type": "duration"
+            },
+            "Base"
         ],
         [
             "unit",
             "power_plant_b",
-            null
+            "initial_units_on",
+            0,
+            "Base"
+        ],
+        [
+            "unit",
+            "power_plant_b",
+            "min_down_time",
+            {
+                "data": "8h",
+                "type": "duration"
+            },
+            "Base"
+        ],
+        [
+            "unit",
+            "power_plant_b",
+            "min_up_time",
+            {
+                "data": "8h",
+                "type": "duration"
+            },
+            "Base"
+        ],
+        [
+            "unit",
+            "power_plant_b",
+            "online_variable_type",
+            "unit_online_variable_type_binary",
+            "Base"
+        ],
+        [
+            "unit",
+            "power_plant_b",
+            "shut_down_cost",
+            7,
+            "Base"
+        ],
+        [
+            "unit",
+            "power_plant_b",
+            "start_up_cost",
+            5,
+            "Base"
+        ],
+        [
+            "unit",
+            "power_plant_b",
+            "units_on_cost",
+            3,
+            "Base"
+        ]
+    ],
+    "tool_feature_methods": [
+        [
+            "object_activity_control",
+            "commodity",
+            "is_active",
+            [
+                [
+                    116,
+                    114,
+                    117,
+                    101
+                ],
+                null
+            ]
+        ],
+        [
+            "object_activity_control",
+            "connection",
+            "is_active",
+            [
+                [
+                    116,
+                    114,
+                    117,
+                    101
+                ],
+                null
+            ]
+        ],
+        [
+            "object_activity_control",
+            "model",
+            "is_active",
+            [
+                [
+                    116,
+                    114,
+                    117,
+                    101
+                ],
+                null
+            ]
+        ],
+        [
+            "object_activity_control",
+            "node",
+            "is_active",
+            [
+                [
+                    116,
+                    114,
+                    117,
+                    101
+                ],
+                null
+            ]
+        ],
+        [
+            "object_activity_control",
+            "node__stochastic_structure",
+            "is_active",
+            [
+                [
+                    116,
+                    114,
+                    117,
+                    101
+                ],
+                null
+            ]
+        ],
+        [
+            "object_activity_control",
+            "node__temporal_block",
+            "is_active",
+            [
+                [
+                    116,
+                    114,
+                    117,
+                    101
+                ],
+                null
+            ]
+        ],
+        [
+            "object_activity_control",
+            "output",
+            "is_active",
+            [
+                [
+                    116,
+                    114,
+                    117,
+                    101
+                ],
+                null
+            ]
+        ],
+        [
+            "object_activity_control",
+            "report",
+            "is_active",
+            [
+                [
+                    116,
+                    114,
+                    117,
+                    101
+                ],
+                null
+            ]
+        ],
+        [
+            "object_activity_control",
+            "stochastic_scenario",
+            "is_active",
+            [
+                [
+                    116,
+                    114,
+                    117,
+                    101
+                ],
+                null
+            ]
+        ],
+        [
+            "object_activity_control",
+            "stochastic_structure",
+            "is_active",
+            [
+                [
+                    116,
+                    114,
+                    117,
+                    101
+                ],
+                null
+            ]
+        ],
+        [
+            "object_activity_control",
+            "temporal_block",
+            "is_active",
+            [
+                [
+                    116,
+                    114,
+                    117,
+                    101
+                ],
+                null
+            ]
+        ],
+        [
+            "object_activity_control",
+            "unit",
+            "is_active",
+            [
+                [
+                    116,
+                    114,
+                    117,
+                    101
+                ],
+                null
+            ]
+        ],
+        [
+            "object_activity_control",
+            "unit__from_node",
+            "is_active",
+            [
+                [
+                    116,
+                    114,
+                    117,
+                    101
+                ],
+                null
+            ]
+        ],
+        [
+            "object_activity_control",
+            "unit__to_node",
+            "is_active",
+            [
+                [
+                    116,
+                    114,
+                    117,
+                    101
+                ],
+                null
+            ]
+        ],
+        [
+            "object_activity_control",
+            "units_on__stochastic_structure",
+            "is_active",
+            [
+                [
+                    116,
+                    114,
+                    117,
+                    101
+                ],
+                null
+            ]
+        ],
+        [
+            "object_activity_control",
+            "units_on__temporal_block",
+            "is_active",
+            [
+                [
+                    116,
+                    114,
+                    117,
+                    101
+                ],
+                null
+            ]
+        ],
+        [
+            "object_activity_control",
+            "user_constraint",
+            "is_active",
+            [
+                [
+                    116,
+                    114,
+                    117,
+                    101
+                ],
+                null
+            ]
+        ]
+    ],
+    "parameter_value_lists": [
+        [
+            "balance_type_list",
+            [
+                [
+                    34,
+                    98,
+                    97,
+                    108,
+                    97,
+                    110,
+                    99,
+                    101,
+                    95,
+                    116,
+                    121,
+                    112,
+                    101,
+                    95,
+                    103,
+                    114,
+                    111,
+                    117,
+                    112,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "balance_type_list",
+            [
+                [
+                    34,
+                    98,
+                    97,
+                    108,
+                    97,
+                    110,
+                    99,
+                    101,
+                    95,
+                    116,
+                    121,
+                    112,
+                    101,
+                    95,
+                    110,
+                    111,
+                    100,
+                    101,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "balance_type_list",
+            [
+                [
+                    34,
+                    98,
+                    97,
+                    108,
+                    97,
+                    110,
+                    99,
+                    101,
+                    95,
+                    116,
+                    121,
+                    112,
+                    101,
+                    95,
+                    110,
+                    111,
+                    110,
+                    101,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "boolean_value_list",
+            [
+                [
+                    102,
+                    97,
+                    108,
+                    115,
+                    101
+                ],
+                null
+            ]
+        ],
+        [
+            "boolean_value_list",
+            [
+                [
+                    116,
+                    114,
+                    117,
+                    101
+                ],
+                null
+            ]
+        ],
+        [
+            "commodity_physics_list",
+            [
+                [
+                    34,
+                    99,
+                    111,
+                    109,
+                    109,
+                    111,
+                    100,
+                    105,
+                    116,
+                    121,
+                    95,
+                    112,
+                    104,
+                    121,
+                    115,
+                    105,
+                    99,
+                    115,
+                    95,
+                    108,
+                    111,
+                    100,
+                    102,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "commodity_physics_list",
+            [
+                [
+                    34,
+                    99,
+                    111,
+                    109,
+                    109,
+                    111,
+                    100,
+                    105,
+                    116,
+                    121,
+                    95,
+                    112,
+                    104,
+                    121,
+                    115,
+                    105,
+                    99,
+                    115,
+                    95,
+                    110,
+                    111,
+                    110,
+                    101,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "commodity_physics_list",
+            [
+                [
+                    34,
+                    99,
+                    111,
+                    109,
+                    109,
+                    111,
+                    100,
+                    105,
+                    116,
+                    121,
+                    95,
+                    112,
+                    104,
+                    121,
+                    115,
+                    105,
+                    99,
+                    115,
+                    95,
+                    112,
+                    116,
+                    100,
+                    102,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "connection_investment_variable_type_list",
+            [
+                [
+                    34,
+                    99,
+                    111,
+                    110,
+                    110,
+                    101,
+                    99,
+                    116,
+                    105,
+                    111,
+                    110,
+                    95,
+                    105,
+                    110,
+                    118,
+                    101,
+                    115,
+                    116,
+                    109,
+                    101,
+                    110,
+                    116,
+                    95,
+                    118,
+                    97,
+                    114,
+                    105,
+                    97,
+                    98,
+                    108,
+                    101,
+                    95,
+                    116,
+                    121,
+                    112,
+                    101,
+                    95,
+                    99,
+                    111,
+                    110,
+                    116,
+                    105,
+                    110,
+                    117,
+                    111,
+                    117,
+                    115,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "connection_investment_variable_type_list",
+            [
+                [
+                    34,
+                    99,
+                    111,
+                    110,
+                    110,
+                    101,
+                    99,
+                    116,
+                    105,
+                    111,
+                    110,
+                    95,
+                    105,
+                    110,
+                    118,
+                    101,
+                    115,
+                    116,
+                    109,
+                    101,
+                    110,
+                    116,
+                    95,
+                    118,
+                    97,
+                    114,
+                    105,
+                    97,
+                    98,
+                    108,
+                    101,
+                    95,
+                    116,
+                    121,
+                    112,
+                    101,
+                    95,
+                    105,
+                    110,
+                    116,
+                    101,
+                    103,
+                    101,
+                    114,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "connection_type_list",
+            [
+                [
+                    34,
+                    99,
+                    111,
+                    110,
+                    110,
+                    101,
+                    99,
+                    116,
+                    105,
+                    111,
+                    110,
+                    95,
+                    116,
+                    121,
+                    112,
+                    101,
+                    95,
+                    108,
+                    111,
+                    115,
+                    115,
+                    108,
+                    101,
+                    115,
+                    115,
+                    95,
+                    98,
+                    105,
+                    100,
+                    105,
+                    114,
+                    101,
+                    99,
+                    116,
+                    105,
+                    111,
+                    110,
+                    97,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "connection_type_list",
+            [
+                [
+                    34,
+                    99,
+                    111,
+                    110,
+                    110,
+                    101,
+                    99,
+                    116,
+                    105,
+                    111,
+                    110,
+                    95,
+                    116,
+                    121,
+                    112,
+                    101,
+                    95,
+                    110,
+                    111,
+                    114,
+                    109,
+                    97,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "constraint_sense_list",
+            [
+                [
+                    34,
+                    60,
+                    61,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "constraint_sense_list",
+            [
+                [
+                    34,
+                    61,
+                    61,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "constraint_sense_list",
+            [
+                [
+                    34,
+                    62,
+                    61,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_lp_solver_list",
+            [
+                [
+                    34,
+                    75,
+                    78,
+                    73,
+                    84,
+                    82,
+                    79,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_lp_solver_list",
+            [
+                [
+                    34,
+                    67,
+                    68,
+                    67,
+                    83,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_lp_solver_list",
+            [
+                [
+                    34,
+                    67,
+                    68,
+                    68,
+                    76,
+                    105,
+                    98,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_lp_solver_list",
+            [
+                [
+                    34,
+                    67,
+                    108,
+                    112,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_lp_solver_list",
+            [
+                [
+                    34,
+                    67,
+                    79,
+                    83,
+                    77,
+                    79,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_lp_solver_list",
+            [
+                [
+                    34,
+                    67,
+                    80,
+                    76,
+                    69,
+                    88,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_lp_solver_list",
+            [
+                [
+                    34,
+                    67,
+                    83,
+                    68,
+                    80,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_lp_solver_list",
+            [
+                [
+                    34,
+                    69,
+                    67,
+                    79,
+                    83,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_lp_solver_list",
+            [
+                [
+                    34,
+                    88,
+                    112,
+                    114,
+                    101,
+                    115,
+                    115,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_lp_solver_list",
+            [
+                [
+                    34,
+                    71,
+                    76,
+                    80,
+                    75,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_lp_solver_list",
+            [
+                [
+                    34,
+                    71,
+                    117,
+                    114,
+                    111,
+                    98,
+                    105,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_lp_solver_list",
+            [
+                [
+                    34,
+                    72,
+                    105,
+                    71,
+                    72,
+                    83,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_lp_solver_list",
+            [
+                [
+                    34,
+                    72,
+                    121,
+                    112,
+                    97,
+                    116,
+                    105,
+                    97,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_lp_solver_list",
+            [
+                [
+                    34,
+                    73,
+                    112,
+                    111,
+                    112,
+                    116,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_lp_solver_list",
+            [
+                [
+                    34,
+                    77,
+                    97,
+                    100,
+                    78,
+                    76,
+                    80,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_lp_solver_list",
+            [
+                [
+                    34,
+                    77,
+                    111,
+                    115,
+                    101,
+                    107,
+                    84,
+                    111,
+                    111,
+                    108,
+                    115,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_lp_solver_list",
+            [
+                [
+                    34,
+                    78,
+                    76,
+                    111,
+                    112,
+                    116,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_lp_solver_list",
+            [
+                [
+                    34,
+                    79,
+                    83,
+                    81,
+                    80,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_lp_solver_list",
+            [
+                [
+                    34,
+                    80,
+                    114,
+                    111,
+                    120,
+                    83,
+                    68,
+                    80,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_lp_solver_list",
+            [
+                [
+                    34,
+                    83,
+                    67,
+                    73,
+                    80,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_lp_solver_list",
+            [
+                [
+                    34,
+                    83,
+                    67,
+                    83,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_lp_solver_list",
+            [
+                [
+                    34,
+                    83,
+                    68,
+                    80,
+                    65,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_lp_solver_list",
+            [
+                [
+                    34,
+                    83,
+                    68,
+                    80,
+                    78,
+                    65,
+                    76,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_lp_solver_list",
+            [
+                [
+                    34,
+                    83,
+                    68,
+                    80,
+                    84,
+                    51,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_lp_solver_list",
+            [
+                [
+                    34,
+                    83,
+                    101,
+                    68,
+                    117,
+                    77,
+                    105,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_mip_solver_list",
+            [
+                [
+                    34,
+                    75,
+                    78,
+                    73,
+                    84,
+                    82,
+                    79,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_mip_solver_list",
+            [
+                [
+                    34,
+                    67,
+                    98,
+                    99,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_mip_solver_list",
+            [
+                [
+                    34,
+                    67,
+                    80,
+                    76,
+                    69,
+                    88,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_mip_solver_list",
+            [
+                [
+                    34,
+                    72,
+                    105,
+                    71,
+                    72,
+                    83,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_mip_solver_list",
+            [
+                [
+                    34,
+                    88,
+                    112,
+                    114,
+                    101,
+                    115,
+                    115,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_mip_solver_list",
+            [
+                [
+                    34,
+                    71,
+                    76,
+                    80,
+                    75,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_mip_solver_list",
+            [
+                [
+                    34,
+                    71,
+                    117,
+                    114,
+                    111,
+                    98,
+                    105,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_mip_solver_list",
+            [
+                [
+                    34,
+                    74,
+                    117,
+                    110,
+                    105,
+                    112,
+                    101,
+                    114,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_mip_solver_list",
+            [
+                [
+                    34,
+                    77,
+                    111,
+                    115,
+                    101,
+                    107,
+                    84,
+                    111,
+                    111,
+                    108,
+                    115,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "db_mip_solver_list",
+            [
+                [
+                    34,
+                    83,
+                    67,
+                    73,
+                    80,
+                    46,
+                    106,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "duration_unit_list",
+            [
+                [
+                    34,
+                    104,
+                    111,
+                    117,
+                    114,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "duration_unit_list",
+            [
+                [
+                    34,
+                    109,
+                    105,
+                    110,
+                    117,
+                    116,
+                    101,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "model_type_list",
+            [
+                [
+                    34,
+                    115,
+                    112,
+                    105,
+                    110,
+                    101,
+                    111,
+                    112,
+                    116,
+                    95,
+                    98,
+                    101,
+                    110,
+                    100,
+                    101,
+                    114,
+                    115,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "model_type_list",
+            [
+                [
+                    34,
+                    115,
+                    112,
+                    105,
+                    110,
+                    101,
+                    111,
+                    112,
+                    116,
+                    95,
+                    115,
+                    116,
+                    97,
+                    110,
+                    100,
+                    97,
+                    114,
+                    100,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "model_type_list",
+            [
+                [
+                    34,
+                    115,
+                    112,
+                    105,
+                    110,
+                    101,
+                    111,
+                    112,
+                    116,
+                    95,
+                    111,
+                    116,
+                    104,
+                    101,
+                    114,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "model_type_list",
+            [
+                [
+                    34,
+                    115,
+                    112,
+                    105,
+                    110,
+                    101,
+                    111,
+                    112,
+                    116,
+                    95,
+                    109,
+                    103,
+                    97,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "node_opf_type_list",
+            [
+                [
+                    34,
+                    110,
+                    111,
+                    100,
+                    101,
+                    95,
+                    111,
+                    112,
+                    102,
+                    95,
+                    116,
+                    121,
+                    112,
+                    101,
+                    95,
+                    110,
+                    111,
+                    114,
+                    109,
+                    97,
+                    108,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "node_opf_type_list",
+            [
+                [
+                    34,
+                    110,
+                    111,
+                    100,
+                    101,
+                    95,
+                    111,
+                    112,
+                    102,
+                    95,
+                    116,
+                    121,
+                    112,
+                    101,
+                    95,
+                    114,
+                    101,
+                    102,
+                    101,
+                    114,
+                    101,
+                    110,
+                    99,
+                    101,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "unit_investment_variable_type_list",
+            [
+                [
+                    34,
+                    117,
+                    110,
+                    105,
+                    116,
+                    95,
+                    105,
+                    110,
+                    118,
+                    101,
+                    115,
+                    116,
+                    109,
+                    101,
+                    110,
+                    116,
+                    95,
+                    118,
+                    97,
+                    114,
+                    105,
+                    97,
+                    98,
+                    108,
+                    101,
+                    95,
+                    116,
+                    121,
+                    112,
+                    101,
+                    95,
+                    99,
+                    111,
+                    110,
+                    116,
+                    105,
+                    110,
+                    117,
+                    111,
+                    117,
+                    115,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "unit_investment_variable_type_list",
+            [
+                [
+                    34,
+                    117,
+                    110,
+                    105,
+                    116,
+                    95,
+                    105,
+                    110,
+                    118,
+                    101,
+                    115,
+                    116,
+                    109,
+                    101,
+                    110,
+                    116,
+                    95,
+                    118,
+                    97,
+                    114,
+                    105,
+                    97,
+                    98,
+                    108,
+                    101,
+                    95,
+                    116,
+                    121,
+                    112,
+                    101,
+                    95,
+                    105,
+                    110,
+                    116,
+                    101,
+                    103,
+                    101,
+                    114,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "unit_online_variable_type_list",
+            [
+                [
+                    34,
+                    117,
+                    110,
+                    105,
+                    116,
+                    95,
+                    111,
+                    110,
+                    108,
+                    105,
+                    110,
+                    101,
+                    95,
+                    118,
+                    97,
+                    114,
+                    105,
+                    97,
+                    98,
+                    108,
+                    101,
+                    95,
+                    116,
+                    121,
+                    112,
+                    101,
+                    95,
+                    98,
+                    105,
+                    110,
+                    97,
+                    114,
+                    121,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "unit_online_variable_type_list",
+            [
+                [
+                    34,
+                    117,
+                    110,
+                    105,
+                    116,
+                    95,
+                    111,
+                    110,
+                    108,
+                    105,
+                    110,
+                    101,
+                    95,
+                    118,
+                    97,
+                    114,
+                    105,
+                    97,
+                    98,
+                    108,
+                    101,
+                    95,
+                    116,
+                    121,
+                    112,
+                    101,
+                    95,
+                    105,
+                    110,
+                    116,
+                    101,
+                    103,
+                    101,
+                    114,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "unit_online_variable_type_list",
+            [
+                [
+                    34,
+                    117,
+                    110,
+                    105,
+                    116,
+                    95,
+                    111,
+                    110,
+                    108,
+                    105,
+                    110,
+                    101,
+                    95,
+                    118,
+                    97,
+                    114,
+                    105,
+                    97,
+                    98,
+                    108,
+                    101,
+                    95,
+                    116,
+                    121,
+                    112,
+                    101,
+                    95,
+                    108,
+                    105,
+                    110,
+                    101,
+                    97,
+                    114,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "unit_online_variable_type_list",
+            [
+                [
+                    34,
+                    117,
+                    110,
+                    105,
+                    116,
+                    95,
+                    111,
+                    110,
+                    108,
+                    105,
+                    110,
+                    101,
+                    95,
+                    118,
+                    97,
+                    114,
+                    105,
+                    97,
+                    98,
+                    108,
+                    101,
+                    95,
+                    116,
+                    121,
+                    112,
+                    101,
+                    95,
+                    110,
+                    111,
+                    110,
+                    101,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "variable_type_list",
+            [
+                [
+                    34,
+                    118,
+                    97,
+                    114,
+                    105,
+                    97,
+                    98,
+                    108,
+                    101,
+                    95,
+                    116,
+                    121,
+                    112,
+                    101,
+                    95,
+                    98,
+                    105,
+                    110,
+                    97,
+                    114,
+                    121,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "variable_type_list",
+            [
+                [
+                    34,
+                    118,
+                    97,
+                    114,
+                    105,
+                    97,
+                    98,
+                    108,
+                    101,
+                    95,
+                    116,
+                    121,
+                    112,
+                    101,
+                    95,
+                    99,
+                    111,
+                    110,
+                    116,
+                    105,
+                    110,
+                    117,
+                    111,
+                    117,
+                    115,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "variable_type_list",
+            [
+                [
+                    34,
+                    118,
+                    97,
+                    114,
+                    105,
+                    97,
+                    98,
+                    108,
+                    101,
+                    95,
+                    116,
+                    121,
+                    112,
+                    101,
+                    95,
+                    105,
+                    110,
+                    116,
+                    101,
+                    103,
+                    101,
+                    114,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "write_mps_file_list",
+            [
+                [
+                    34,
+                    119,
+                    114,
+                    105,
+                    116,
+                    101,
+                    95,
+                    109,
+                    112,
+                    115,
+                    95,
+                    97,
+                    108,
+                    119,
+                    97,
+                    121,
+                    115,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "write_mps_file_list",
+            [
+                [
+                    34,
+                    119,
+                    114,
+                    105,
+                    116,
+                    101,
+                    95,
+                    109,
+                    112,
+                    115,
+                    95,
+                    110,
+                    101,
+                    118,
+                    101,
+                    114,
+                    34
+                ],
+                null
+            ]
+        ],
+        [
+            "write_mps_file_list",
+            [
+                [
+                    34,
+                    119,
+                    114,
+                    105,
+                    116,
+                    101,
+                    95,
+                    109,
+                    112,
+                    115,
+                    95,
+                    111,
+                    110,
+                    95,
+                    110,
+                    111,
+                    95,
+                    115,
+                    111,
+                    108,
+                    118,
+                    101,
+                    34
+                ],
+                null
+            ]
         ]
     ],
     "relationships": [
@@ -3484,205 +5372,108 @@
             ]
         ]
     ],
-    "object_parameter_values": [
-        [
-            "node",
-            "electricity_node",
-            "demand",
-            {
-                "type": "time_series",
-                "index": {
-                    "start": "2000-01-01 00:00:00",
-                    "resolution": "1h",
-                    "ignore_year": false,
-                    "repeat": false
-                },
-                "data": [
-                    90.0,
-                    90.0,
-                    90.0,
-                    90.0,
-                    90.0,
-                    130.0,
-                    130.0,
-                    130.0,
-                    130.0,
-                    130.0,
-                    50.0,
-                    50.0,
-                    50.0,
-                    50.0,
-                    50.0,
-                    50.0,
-                    130.0,
-                    130.0,
-                    130.0,
-                    130.0,
-                    130.0,
-                    130.0,
-                    130.0,
-                    90.0
-                ]
-            },
-            "Base"
-        ],
-        [
-            "node",
-            "fuel_node",
-            "balance_type",
-            "balance_type_none",
-            "Base"
-        ],
-        [
-            "temporal_block",
-            "flat",
-            "resolution",
-            {
-                "type": "duration",
-                "data": "1h"
-            },
-            "Base"
-        ],
-        [
-            "unit",
-            "power_plant_b",
-            "initial_units_on",
-            0,
-            "Base"
-        ],
-        [
-            "unit",
-            "power_plant_b",
-            "min_down_time",
-            {
-                "type": "duration",
-                "data": "8h"
-            },
-            "Base"
-        ],
-        [
-            "unit",
-            "power_plant_b",
-            "min_up_time",
-            {
-                "type": "duration",
-                "data": "8h"
-            },
-            "Base"
-        ],
-        [
-            "unit",
-            "power_plant_b",
-            "online_variable_type",
-            "unit_online_variable_type_binary",
-            "Base"
-        ],
-        [
-            "unit",
-            "power_plant_b",
-            "shut_down_cost",
-            7,
-            "Base"
-        ],
-        [
-            "unit",
-            "power_plant_b",
-            "start_up_cost",
-            5,
-            "Base"
-        ],
-        [
-            "unit",
-            "power_plant_b",
-            "units_on_cost",
-            3,
-            "Base"
-        ]
-    ],
-    "relationship_parameter_values": [
-        [
-            "unit__from_node",
-            [
-                "power_plant_a",
-                "fuel_node"
-            ],
-            "vom_cost",
-            25,
-            "Base"
-        ],
-        [
-            "unit__from_node",
-            [
-                "power_plant_b",
-                "fuel_node"
-            ],
-            "vom_cost",
-            50,
-            "Base"
-        ],
-        [
-            "unit__node__node",
-            [
-                "power_plant_a",
-                "electricity_node",
-                "fuel_node"
-            ],
-            "fix_ratio_out_in_unit_flow",
-            0.7,
-            "Base"
-        ],
-        [
-            "unit__node__node",
-            [
-                "power_plant_b",
-                "electricity_node",
-                "fuel_node"
-            ],
-            "fix_ratio_out_in_unit_flow",
-            0.8,
-            "Base"
-        ],
-        [
-            "unit__to_node",
-            [
-                "power_plant_a",
-                "electricity_node"
-            ],
-            "unit_capacity",
-            100,
-            "Base"
-        ],
-        [
-            "unit__to_node",
-            [
-                "power_plant_b",
-                "electricity_node"
-            ],
-            "minimum_operating_point",
-            0.1,
-            "Base"
-        ],
-        [
-            "unit__to_node",
-            [
-                "power_plant_b",
-                "electricity_node"
-            ],
-            "unit_capacity",
-            200.0,
-            "Base"
-        ]
-    ],
-    "alternatives": [
-        [
-            "Base",
-            "Base alternative"
-        ]
-    ],
-    "tools": [
+    "tool_features": [
         [
             "object_activity_control",
-            ""
+            "commodity",
+            "is_active",
+            false
+        ],
+        [
+            "object_activity_control",
+            "connection",
+            "is_active",
+            false
+        ],
+        [
+            "object_activity_control",
+            "model",
+            "is_active",
+            false
+        ],
+        [
+            "object_activity_control",
+            "node",
+            "is_active",
+            false
+        ],
+        [
+            "object_activity_control",
+            "node__stochastic_structure",
+            "is_active",
+            false
+        ],
+        [
+            "object_activity_control",
+            "node__temporal_block",
+            "is_active",
+            false
+        ],
+        [
+            "object_activity_control",
+            "output",
+            "is_active",
+            false
+        ],
+        [
+            "object_activity_control",
+            "report",
+            "is_active",
+            false
+        ],
+        [
+            "object_activity_control",
+            "stochastic_scenario",
+            "is_active",
+            false
+        ],
+        [
+            "object_activity_control",
+            "stochastic_structure",
+            "is_active",
+            false
+        ],
+        [
+            "object_activity_control",
+            "temporal_block",
+            "is_active",
+            false
+        ],
+        [
+            "object_activity_control",
+            "unit",
+            "is_active",
+            false
+        ],
+        [
+            "object_activity_control",
+            "unit__from_node",
+            "is_active",
+            false
+        ],
+        [
+            "object_activity_control",
+            "unit__to_node",
+            "is_active",
+            false
+        ],
+        [
+            "object_activity_control",
+            "units_on__stochastic_structure",
+            "is_active",
+            false
+        ],
+        [
+            "object_activity_control",
+            "units_on__temporal_block",
+            "is_active",
+            false
+        ],
+        [
+            "object_activity_control",
+            "user_constraint",
+            "is_active",
+            false
         ]
     ],
     "features": [
@@ -3789,212 +5580,71 @@
             "boolean_value_list"
         ]
     ],
-    "tool_features": [
+    "object_classes": [
         [
-            "object_activity_control",
             "commodity",
-            "is_active",
-            false
+            "A good or product that can be consumed, produced, traded. E.g., electricity, oil, gas, water...",
+            281473533932880
         ],
         [
-            "object_activity_control",
             "connection",
-            "is_active",
-            false
+            "A transfer of commodities between nodes. E.g. electricity line, gas pipeline...",
+            280378317271233
         ],
         [
-            "object_activity_control",
+            "investment_group",
+            "A group of investments that need to be done together.",
+            281105609585860
+        ],
+        [
             "model",
-            "is_active",
-            false
+            "An instance of SpineOpt, that specifies general parameters such as the temporal horizon.",
+            281107035648412
         ],
         [
-            "object_activity_control",
             "node",
-            "is_active",
-            false
+            "A universal aggregator of commodify flows over units and connections, with storage capabilities.",
+            280740554077951
         ],
         [
-            "object_activity_control",
-            "node__stochastic_structure",
-            "is_active",
-            false
-        ],
-        [
-            "object_activity_control",
-            "node__temporal_block",
-            "is_active",
-            false
-        ],
-        [
-            "object_activity_control",
             "output",
-            "is_active",
-            false
+            "A variable name from SpineOpt that can be included in a report.",
+            280743406202948
         ],
         [
-            "object_activity_control",
             "report",
-            "is_active",
-            false
+            "A results report from a particular SpineOpt run, including the value of specific variables.",
+            281108461711708
         ],
         [
-            "object_activity_control",
+            "settings",
+            "Internal SpineOpt settings. We kindly advise not to mess with this one.",
+            280375465144798
+        ],
+        [
             "stochastic_scenario",
-            "is_active",
-            false
+            "A scenario for stochastic optimisation in SpineOpt.",
+            280743389491710
         ],
         [
-            "object_activity_control",
             "stochastic_structure",
-            "is_active",
-            false
+            "A group of stochastic scenarios that represent a structure.",
+            281470681806146
         ],
         [
-            "object_activity_control",
             "temporal_block",
-            "is_active",
-            false
+            "A length of time with a particular resolution.",
+            280376891207703
         ],
         [
-            "object_activity_control",
             "unit",
-            "is_active",
-            false
+            "A conversion of one/many comodities between nodes.",
+            281470681805429
         ],
         [
-            "object_activity_control",
-            "unit__from_node",
-            "is_active",
-            false
-        ],
-        [
-            "object_activity_control",
-            "unit__to_node",
-            "is_active",
-            false
-        ],
-        [
-            "object_activity_control",
-            "units_on__stochastic_structure",
-            "is_active",
-            false
-        ],
-        [
-            "object_activity_control",
-            "units_on__temporal_block",
-            "is_active",
-            false
-        ],
-        [
-            "object_activity_control",
             "user_constraint",
-            "is_active",
-            false
-        ]
-    ],
-    "tool_feature_methods": [
-        [
-            "object_activity_control",
-            "commodity",
-            "is_active",
-            true
-        ],
-        [
-            "object_activity_control",
-            "connection",
-            "is_active",
-            true
-        ],
-        [
-            "object_activity_control",
-            "model",
-            "is_active",
-            true
-        ],
-        [
-            "object_activity_control",
-            "node",
-            "is_active",
-            true
-        ],
-        [
-            "object_activity_control",
-            "node__stochastic_structure",
-            "is_active",
-            true
-        ],
-        [
-            "object_activity_control",
-            "node__temporal_block",
-            "is_active",
-            true
-        ],
-        [
-            "object_activity_control",
-            "output",
-            "is_active",
-            true
-        ],
-        [
-            "object_activity_control",
-            "report",
-            "is_active",
-            true
-        ],
-        [
-            "object_activity_control",
-            "stochastic_scenario",
-            "is_active",
-            true
-        ],
-        [
-            "object_activity_control",
-            "stochastic_structure",
-            "is_active",
-            true
-        ],
-        [
-            "object_activity_control",
-            "temporal_block",
-            "is_active",
-            true
-        ],
-        [
-            "object_activity_control",
-            "unit",
-            "is_active",
-            true
-        ],
-        [
-            "object_activity_control",
-            "unit__from_node",
-            "is_active",
-            true
-        ],
-        [
-            "object_activity_control",
-            "unit__to_node",
-            "is_active",
-            true
-        ],
-        [
-            "object_activity_control",
-            "units_on__stochastic_structure",
-            "is_active",
-            true
-        ],
-        [
-            "object_activity_control",
-            "units_on__temporal_block",
-            "is_active",
-            true
-        ],
-        [
-            "object_activity_control",
-            "user_constraint",
-            "is_active",
-            true
+            "A generic data-driven custom constraint.",
+            281473533931636
         ]
     ]
 }

--- a/examples/upgrade_all.jl
+++ b/examples/upgrade_all.jl
@@ -1,0 +1,30 @@
+# Upgrades all JSON files in this folder to the latest version
+using JSON
+using SpineInterface
+using SpineOpt
+
+for path in readdir(@__DIR__; join=true)
+    if splitext(path)[end] == ".json"
+        @info "upgrading $path"
+        data = JSON.parsefile(path)
+        db_url = "sqlite://"
+        SpineInterface.close_connection(db_url)
+        SpineInterface.open_connection(db_url)
+        import_data(db_url, data, "Import $path")
+        SpineOpt.upgrade_db(db_url; log_level=3)
+        new_data = export_data(db_url)
+        for key in ("object_parameters", "relationship_parameters")
+            for x in get(new_data, key, ())
+                x[3] = db_value_and_type(parse_db_value(x[3]))
+            end
+        end
+        for key in ("object_parameter_values", "relationship_parameter_values")
+            for x in get(new_data, key, ())
+                x[4] = db_value_and_type(parse_db_value(x[4]))
+            end
+        end
+        open(path, "w") do f
+            JSON.print(f, new_data, 4)
+        end
+    end
+end

--- a/test/run_examples.jl
+++ b/test/run_examples.jl
@@ -1,9 +1,6 @@
-for path in readdir(joinpath(dirname(@__DIR__),"examples");join=true)
-    if split(path, ".")[end] == "json"
-        inputdata = open(path, "r") do f
-            dicttxt = read(f,String) # file information to string
-            return JSON.parse(dicttxt) # parse and transform data
-        end
-        @test termination_status(run_spineopt(inputdata;upgrade=true)) == MOI.OPTIMAL
+@testset for path in readdir(joinpath(dirname(@__DIR__), "examples"); join=true)
+    if splitext(path)[end] == ".json"
+        input_data = JSON.parsefile(path)
+        @test termination_status(run_spineopt(input_data, nothing; log_level=3)) == MOI.OPTIMAL
     end
 end


### PR DESCRIPTION
Also upgrade examples json to latest structure.


## Checklist before merging
- [x] Documentation is up-to-date
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted according to SpineOpt's style
- [x] Unit tests pass
