### PR TITLE
Make sure the sp obj val computation starts at zero for the first window

### DIFF
--- a/src/data_structure/benders_data.jl
+++ b/src/data_structure/benders_data.jl
@@ -117,11 +117,12 @@ function _save_sp_marginal_values!(m, var_name, param_name, obj_cls, k, win_weig
 end
 
 function _save_sp_objective_value!(m, k, win_weight)
-    increment = win_weight * sum(values(m.ext[:spineopt].values[:total_costs]); init=0)
+    current_sp_obj_val = win_weight * sum(values(m.ext[:spineopt].values[:total_costs]); init=0)
     if _is_last_window(m, k)
-        increment += sum(values(m.ext[:spineopt].values[:total_costs_tail]); init=0)
+        current_sp_obj_val += sum(values(m.ext[:spineopt].values[:total_costs_tail]); init=0)
     end
-    total_sp_obj_val = sp_objective_value_bi(benders_iteration=current_bi, _default=0) + increment
+    previous_sp_obj_val = k == 1 ? 0 : sp_objective_value_bi(benders_iteration=current_bi, _default=0)
+    total_sp_obj_val = previous_sp_obj_val + current_sp_obj_val
     add_object_parameter_values!(
         benders_iteration, Dict(current_bi => Dict(:sp_objective_value_bi => parameter_value(total_sp_obj_val)))
     )

--- a/src/run_spineopt_benders.jl
+++ b/src/run_spineopt_benders.jl
@@ -30,6 +30,8 @@ function rerun_spineopt_benders!(
     resume_file_path,
     run_kernel,
 )
+    _add_window_about_to_solve_callback!(m, _set_sp_solution!)
+    _add_window_solved_callback!(m, process_subproblem_solution!)
     m_mp = master_problem_model(m)
     @timelog log_level 2 "Creating subproblem temporal structure..." generate_temporal_structure!(m)
     @timelog log_level 2 "Creating master problem temporal structure..." generate_master_temporal_structure!(m_mp)
@@ -62,8 +64,6 @@ function rerun_spineopt_benders!(
             update_names=update_names,
             calculate_duals=true,
             log_prefix="Benders iteration $j - ",
-            handle_window_about_to_solve=_set_sp_solution!,
-            handle_window_solved=process_subproblem_solution!,
         ) || break
         @timelog log_level 2 "Computing benders gap..." save_mp_objective_bounds_and_gap!(m_mp)
         @log log_level 1 "Benders iteration $j complete"

--- a/src/run_spineopt_standard.jl
+++ b/src/run_spineopt_standard.jl
@@ -253,19 +253,17 @@ function run_spineopt_kernel!(
     resume_file_path=nothing,
     output_suffix=(;),
     log_prefix="",
-    handle_window_solved=(m, k) -> nothing,
-    handle_window_about_to_solve=(m, k) -> nothing,
 )
     k = _resume_run!(m, resume_file_path; log_level, update_names)
     k === nothing && return m
     while true
         @log log_level 1 "\n$(log_prefix)Window $k: $(current_window(m))"
-        handle_window_about_to_solve(m, k)
+        (callback -> callback(m, k)).(m.ext[:spineopt].window_about_to_solve_callbacks)
         optimize_model!(
             m; log_level=log_level, calculate_duals=calculate_duals, output_suffix=output_suffix
         ) || return false
         _save_window_state(m, k; write_as_roll, resume_file_path)
-        handle_window_solved(m, k)
+        (callback -> callback(m, k)).(m.ext[:spineopt].window_solved_callbacks)
         if @timelog log_level 2 "$(log_prefix)Rolling temporal structure...\n" !roll_temporal_structure!(m, k)
             @timelog log_level 2 "$(log_prefix) ... Rolling complete\n" break
         end


### PR DESCRIPTION
This is to avoid double counting when the kernel is called in a loop by a third party kernel used as replacement.

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted according to SpineOpt's style
- [x] Unit tests pass
