### PR TITLE
Fix t_history_t for cases with lookahead

### DIFF
--- a/src/run_spineopt_standard.jl
+++ b/src/run_spineopt_standard.jl
@@ -1103,8 +1103,8 @@ function _fix_history_variable!(m::Model, name::Symbol, indices)
         history_t = t_history_t(m; t=ind.t)
         history_t === nothing && continue
         for history_ind in indices(m; ind..., t=history_t)
-            v = get(var, history_ind, nothing) # NOTE: only fix variables that have history
-            if v === nothing continue end
+            v = get(var, history_ind, nothing)  # NOTE: only fix variables that have history
+            v === nothing && continue
             _fix(v, val[ind])
         end
     end


### PR DESCRIPTION
There was a mistake in building the mapping from window time slice to history time slice in rolling models with a look-ahead - the window time-slice wouldn't roll. This PR fixes it.


## Checklist before merging
- [ ] Documentation is up-to-date
- [ ] Unit tests have been added/updated accordingly
- [ ] Code has been formatted according to SpineOpt's style
- [ ] Unit tests pass
