### PR TITLE
Add free energy warning to docs

### DIFF
--- a/docs/src/concept_reference/fix_connection_flow.md
+++ b/docs/src/concept_reference/fix_connection_flow.md
@@ -1,1 +1,3 @@
-The [fix\_connection\_flow](@ref) parameter fixes the value of the [connection\_flow](@ref) variable.
+The [fix_connection_flow](@ref) parameter fixes the value of the [connection_flow](@ref) variable.
+
+> **Warning:** that this parameter should be set to 0 for history timeslices to avoid free energy in the model when using the [connection_flow_delay](@ref) parameter.


### PR DESCRIPTION
Fixes #414

## Checklist before merging
- [X] Documentation is up-to-date
- [NA] Unit tests have been added/updated accordingly
- [X] Code has been formatted according to SpineOpt's style
- [NA] Unit tests pass
