### PR TITLE
Performance optimisation

### DIFF
--- a/src/constraints/constraint_common.jl
+++ b/src/constraints/constraint_common.jl
@@ -29,12 +29,14 @@ function t_lowest_resolution_path(m, indices, extra_indices...)
     isempty(indices) && return ()
     scens_by_t = t_lowest_resolution_sets!(_scens_by_t(indices))
     extra_scens_by_t = _scens_by_t(Iterators.flatten(extra_indices))
+    t_arr = sort(collect(keys(scens_by_t)))
     extra_t_arr = sort(collect(keys(extra_scens_by_t)))
+    t = _popfirst!(t_arr, nothing)
     extra_t = _popfirst!(extra_t_arr, nothing)
-    for t in sort(collect(keys(scens_by_t)))
-        extra_t === nothing && break
+    while t !== nothing && extra_t !== nothing
         if iscontained(t, extra_t)
             union!(scens_by_t[t], extra_scens_by_t[extra_t])
+            t = _popfirst!(t_arr, nothing)
         else
             extra_t = _popfirst!(extra_t_arr, nothing)
         end

--- a/src/constraints/constraint_common.jl
+++ b/src/constraints/constraint_common.jl
@@ -23,19 +23,27 @@
 An iterator of tuples `(t, path)` where `t` is a `TimeSlice` and `path` is a `Vector` of stochastic scenario `Object`s
 corresponding to the active stochastic paths for that `t`.
 The `t`s in the result are the lowest resolution `TimeSlice`s in `indices`.
-For each of these `t`s, the `path` also includes scenarios in `more_indices` where the `TimeSlice` contains the `t`.
+For each of these `t`s, the `path` also includes scenarios in `extra_indices` where the `TimeSlice` contains the `t`.
 """
-function t_lowest_resolution_path(m, indices, more_indices...)
+function t_lowest_resolution_path(m, indices, extra_indices...)
     isempty(indices) && return ()
     scens_by_t = t_lowest_resolution_sets!(_scens_by_t(indices))
-    for (other_t, other_scens) in _scens_by_t(Iterators.flatten(more_indices))
-        for (t, scens) in scens_by_t
-            if iscontained(t, other_t)
-                union!(scens, other_scens)
-            end
+    extra_scens_by_t = _scens_by_t(Iterators.flatten(extra_indices))
+    extra_t_arr = sort(collect(keys(extra_scens_by_t)))
+    extra_t = _popfirst!(extra_t_arr, nothing)
+    for t in sort(collect(keys(scens_by_t)))
+        extra_t === nothing && break
+        if iscontained(t, extra_t)
+            union!(scens_by_t[t], extra_scens_by_t[extra_t])
+        else
+            extra_t = _popfirst!(extra_t_arr, nothing)
         end
     end
     ((t, path) for (t, scens) in scens_by_t for path in active_stochastic_paths(m, scens))
+end
+
+function _popfirst!(arr, default)
+    try popfirst!(arr) catch default end
 end
 
 function _scens_by_t(indices)

--- a/src/constraints/constraint_connection_intact_flow_ptdf.jl
+++ b/src/constraints/constraint_connection_intact_flow_ptdf.jl
@@ -111,7 +111,7 @@ function constraint_connection_intact_flow_ptdf_indices(m::Model)
             m,
             vcat(
                 connection_intact_flow_indices(m; connection=conn, node=n_to, direction=d_to, t=t),
-                node_stochastic_time_indices(m; node=ptdf_connection__node(connection=conn), t=t)
+                collect(node_stochastic_time_indices(m; node=ptdf_connection__node(connection=conn), t=t)),
             )
         )
     )

--- a/src/constraints/constraint_node_injection.jl
+++ b/src/constraints/constraint_node_injection.jl
@@ -159,7 +159,7 @@ function constraint_node_injection_indices(m::Model)
         for path in active_stochastic_paths(
             m,
             vcat(
-                node_stochastic_time_indices(m; node=n, t=t_after),
+                collect(node_stochastic_time_indices(m; node=n, t=t_after)),
                 node_state_indices(m; node=n, t=t_before),
                 node_state_indices(m; node=[node__node(node2=n); node__node(node1=n)], t=t_after)
             )

--- a/src/constraints/constraint_ratio_unit_flow.jl
+++ b/src/constraints/constraint_ratio_unit_flow.jl
@@ -237,7 +237,7 @@ function constraint_ratio_unit_flow_indices(m::Model, ratio, d1, d2)
         for (u, n1, n2) in indices(ratio)
         for (t, path) in t_lowest_resolution_path(
             m,
-            unit_flow_indices(m; unit=u, node=[n1; n2]),
+            unit_flow_indices(m; unit=u, node=[n1, n2]),
             vcat(
                 unit_flow_indices(m; unit=u, node=n1, direction=d1),
                 unit_flow_indices(m; unit=u, node=n2, direction=d2),

--- a/src/constraints/constraint_unit_flow_capacity.jl
+++ b/src/constraints/constraint_unit_flow_capacity.jl
@@ -121,7 +121,7 @@ function add_constraint_unit_flow_capacity!(m::Model)
                     * duration(t_after)
                     for (u, s, t_after) in units_on_indices(m; unit=u, stochastic_scenario=s, t=t_next);
                     init=0
-                )                
+                )
                 + sum(
                     + _shutdown_margin(u, ng, d, s, t0, t, case, part)
                     * _unit_flow_capacity(u, ng, d, s, t0, t)

--- a/src/data_structure/stochastic_structure.jl
+++ b/src/data_structure/stochastic_structure.jl
@@ -319,7 +319,7 @@ function stochastic_time_indices(
     temporal_block=anything,
     t=anything,
 )
-    unique(
+    (
         (stochastic_scenario=s, t=t)
         for ss in stochastic_structure()
         for tb in intersect(SpineOpt.temporal_block(), temporal_block)
@@ -329,14 +329,14 @@ function stochastic_time_indices(
 end
 
 """
