### PR TITLE
Improve treatment of representative time slices

### DIFF
--- a/src/constraints/constraint_node_injection.jl
+++ b/src/constraints/constraint_node_injection.jl
@@ -71,7 +71,7 @@ function add_constraint_node_injection!(m::Model)
             + sum(
                 + node_injection[n, s, t]
                 + demand[
-                    (node=n, stochastic_scenario=s, analysis_time=t0, t=representative_time_slice(m, t))
+                    (node=n, stochastic_scenario=s, analysis_time=t0, t=first(representative_time_slice(m, t)))
                 ]
                 # node slack
                 - get(node_slack_pos, (n, s, t), 0) + get(node_slack_neg, (n, s, t), 0)
@@ -81,8 +81,10 @@ function add_constraint_node_injection!(m::Model)
                 init=0,
             )
             + sum(
-                fractional_demand[(node=n, stochastic_scenario=s, analysis_time=t0, t=representative_time_slice(m, t))]
-                * demand[(node=ng, stochastic_scenario=s, analysis_time=t0, t=representative_time_slice(m, t))]
+                fractional_demand[
+                    (node=n, stochastic_scenario=s, analysis_time=t0, t=first(representative_time_slice(m, t)))
+                ]
+                * demand[(node=ng, stochastic_scenario=s, analysis_time=t0, t=first(representative_time_slice(m, t)))]
                 for (n, s, t) in node_injection_indices(
                     m; node=n, stochastic_scenario=s, t=t_after, temporal_block=anything
                 )

--- a/src/variables/variable_common.jl
+++ b/src/variables/variable_common.jl
@@ -92,6 +92,22 @@ The representative index corresponding to the given one.
 function _representative_index(m, ind, indices)
     representative_t = representative_time_slice(m, ind.t)
     representative_inds = indices(m; ind..., t=representative_t)
+    if isempty(representative_inds)
+        representative_blocks = unique(
+            blk
+            for t in representative_t
+            for blk in blocks(t)
+            if representative_periods_mapping(temporal_block=blk) === nothing
+        )
+        node_or_unit = hasproperty(ind, :node) ? "node '$(ind.node)'" : "unit '$(ind.unit)'"
+        error(
+            "can't find a representative index for $ind -",
+            " this is probably because ",
+            node_or_unit,
+            " is not associated to any of the representative temporal_blocks ",
+            join(("'$blk'" for blk in representative_blocks), ", "),
+        )
+    end
     first(representative_inds)
 end
 

--- a/test/data_structure/temporal_structure.jl
+++ b/test/data_structure/temporal_structure.jl
@@ -88,17 +88,17 @@ function _test_representative_time_slice()
         for t in SpineOpt.time_slice(m, temporal_block=temporal_block(:block_a))
             t_end = end_(t)
             if t_end <= m_start + Hour(4)
-                @test SpineOpt.representative_time_slice(m, t) == rep_blk1_ts[1]
+                @test first(SpineOpt.representative_time_slice(m, t)) == rep_blk1_ts[1]
             elseif t_end <= m_start + Hour(8)
-                @test SpineOpt.representative_time_slice(m, t) == t
+                @test first(SpineOpt.representative_time_slice(m, t)) == t
             elseif t_end <= m_start + Hour(12)
-                @test SpineOpt.representative_time_slice(m, t) == rep_blk2_ts[1]
+                @test first(SpineOpt.representative_time_slice(m, t)) == rep_blk2_ts[1]
             elseif t_end <= m_start + Hour(16)
-                @test SpineOpt.representative_time_slice(m, t) == rep_blk2_ts[2]
+                @test first(SpineOpt.representative_time_slice(m, t)) == rep_blk2_ts[2]
             elseif t_end <= m_start + Hour(20)
-                @test SpineOpt.representative_time_slice(m, t) == rep_blk2_ts[3]
+                @test first(SpineOpt.representative_time_slice(m, t)) == rep_blk2_ts[3]
             else
-                @test SpineOpt.representative_time_slice(m, t) == t
+                @test first(SpineOpt.representative_time_slice(m, t)) == t
             end
         end
     end


### PR DESCRIPTION
Previously, if the same t was represented by more than one representative ts, only the last one processed would stay, leading to bugs. Now we fix that and also help the user in case they created a mapping for a temporal block but forgot to associate the
representative temporal block with their node or unit.

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted according to SpineOpt's style
- [ ] Unit tests pass
