### PR TITLE
Apply lookahead relative to the end of the window

### DIFF
--- a/src/data_structure/benders_data.jl
+++ b/src/data_structure/benders_data.jl
@@ -101,7 +101,7 @@ function _save_sp_marginal_values!(m, var_name, param_name, obj_cls, k, win_weig
     vals = Dict(
         k => win_weight * realize(v)
         for (k, v) in m.ext[:spineopt].values[var_name]
-        if start(k.t) < end_(current_window(m))
+        if iscontained(k.t, current_window(m))
     )
     if _is_last_window(m, k)
         merge!(

--- a/src/data_structure/benders_data.jl
+++ b/src/data_structure/benders_data.jl
@@ -101,13 +101,15 @@ function _save_sp_marginal_values!(m, var_name, param_name, obj_cls, k, win_weig
     vals = Dict(
         k => win_weight * realize(v)
         for (k, v) in m.ext[:spineopt].values[var_name]
-        if iscontained(k.t, current_window(m))
+        if start(k.t) < end_(current_window(m))
     )
     if _is_last_window(m, k)
         merge!(
             vals,
             Dict(
-                k => realize(v) for (k, v) in m.ext[:spineopt].values[var_name] if start(k.t) >= end_(current_window(m))
+                k => win_weight * realize(v)
+                for (k, v) in m.ext[:spineopt].values[var_name]
+                if start(k.t) >= end_(current_window(m))
             )
         )
     end

--- a/src/data_structure/temporal_structure.jl
+++ b/src/data_structure/temporal_structure.jl
@@ -108,9 +108,7 @@ The adjusted end of a `temporal_block`.
 """
 _adjusted_end(m, _blk_end::Nothing) = end_(current_window(m))
 _adjusted_end(m, blk_end::DateTime) = max(start(current_window(m)), blk_end)
-function _adjusted_end(m, blk_end::Union{Period,CompoundPeriod})
-    end_(current_window(m)) + max(Minute(0), blk_end - _model_window_duration(m))
-end
+_adjusted_end(m, blk_end::Union{Period,CompoundPeriod}) = end_(current_window(m)) + blk_end - _model_window_duration(m)
 
 """
     _blocks_by_time_interval(m::Model)

--- a/test/run_spineopt_benders.jl
+++ b/test/run_spineopt_benders.jl
@@ -121,7 +121,7 @@ function _test_benders_unit()
                 ["unit", "unit_ab_alt", "online_variable_type", "unit_online_variable_type_integer"],
                 ["unit", "unit_ab_alt", "unit_investment_cost", u_inv_cost],
                 ["temporal_block", "hourly", "block_end", unparse_db_value(Hour(rf + look_ahead))],
-                ["temporal_block", "investments_hourly", "block_end", unparse_db_value(Hour(24 + look_ahead))],
+                ["temporal_block", "investments_hourly", "block_end", unparse_db_value(Hour(rf + look_ahead))],
                 ["temporal_block", "hourly", "resolution", unparse_db_value(Hour(res))],
                 ["temporal_block", "investments_hourly", "resolution", unparse_db_value(Hour(res))],
             ]
@@ -232,7 +232,7 @@ function _test_benders_storage()
                 ["node", "node_b", "demand", dem],
                 ["node", "node_a", "node_slack_penalty", penalty],
                 ["temporal_block", "hourly", "block_end", unparse_db_value(Hour(rf + look_ahead))],
-                ["temporal_block", "investments_hourly", "block_end", unparse_db_value(Hour(24 + look_ahead))],
+                ["temporal_block", "investments_hourly", "block_end", unparse_db_value(Hour(rf + look_ahead))],
                 ["temporal_block", "hourly", "resolution", unparse_db_value(Hour(res))],
                 ["temporal_block", "investments_hourly", "resolution", unparse_db_value(Hour(res))],
             ]
@@ -361,7 +361,7 @@ function _test_benders_unit_storage()
                 ["node", "node_b", "demand", dem],
                 ["node", "node_a", "node_slack_penalty", penalty],
                 ["temporal_block", "hourly", "block_end", unparse_db_value(Hour(rf + look_ahead))],
-                ["temporal_block", "investments_hourly", "block_end", unparse_db_value(Hour(24 + look_ahead))],
+                ["temporal_block", "investments_hourly", "block_end", unparse_db_value(Hour(rf + look_ahead))],
                 ["temporal_block", "hourly", "resolution", unparse_db_value(Hour(res))],
                 ["temporal_block", "investments_hourly", "resolution", unparse_db_value(Hour(res))],
             ]
@@ -684,7 +684,7 @@ function _test_benders_mp_min_res_gen_to_demand_ratio_cuts()
                 ["unit", "unit_ab_alt", "online_variable_type", "unit_online_variable_type_integer"],
                 ["unit", "unit_ab_alt", "unit_investment_cost", u_inv_cost],
                 ["temporal_block", "hourly", "block_end", unparse_db_value(Hour(rf + look_ahead))],
-                ["temporal_block", "investments_hourly", "block_end", unparse_db_value(Hour(24 + look_ahead))],
+                ["temporal_block", "investments_hourly", "block_end", unparse_db_value(Hour(rf + look_ahead))],
                 ["temporal_block", "hourly", "resolution", unparse_db_value(Hour(res))],
                 ["temporal_block", "investments_hourly", "resolution", unparse_db_value(Hour(res))],
             ]
@@ -800,7 +800,7 @@ function _test_benders_starting_units_invested()
                 ["unit", "unit_ab_alt", "online_variable_type", "unit_online_variable_type_integer"],
                 ["unit", "unit_ab_alt", "unit_investment_cost", u_inv_cost],
                 ["temporal_block", "hourly", "block_end", unparse_db_value(Hour(rf + look_ahead))],
-                ["temporal_block", "investments_hourly", "block_end", unparse_db_value(Hour(24 + look_ahead))],
+                ["temporal_block", "investments_hourly", "block_end", unparse_db_value(Hour(rf + look_ahead))],
                 ["temporal_block", "hourly", "resolution", unparse_db_value(Hour(res))],
                 ["temporal_block", "investments_hourly", "resolution", unparse_db_value(Hour(res))],
             ]


### PR DESCRIPTION
In Benders, if user defines block_end it is safe to assume it is relative to the sub problem rolling window. Currently, if the user defines a look-ahead for the investment block so it is applied to the rolling window, it is also applied to the master problem window with disastrous consequences (the investment block will end too soon in the master problem, probably).

This PR fixes the above issue by adjusting the block end in the master problem window so it looks ahead the same amount as in the subproblem rolling window.

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted according to SpineOpt's style
- [x] Unit tests pass