-    node_stochastic_time_indices(m;<keyword arguments>)
+    node_stochastic_time_indices(m; <keyword arguments>)
 
 Stochastic time indexes for `nodes` with keyword arguments that allow filtering.
 """
 function node_stochastic_time_indices(
     m::Model; node=anything, stochastic_scenario=anything, temporal_block=anything, t=anything
 )
-    unique(
+    (
         (node=n, stochastic_scenario=s, t=t)
         for (n, t) in node_time_indices(m; node=node, temporal_block=temporal_block, t=t)
         for ss in node__stochastic_structure(node=n)
@@ -345,7 +345,7 @@ function node_stochastic_time_indices(
 end
 
 """
-    unit_stochastic_time_indices(;<keyword arguments>)
+    unit_stochastic_time_indices(m; <keyword arguments>)
 
 Stochastic time indexes for `units` with keyword arguments that allow filtering.
 """
@@ -356,7 +356,7 @@ function unit_stochastic_time_indices(
     temporal_block=anything,
     t=anything,
 )
-    unique(
+    (
         (unit=u, stochastic_scenario=s, t=t)
         for (u, t) in unit_time_indices(m; unit=unit, temporal_block=temporal_block, t=t)
         for ss in units_on__stochastic_structure(unit=u)
@@ -365,7 +365,7 @@ function unit_stochastic_time_indices(
 end
 
 """
-    unit_investment_stochastic_time_indices(;<keyword arguments>)
+    unit_investment_stochastic_time_indices(m; <keyword arguments>)
 
 Stochastic time indexes for `units_invested` with keyword arguments that allow filtering.
 """
@@ -376,7 +376,7 @@ function unit_investment_stochastic_time_indices(
     temporal_block=anything,
     t=anything,
 )
-    unique(
+    (
         (unit=u, stochastic_scenario=s, t=t)
         for (u, t) in unit_investment_time_indices(m; unit=unit, temporal_block=temporal_block, t=t)
         for ss in unit__investment_stochastic_structure(unit=u)
@@ -385,7 +385,7 @@ function unit_investment_stochastic_time_indices(
 end
 
 """
-    connection_investment_stochastic_time_indices(;<keyword arguments>)
+    connection_investment_stochastic_time_indices(m; <keyword arguments>)
 
 Stochastic time indexes for `connections_invested` with keyword arguments that allow filtering.
 """
@@ -396,7 +396,7 @@ function connection_investment_stochastic_time_indices(
     temporal_block=anything,
     t=anything,
 )
-    unique(
+    (
         (connection=conn, stochastic_scenario=s, t=t)
         for (conn, t) in connection_investment_time_indices(
             m; connection=connection, temporal_block=temporal_block, t=t,
@@ -407,7 +407,7 @@ function connection_investment_stochastic_time_indices(
 end
 
 """
