### PR TITLE
Improve extension mechanism once more

### DIFF
--- a/docs/src/library.md
+++ b/docs/src/library.md
@@ -19,6 +19,8 @@ Depth = 3
 
 ```@docs
 run_spineopt
+prepare_spineopt
+run_spineopt!
 create_model
 build_model!
 solve_model!

--- a/src/SpineOpt.jl
+++ b/src/SpineOpt.jl
@@ -38,6 +38,8 @@ import SpineInterface: Parameter, parameter_value
 
 export SpineOptExt
 export run_spineopt
+export prepare_spineopt
+export run_spineopt!
 export add_event_handler!
 export create_model
 export build_model!

--- a/src/run_spineopt.jl
+++ b/src/run_spineopt.jl
@@ -135,21 +135,21 @@ end
 """
     prepare_spineopt(url_in; <keyword arguments>)
 
-A SpineOpt model from the contents of `url_in`.
+A SpineOpt model from the contents of `url_in` - ready to be passed to [run_spineopt!](@ref).
 The argument `url_in` must be either a `String` pointing to a valid Spine database,
 or a `Dict` (e.g. manually created or parsed from a json file).
 
 # Arguments
 
-- `log_level::Int=3`: an integer to control the log level.
-- `upgrade::Bool=false`: whether or not to automatically upgrade the data structure in `url_in` to latest.
-- `filters::Dict{String,String}=Dict("tool" => "object_activity_control")`: a dictionary to specify filters.
-   Possible keys are "tool" and "scenario". Values should be a tool or scenario name in the input DB.
-- `templates`: a collection of templates to load on top of the SpineOpt template.
-   Each template must be a `Dict` with the same structure as the one returned by `SpineOpt.template()`.
-- `mip_solver=nothing`: a MIP solver to use if no MIP solver specified in the DB.
-- `lp_solver=nothing`: a LP solver to use if no LP solver specified in the DB.
-- `use_direct_model::Bool=false`: whether or not to use `JuMP.direct_model` to build the `Model` object.
+- `log_level`
+- `upgrade`
+- `filters`
+- `templates`
+- `mip_solver`
+- `lp_solver`
+- `use_direct_model`
+
+See [run_spineopt](@ref) for the description of the keyword arguments.
 """
 function prepare_spineopt(
     url_in;
@@ -235,23 +235,20 @@ _data(data::Dict; kwargs...) = data
 """
     run_spineopt!(m, url_out; <keyword arguments>)
 
-Run given SpineOpt model and write report(s) to `url_out`.
+Build SpineOpt on the given `m` and solve it; write report(s) to `url_out`.
 A new Spine database is created at `url_out` if one doesn't exist.
 
 # Arguments
 
-- `log_level::Int=3`: an integer to control the log level.
-- `optimize::Bool=true`: whether or not to optimise the model (useful for running tests).
-- `update_names::Bool=false`: whether or not to update variable and constraint names after the model rolls
-   (expensive).
-- `alternative::String=""`: if non empty, write results to the given alternative in the output DB.
-- `write_as_roll::Int=0`: if greater than 0 and the run has a rolling horizon, then write results every that many
-   windows.
-- `log_file_path::String=nothing`: if not nothing, log all console output to a file at the given path. The file
-   is overwritten at each call.
-- `resume_file_path::String=nothing`: only relevant in rolling horizon optimisations with `write_as_roll` greater or
-   equal than one. If the file at given path contains resume data from a previous run, start the run from that point.
-   Also, save resume data to that same file as the model rolls and results are written to the output database.
+- `log_level`
+- `optimize`
+- `update_names`
+- `alternative`
+- `write_as_roll`
+- `log_file_path`
+- `resume_file_path`
+
+See [run_spineopt](@ref) for the description of the keyword arguments.
 """
 function run_spineopt!(
     m::Model,
@@ -437,9 +434,6 @@ struct SpineOptExt
             :model_solved => [],
             :window_about_to_solve => [],
             :window_solved => [],
-            :master_model_built => [],
-            :master_model_about_to_solve => [],
-            :master_model_solved => [],
         )
         new(
             instance,
@@ -524,9 +518,6 @@ Below is a table of events, arguments, and when do they fire.
 | `:model_solved` | `m` | Right after model `m` is solved. |
 | `:window_about_to_solve` | `(m, k)` | Right before window `k` for model `m` is solved. |
 | `:window_solved` | `(m, k)` | Right after window `k` for model `m` is solved. |
-| `:master_model_built` | `m` | Right after the Benders master model for model `m` is built. |
-| `:master_model_about_to_solve` | `(m, j)` | Right before the Benders master model for model `m` and iteration `j` is solved. |
-| `:master_model_solved` | `(m, j)` | Right after the Benders master model for model `m` and iteration `j` is solved. |
 
 # Example
 

--- a/src/run_spineopt_standard.jl
+++ b/src/run_spineopt_standard.jl
@@ -72,6 +72,7 @@ Build given SpineOpt model:
 - `log_level::Int`: an integer to control the log level.
 """
 function build_model!(m; log_level)
+    num_variables(m) == 0 || return
     model_name = _model_name(m)
     @timelog log_level 2 "Creating $model_name temporal structure..." generate_temporal_structure!(m)
     @timelog log_level 2 "Creating $model_name stochastic structure..." generate_stochastic_structure!(m)
@@ -388,13 +389,14 @@ function solve_model!(
     calculate_duals=false,
     output_suffix=(;),
     log_prefix="",
+    rewind=true,
 )
     k = _resume_run!(m, resume_file_path; log_level, update_names)
     k === nothing && return m
     _solve_stage_models!(m; log_level, log_prefix) || return false
     _call_event_handlers(m, :model_about_to_solve)
     model_name = string(log_prefix, _model_name(m))
-    @timelog log_level 2 "Bringing $model_name to the first window..." rewind_temporal_structure!(m)
+    rewind && @timelog log_level 2 "Bringing $model_name to the first window..." rewind_temporal_structure!(m)
     while true
         @log log_level 1 "\n$model_name - Window $k: $(current_window(m))"
         _call_event_handlers(m, :window_about_to_solve, k)


### PR DESCRIPTION
- Remove benders master problem events, users can hook to normal events on the master model object itself.
- Expose prepare_spineopt and run_spineopt!
- Don't rebuild the model if already built, this way users can really reuse the same `m` in multiple calls to run_spineopt!

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted according to SpineOpt's style
- [x] Unit tests pass
