### PR TITLE
Add the objective function of the examples to the tests in run examples.jl

### DIFF
--- a/examples/reserves.json
+++ b/examples/reserves.json
@@ -1098,7 +1098,7 @@
                             "data": [
                                 [
                                     "mip_rel_gap",
-                                    0.01
+                                    1e-6
                                 ],
                                 [
                                     "presolve",

--- a/examples/simple_system.json
+++ b/examples/simple_system.json
@@ -1076,7 +1076,7 @@
                             "data": [
                                 [
                                     "mip_rel_gap",
-                                    0.01
+                                    1e-6
                                 ],
                                 [
                                     "presolve",

--- a/examples/unit_commitment.json
+++ b/examples/unit_commitment.json
@@ -1076,7 +1076,7 @@
                             "data": [
                                 [
                                     "mip_rel_gap",
-                                    0.01
+                                    1e-6
                                 ],
                                 [
                                     "presolve",

--- a/test/run_examples.jl
+++ b/test/run_examples.jl
@@ -1,6 +1,18 @@
+# Examples that we want to check the objective function value
+objective_function_reference_values = Dict(
+    "6_unit_system.json" => 6.966879153985747e6,
+    "reserves.json" => 175971.42857142858,
+    "simple_system.json" => 160714.28571428574,
+    "unit_commitment.json" => 98637.42857142858
+)
+
 @testset for path in readdir(joinpath(dirname(@__DIR__), "examples"); join=true)
     if splitext(path)[end] == ".json"
         input_data = JSON.parsefile(path)
-        @test termination_status(run_spineopt(input_data, nothing; log_level=3)) == MOI.OPTIMAL
+        m = run_spineopt(input_data, nothing; log_level=3)        
+        @test termination_status(m) == MOI.OPTIMAL
+        if haskey(objective_function_reference_values, basename(path))
+            @test abs(objective_value(m) - objective_function_reference_values[basename(path)]) < 1e-6
+        end
     end
 end

--- a/test/run_examples.jl
+++ b/test/run_examples.jl
@@ -12,7 +12,7 @@ objective_function_reference_values = Dict(
         m = run_spineopt(input_data, nothing; log_level=3)        
         @test termination_status(m) == MOI.OPTIMAL
         if haskey(objective_function_reference_values, basename(path))
-            @test abs(objective_value(m) - objective_function_reference_values[basename(path)]) < 1e-6
+            @test abs(objective_value(m) - objective_function_reference_values[basename(path)]) < 1e-4
         end
     end
 end


### PR DESCRIPTION
To maintain consistency in the objective function of our examples, we add it to the test. We use a dictionary to select the examples we want to test the objective function for, or simply check if it's optimal.

Fixes #935 

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted according to SpineOpt's style
- [x] Unit tests pass