-    node_investment_stochastic_time_indices(;<keyword arguments>)
+    node_investment_stochastic_time_indices(m; <keyword arguments>)
 
 Stochastic time indexes for `storages_invested` with keyword arguments that allow filtering.
 """
@@ -418,7 +418,7 @@ function node_investment_stochastic_time_indices(
     temporal_block=anything,
     t=anything,
 )
-    unique(
+    (
         (node=n, stochastic_scenario=s, t=t)
         for (n, t) in node_investment_time_indices(m; node=node, temporal_block=temporal_block, t=t)
         for ss in node__investment_stochastic_structure(node=n)

--- a/src/data_structure/temporal_structure.jl
+++ b/src/data_structure/temporal_structure.jl
@@ -631,8 +631,10 @@ end
 function dynamic_time_indices(m, blk; t_before=anything, t_after=anything)
     (
         (tb, ta)
-        for (tb, ta) in t_before_t(m; t_before=t_before, t_after=t_after, _compact=false)
-        if all(!isempty(intersect(members(blk), blocks(t))) for t in (tb, ta))
+        for (tb, ta) in t_before_t(
+            m; t_before=t_before, t_after=time_slice(m; temporal_block=members(blk), t=t_after), _compact=false
+        )
+        if !isempty(intersect(members(blk), blocks(tb)))
     )
 end
 

--- a/src/expressions/capacity_margin.jl
+++ b/src/expressions/capacity_margin.jl
@@ -144,7 +144,7 @@ function expression_capacity_margin_indices(m::Model; t_range=anything)
         for path in active_stochastic_paths(
             m,  
             [                                      
-                node_stochastic_time_indices(m; node=n, t=t);
+                collect(node_stochastic_time_indices(m; node=n, t=t));
                 [
                     (unit=u, stochastic_scenario=s, t=t2)
                     for u in indices(unit_capacity; node=n, direction=direction(:to_node)) if !is_storage_unit(u)

--- a/test/data_structure/stochastic_structure.jl
+++ b/test/data_structure/stochastic_structure.jl
@@ -159,22 +159,22 @@
     m = run_spineopt(url_in, log_level=0, optimize=false)
 
     @testset "node_stochastic_time_indices" begin
-        @test length(node_stochastic_time_indices(m; stochastic_scenario=stochastic_scenario(:scenario_a))) == 1
-        @test length(node_stochastic_time_indices(m; stochastic_scenario=stochastic_scenario(:scenario_a1))) == 2
-        @test length(node_stochastic_time_indices(m; stochastic_scenario=stochastic_scenario(:scenario_a2))) == 2
-        @test length(node_stochastic_time_indices(m; stochastic_scenario=stochastic_scenario(:scenario_b))) == 3
+        @test length(collect(node_stochastic_time_indices(m; stochastic_scenario=stochastic_scenario(:scenario_a)))) == 1
+        @test length(collect(node_stochastic_time_indices(m; stochastic_scenario=stochastic_scenario(:scenario_a1)))) == 2
+        @test length(collect(node_stochastic_time_indices(m; stochastic_scenario=stochastic_scenario(:scenario_a2)))) == 2
+        @test length(collect(node_stochastic_time_indices(m; stochastic_scenario=stochastic_scenario(:scenario_b)))) == 3
         @test isempty(node_stochastic_time_indices(m; stochastic_scenario=stochastic_scenario(:scenario_b1)))
         @test isempty(node_stochastic_time_indices(m; stochastic_scenario=stochastic_scenario(:scenario_b2)))
-        @test length(node_stochastic_time_indices(m)) == 8
+        @test length(collect(node_stochastic_time_indices(m))) == 8
     end
     @testset "unit_stochastic_time_indices" begin
-        @test length(unit_stochastic_time_indices(m; stochastic_scenario=stochastic_scenario(:scenario_a))) == 3
+        @test length(collect(unit_stochastic_time_indices(m; stochastic_scenario=stochastic_scenario(:scenario_a)))) == 3
         @test isempty(unit_stochastic_time_indices(m; stochastic_scenario=stochastic_scenario(:scenario_a1)))
         @test isempty(unit_stochastic_time_indices(m; stochastic_scenario=stochastic_scenario(:scenario_a2)))
-        @test length(unit_stochastic_time_indices(m; stochastic_scenario=stochastic_scenario(:scenario_b))) == 2
-        @test length(unit_stochastic_time_indices(m; stochastic_scenario=stochastic_scenario(:scenario_b1))) == 1
-        @test length(unit_stochastic_time_indices(m; stochastic_scenario=stochastic_scenario(:scenario_b2))) == 1
-        @test length(unit_stochastic_time_indices(m)) == 7
+        @test length(collect(unit_stochastic_time_indices(m; stochastic_scenario=stochastic_scenario(:scenario_b)))) == 2
+        @test length(collect(unit_stochastic_time_indices(m; stochastic_scenario=stochastic_scenario(:scenario_b1)))) == 1
+        @test length(collect(unit_stochastic_time_indices(m; stochastic_scenario=stochastic_scenario(:scenario_b2)))) == 1
+        @test length(collect(unit_stochastic_time_indices(m))) == 7
     end
     @testset "node_stochastic_scenario_weight" begin
         @test realize(


### PR DESCRIPTION
This PR (together with a recent commit to SpineInterface) improves the algorithm to compute the low/highest resolution time slices in a set. Before, for each time slice we would look at all the others to see if it contained/was contained in the other. This has a complexity of order n square, leading to quick performance degration with the number of time slices. Now we rely on ordering/grouping time slices by duration to achieve near order n performance.

I tested Yi's PyPSA model and the 1 year run now completes in about 2 minutes and a half instead of the 10 minutes previously reported.

Re #855 

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted according to SpineOpt's style
- [x] Unit tests pass
