### PR TITLE
Register window about to solve/solved callbacks in model ext

### DIFF
--- a/src/run_spineopt_benders.jl
+++ b/src/run_spineopt_benders.jl
@@ -30,6 +30,8 @@ function rerun_spineopt_benders!(
     resume_file_path,
     run_kernel,
 )
+    _add_window_about_to_solve_callback!(m, _set_sp_solution!)
+    _add_window_solved_callback!(m, process_subproblem_solution!)
     m_mp = master_problem_model(m)
     @timelog log_level 2 "Creating subproblem temporal structure..." generate_temporal_structure!(m)
     @timelog log_level 2 "Creating master problem temporal structure..." generate_master_temporal_structure!(m_mp)
@@ -62,8 +64,6 @@ function rerun_spineopt_benders!(
             update_names=update_names,
             calculate_duals=true,
             log_prefix="Benders iteration $j - ",
-            handle_window_about_to_solve=_set_sp_solution!,
-            handle_window_solved=process_subproblem_solution!,
         ) || break
         @timelog log_level 2 "Computing benders gap..." save_mp_objective_bounds_and_gap!(m_mp)
         @log log_level 1 "Benders iteration $j complete"

--- a/src/run_spineopt_standard.jl
+++ b/src/run_spineopt_standard.jl
@@ -253,19 +253,17 @@ function run_spineopt_kernel!(
     resume_file_path=nothing,
     output_suffix=(;),
     log_prefix="",
-    handle_window_solved=(m, k) -> nothing,
-    handle_window_about_to_solve=(m, k) -> nothing,
 )
     k = _resume_run!(m, resume_file_path; log_level, update_names)
     k === nothing && return m
     while true
         @log log_level 1 "\n$(log_prefix)Window $k: $(current_window(m))"
-        handle_window_about_to_solve(m, k)
+        (callback -> callback(m, k)).(m.ext[:spineopt].window_about_to_solve_callbacks)
         optimize_model!(
             m; log_level=log_level, calculate_duals=calculate_duals, output_suffix=output_suffix
         ) || return false
         _save_window_state(m, k; write_as_roll, resume_file_path)
-        handle_window_solved(m, k)
+        (callback -> callback(m, k)).(m.ext[:spineopt].window_solved_callbacks)
         if @timelog log_level 2 "$(log_prefix)Rolling temporal structure...\n" !roll_temporal_structure!(m, k)
             @timelog log_level 2 "$(log_prefix) ... Rolling complete\n" break
         end


### PR DESCRIPTION
This is so we can have more than one callback.
It allows for more customization, notably to add user callbacks on top of already existing e.g. Benders callbacks.

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted according to SpineOpt's style
- [x] Unit tests pass
