### PR TITLE
Speed up setting variable bounds

### DIFF
--- a/src/variables/variable_common.jl
+++ b/src/variables/variable_common.jl
@@ -64,6 +64,11 @@ function add_variable!(
         :non_anticipativity_margin => non_anticipativity_margin,
         :required_history => required_history
     )
+    lb = _nothing_if_empty(lb)
+    ub = _nothing_if_empty(ub)
+    initial_value = _nothing_if_empty(initial_value)
+    fix_value = _nothing_if_empty(fix_value)
+    internal_fix_value = _nothing_if_empty(internal_fix_value)
     var = m.ext[:spineopt].variables[name] = Dict(
         ind => _variable(
             m,
@@ -91,8 +96,14 @@ function add_variable!(
             fix(v, Call(initial_value_ts, (t=ind.t,), (Symbol(:initial_, name), ind)))
         end
     end
-    merge!(var, _representative_periods_mapping(m, var, indices))
+    isempty(SpineInterface.indices(representative_periods_mapping)) || merge!(
+        var, _representative_periods_mapping(m, var, indices)
+    )
+    var
 end
+
+_nothing_if_empty(p::Parameter) = isempty(indices(p)) ? nothing : p
+_nothing_if_empty(x) = x
 
 """
     _representative_index(ind)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -62,9 +62,39 @@ function _load_test_data_without_template(db_url, test_data)
     SpineInterface.import_data(db_url; test_data...)
 end
 
-function _is_constraint_equal(x, y)
-    x_terms, y_terms = x.func.terms, y.func.terms
-    x.set == y.set && keys(x_terms) == keys(y_terms) && all(isapprox(x_terms[k], y_terms[k]) for k in keys(x_terms))
+function _is_constraint_equal(left, right)
+    if !_is_constraint_equal_kernel(left, right)
+        @show left
+        @show right
+        false
+    else
+        true
+    end
+end
+
+function _is_constraint_equal_kernel(left, right)
+    if left.set != right.set
+        @error string(left.set, " != ", right.set)
+        return false
+    end
+    left_terms, right_terms = left.func.terms, right.func.terms
+    missing_in_right = setdiff(keys(left_terms), keys(right_terms))
+    if !isempty(missing_in_right)
+        @error string("missing in right constraint", missing_in_right)
+        return false
+    end
+    missing_in_left = setdiff(keys(right_terms), keys(left_terms))
+    if !isempty(missing_in_left)
+        @error string("missing in left constraint", missing_in_left)
+        return false
+    end
+    for k in keys(left_terms)
+        if !isapprox(left_terms[k], right_terms[k])
+            @error string(left_terms[k], " != ", right_terms[k])
+            return false
+        end
+    end
+    return true
 end
 
 function _is_expression_equal(x, y)


### PR DESCRIPTION
Don't try to access parameters if no indices.

## Checklist before merging
- [ ] Documentation is up-to-date
- [ ] Unit tests have been added/updated accordingly
- [ ] Code has been formatted according to SpineOpt's style
- [ ] Unit tests pass
