### PR TITLE
Update Julia version in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,7 @@ jobs:
           PYTHON: python
       - uses: julia-actions/julia-runtest@latest
       - uses: julia-actions/julia-processcoverage@v1
+        if: matrix.version == '1' && matrix.os == 'ubuntu-latest'
       - uses: codecov/codecov-action@v1
         with:
           file: lcov.info

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         version:
           - "1.6"  # Minimum compatible Release
-          - "1.9"  # Latest Release
+          - "1"    # Latest Release of Julia v1.x
         os:
           - ubuntu-latest
           - macOS-latest


### PR DESCRIPTION
Update Julia version in CI workflow to test the latest release of Julia v1.x

Fixes # 932

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted according to SpineOpt's style
- [x] Unit tests pass
