### PR TITLE
Only create unit variables if needed

### DIFF
--- a/src/constraints/constraint_minimum_operating_point.jl
+++ b/src/constraints/constraint_minimum_operating_point.jl
@@ -64,7 +64,7 @@ See also
 [unit\_conv\_cap\_to\_flow](@ref)
 """
 function add_constraint_minimum_operating_point!(m::Model)
-    @fetch unit_flow, units_on, nonspin_units_started_up, nonspin_units_shut_down = m.ext[:spineopt].variables
+    @fetch unit_flow, nonspin_units_started_up, nonspin_units_shut_down = m.ext[:spineopt].variables
     t0 = _analysis_time(m)
     m.ext[:spineopt].constraints[:minimum_operating_point] = Dict(
         (unit=u, node=ng, direction=d, stochastic_path=s_path, t=t) => @constraint(
@@ -88,7 +88,7 @@ function add_constraint_minimum_operating_point!(m::Model)
             >=
             + sum(
                 (
-                    + units_on[u, s, t_over]
+                    + _get_units_on(m, u, s, t_over)
                     - sum(
                         _switch(
                             d; from_node=nonspin_units_started_up, to_node=nonspin_units_shut_down
@@ -103,7 +103,9 @@ function add_constraint_minimum_operating_point!(m::Model)
                 * minimum_operating_point(m; unit=u, node=ng, direction=d, stochastic_scenario=s, analysis_time=t0, t=t)
                 * unit_capacity(m; unit=u, node=ng, direction=d, stochastic_scenario=s, analysis_time=t0, t=t)
                 * unit_conv_cap_to_flow(m; unit=u, node=ng, direction=d, stochastic_scenario=s, analysis_time=t0, t=t)
-                for (u, s, t_over) in units_on_indices(m; unit=u, stochastic_scenario=s_path, t=t_overlaps_t(m; t=t));
+                for (u, s, t_over) in unit_stochastic_time_indices(
+                    m; unit=u, stochastic_scenario=s_path, t=t_overlaps_t(m; t=t)
+                );
                 init=0,
             )
         )

--- a/src/constraints/constraint_operating_point_bounds.jl
+++ b/src/constraints/constraint_operating_point_bounds.jl
@@ -34,7 +34,7 @@ online units. This constraint is activated only when parameter [ordered\_unit\_f
 See also [operating\_points](@ref), [ordered\_unit\_flow\_op](@ref).
 """
 function add_constraint_operating_point_bounds!(m::Model)
-    @fetch unit_flow_op_active, units_on = m.ext[:spineopt].variables
+    @fetch unit_flow_op_active = m.ext[:spineopt].variables
     m.ext[:spineopt].constraints[:operating_point_bounds] = Dict(
         (unit=u, node=n, direction=d, i=op, stochastic_path=s_path, t=t) => @constraint(
             m,
@@ -47,8 +47,10 @@ function add_constraint_operating_point_bounds!(m::Model)
             )
             <= 
             sum(
-                units_on[u, s, t]
-                for (u, s, t) in units_on_indices(m; unit=u, stochastic_scenario=s_path, t=t_in_t(m; t_long=t));
+                _get_units_on(m, u, s, t)
+                for (u, s, t) in unit_stochastic_time_indices(
+                    m; unit=u, stochastic_scenario=s_path, t=t_in_t(m; t_long=t)
+                );
                 init=0,
             )
         )

--- a/src/constraints/constraint_ratio_unit_flow.jl
+++ b/src/constraints/constraint_ratio_unit_flow.jl
@@ -65,7 +65,7 @@ See also [fix\_ratio\_out\_in\_unit\_flow](@ref), [fix\_units\_on\_coefficient\_
 function add_constraint_ratio_unit_flow!(m::Model, ratio, units_on_coefficient, sense, d1, d2)
     # NOTE: that the `<sense>_ratio_<directions>_unit_flow` parameter uses the stochastic dimensions of the second
     # <direction>!
-    @fetch unit_flow, units_on = m.ext[:spineopt].variables
+    @fetch unit_flow = m.ext[:spineopt].variables
     t0 = _analysis_time(m)
     m.ext[:spineopt].constraints[ratio.name] = Dict(
         (unit=u, node1=ng1, node2=ng2, stochastic_path=s_path, t=t) => sense_constraint(
@@ -88,10 +88,12 @@ function add_constraint_ratio_unit_flow!(m::Model, ratio, units_on_coefficient, 
                 init=0,
             )
             + sum(
-                units_on[u, s, t1]
+                _get_units_on(m, u, s, t1)
                 * min(duration(t1), duration(t))
                 * units_on_coefficient(m; unit=u, node1=ng1, node2=ng2, stochastic_scenario=s, analysis_time=t0, t=t)
-                for (u, s, t1) in units_on_indices(m; unit=u, stochastic_scenario=s_path, t=t_overlaps_t(m; t=t));
+                for (u, s, t1) in unit_stochastic_time_indices(
+                    m; unit=u, stochastic_scenario=s_path, t=t_overlaps_t(m; t=t)
+                );
                 init=0,
             )
         )

--- a/src/constraints/constraint_unit_flow_capacity.jl
+++ b/src/constraints/constraint_unit_flow_capacity.jl
@@ -167,10 +167,9 @@ function _term_unit_flow(m, u, ng, d, s_path, t)
 end
 
 function _term_flow_capacity(m, u, ng, d, s_path, t)
-    @fetch units_on = m.ext[:spineopt].variables
     t0 = _analysis_time(m)
     sum(
-        _unit_flow_capacity(m, u, ng, d, s, t0, t) * units_on[u, s, t_over] * overlap_duration(t_over, t)
+        _unit_flow_capacity(m, u, ng, d, s, t0, t) * _get_units_on(m, u, s, t_over) * overlap_duration(t_over, t)
         for (u, s, t_over) in unit_stochastic_time_indices(
             m; unit=u, stochastic_scenario=s_path, t=t_overlaps_t(m; t=t)
         );

--- a/src/constraints/constraint_unit_flow_op_bounds.jl
+++ b/src/constraints/constraint_unit_flow_op_bounds.jl
@@ -53,7 +53,7 @@ See also
 [ordered\_unit\_flow\_op](@ref).
 """
 function add_constraint_unit_flow_op_bounds!(m::Model)
-    @fetch units_on, unit_flow_op, unit_flow_op_active = m.ext[:spineopt].variables
+    @fetch unit_flow_op, unit_flow_op_active = m.ext[:spineopt].variables
     t0 = _analysis_time(m)
     m.ext[:spineopt].constraints[:unit_flow_op_bounds] = Dict(
         (unit=u, node=n, direction=d, i=op, stochastic_scenario=s, t=t) => @constraint(
@@ -62,7 +62,7 @@ function add_constraint_unit_flow_op_bounds!(m::Model)
             <=
             (
                 ordered_unit_flow_op(unit = u, node=n, direction=d, _default=false) ? 
-                unit_flow_op_active[u, n, d, op, s, t] : units_on[u, s, t]
+                unit_flow_op_active[u, n, d, op, s, t] : _get_units_on(m, u, s, t)
             )
             * (
                 + operating_points(m; unit=u, node=n, direction=d, stochastic_scenario=s, analysis_time=t0, i=op)

--- a/src/constraints/constraint_unit_state_transition.jl
+++ b/src/constraints/constraint_unit_state_transition.jl
@@ -58,7 +58,7 @@ end
 function constraint_unit_state_transition_indices(m::Model)
     (
         (unit=u, stochastic_path=path, t_before=t_before, t_after=t_after)
-        for (u, t_before, t_after) in unit_dynamic_time_indices(m)
+        for (u, t_before, t_after) in unit_dynamic_time_indices(m; unit=_switchable_unit())
         for path in active_stochastic_paths(m, units_on_indices(m; unit=u, t=[t_before, t_after]))
     )
 end

--- a/src/constraints/constraint_units_available.jl
+++ b/src/constraints/constraint_units_available.jl
@@ -66,7 +66,7 @@ constraint generation.
 function constraint_units_available_indices(m::Model)
     (
         (unit=u, stochastic_scenario=s, t=t)
-        for (u, t) in unit_time_indices(m)
+        for (u, t) in unit_time_indices(m; unit=_activatable_unit())
         for path in active_stochastic_paths(
             m,
             Iterators.flatten(

--- a/src/constraints/constraint_units_available.jl
+++ b/src/constraints/constraint_units_available.jl
@@ -39,7 +39,7 @@ function add_constraint_units_available!(m::Model)
             m,
             + sum(
                 + units_on[u, s, t] 
-                + units_out_of_service[u, s, t]
+                + _get_units_out_of_service(m, u, s, t)
                 for (u, s, t) in units_on_indices(m; unit=u, stochastic_scenario=s, t=t);
                 init=0,
             )

--- a/src/constraints/constraint_units_out_of_service_transition.jl
+++ b/src/constraints/constraint_units_out_of_service_transition.jl
@@ -58,8 +58,7 @@ end
 function constraint_units_out_of_service_transition_indices(m::Model)
     (
         (unit=u, stochastic_path=path, t_before=t_before, t_after=t_after)
-        for u in indices(scheduled_outage_duration)
-        for (u, t_before, t_after) in unit_dynamic_time_indices(m; unit=u)
+        for (u, t_before, t_after) in unit_dynamic_time_indices(m; unit=_deactivatable_unit())
         for path in active_stochastic_paths(m, units_on_indices(m; unit=u, t=[t_before, t_after]))
     )
 end

--- a/src/data_structure/preprocess_data_structure.jl
+++ b/src/data_structure/preprocess_data_structure.jl
@@ -44,6 +44,7 @@ function preprocess_data_structure()
     apply_forced_availability_factor()
     generate_is_boundary()
     generate_unit_flow_capacity()
+    generate_unit_commitment_parameters()
 end
 
 """
@@ -245,8 +246,8 @@ function generate_connection_has_ptdf()
     end
 
     add_object_parameter_values!(connection, Dict(conn => _new_connection_pvals(conn) for conn in connection()))
-    push!(has_ptdf.classes, connection)
-    push!(ptdf_duration.classes, connection)
+    push_class!(has_ptdf, connection)
+    push_class!(ptdf_duration, connection)
 end
 
 """
@@ -917,3 +918,45 @@ function generate_unit_flow_capacity()
     end
 end
 
+function generate_unit_commitment_parameters()
+    _switchable_unit_iter = Iterators.flatten(
+        (
+            indices(min_up_time),
+            indices(min_down_time),
+            indices(start_up_cost),
+            indices(shut_down_cost), 
+            (x.unit for x in indices(start_up_limit)),
+            (x.unit for x in indices(shut_down_limit)),
+            (x.unit for x in indices(unit_start_flow) if unit_start_flow(; x...) != 0),
+            (x.unit for x in indices(units_started_up_coefficient) if units_started_up_coefficient(; x...) != 0),
+        )
+    )
+    _activatable_unit_iter = Iterators.flatten(
+        (
+            _switchable_unit_iter,
+            indices(units_on_cost),
+            indices(units_on_non_anticipativity_time),
+            (u for u in indices(candidate_units) if candidate_units(unit=u) > 0),
+            (x.unit for x in indices(units_on_coefficient) if units_on_coefficient(; x...) != 0),
+        )
+    )
+    _deactivatable_unit_iter = Iterators.flatten(
+        (indices(scheduled_outage_duration), (u for u in indices(units_unavailable) if units_unavailable(unit=u) != 0))
+    )
+    for (pname, iter) in (
+        (:is_switchable, _switchable_unit_iter),
+        (:is_activatable, _activatable_unit_iter),
+        (:is_deactivatable, _deactivatable_unit_iter),
+    )
+        add_object_parameter_values!(unit, Dict(u => Dict(pname => parameter_value(true)) for u in unique(iter)))
+        add_object_parameter_defaults!(unit, Dict(pname => parameter_value(false)))
+    end
+    @eval begin
+        is_switchable = Parameter(:is_switchable, [unit])
+        is_activatable = Parameter(:is_activatable, [unit])
+        is_deactivatable = Parameter(:is_deactivatable, [unit])
+        export is_switchable
+        export is_activatable
+        export is_deactivatable
+    end
+end

--- a/src/expressions/capacity_margin.jl
+++ b/src/expressions/capacity_margin.jl
@@ -106,13 +106,9 @@ function add_expression_capacity_margin!(m::Model)
                 )
                 * (
                     + sum(
-                        + units_on[u, s, t_ua]
-                        for (u, s, t_ua) in units_on_indices(
-                            m;
-                            unit=u,
-                            stochastic_scenario=s_path,
-                            t=t_overlaps_t(m; t=t),
-                            temporal_block=anything,
+                        + _get_units_on(m, u, s, t_uon)
+                        for (u, s, t_uon) in unit_stochastic_time_indices(
+                            m; unit=u, stochastic_scenario=s_path, t=t_overlaps_t(m; t=t), temporal_block=anything
                         );
                         init=0,
                     )

--- a/src/variables/variable_units_on.jl
+++ b/src/variables/variable_units_on.jl
@@ -30,6 +30,7 @@ function units_on_indices(
     t=anything,
     temporal_block=temporal_block(representative_periods_mapping=nothing),
 )
+    unit = intersect(unit, _activatable_unit())
     (
         (unit=u, stochastic_scenario=s, t=t)
         for (u, s, t) in unit_stochastic_time_indices(
@@ -50,6 +51,7 @@ function units_switched_indices(
     t=anything,
     temporal_block=temporal_block(representative_periods_mapping=nothing),
 )
+    unit = intersect(unit, _switchable_unit())
     (
         (unit=u, stochastic_scenario=s, t=t)
         for (u, s, t) in unit_stochastic_time_indices(
@@ -57,6 +59,20 @@ function units_switched_indices(
         )
     )
 end
+
+"""
+    _activatable_unit()
+
+An `Array` of units that need a `units_on` variable.
+"""
+_activatable_unit() = unit(is_activatable=true)
+
+"""
+    _switchable_unit()
+
+An `Array` of units that need a `units_started_up` and `units_shut_down` variables.
+"""
+_switchable_unit() = unit(is_switchable=true)
 
 """
     units_on_bin(x)
@@ -108,4 +124,10 @@ function add_variable_units_on!(m::Model)
         non_anticipativity_margin=units_on_non_anticipativity_margin,
         required_history_period=_get_max_duration(m, [min_up_time, min_down_time]),
     )
+end
+
+function _get_units_on(m, u, s, t)
+    get(m.ext[:spineopt].variables[:units_on], (u, s, t)) do
+        number_of_units(m; unit=u, stochastic_scenario=s, analysis_time=_analysis_time(m), t=t)
+    end
 end

--- a/src/variables/variable_units_out_of_service.jl
+++ b/src/variables/variable_units_out_of_service.jl
@@ -24,10 +24,18 @@ function units_out_of_service_indices(
     t=anything,
     temporal_block=temporal_block(representative_periods_mapping=nothing),
 )
+    unit = intersect(unit, _deactivatable_unit())
     unit_stochastic_time_indices(
         m; unit=unit, stochastic_scenario=stochastic_scenario, t=t, temporal_block=temporal_block,
     )
 end
+
+"""
+    _deactivatable_unit()
+
+An `Array` of units that need a `units_out_of_service` and friends variables.
+"""
+_deactivatable_unit() = unit(is_deactivatable=true)
 
 """
     units_out_of_service_bin(x)
@@ -78,4 +86,10 @@ function add_variable_units_out_of_service!(m::Model)
         replacement_value=units_out_of_service_replacement_value,
         required_history_period=maximum_parameter_value(scheduled_outage_duration),        
     )
+end
+
+function _get_units_out_of_service(m, u, s, t)
+    get(m.ext[:spineopt].variables[:units_out_of_service], (u, s, t)) do
+        units_unavailable(m; unit=u, stochastic_scenario=s, analysis_time=_analysis_time(m), t=t)
+    end
 end

--- a/test/constraints/constraint_node.jl
+++ b/test/constraints/constraint_node.jl
@@ -945,6 +945,7 @@ function test_constraint_min_capacity_margin()
         object_parameter_values = [
             ["node", "node_b", "min_capacity_margin", margin_b],
             ["node", "node_b", "demand", demand_b],
+            ["unit", "unit_ab", "units_on_cost", 1],  # To have unis_on variables
         ]
         relationship_parameter_values = [
             ["unit__to_node", ["unit_ab", "node_b"], "unit_capacity", capacity]

--- a/test/constraints/constraint_unit.jl
+++ b/test/constraints/constraint_unit.jl
@@ -73,6 +73,7 @@ function _test_constraint_unit_setup()
             ["temporal_block", "two_hourly", "resolution", Dict("type" => "duration", "data" => "2h")],
             ["model", "instance", "db_mip_solver", "HiGHS.jl"],
             ["model", "instance", "db_lp_solver", "HiGHS.jl"],
+            ["unit", "unit_ab", "units_on_cost", 1],  # Just to have units_on variables
         ],
         :relationship_parameter_values => [
             [
@@ -216,7 +217,10 @@ end
 function test_constraint_unit_state_transition()
     @testset "constraint_unit_state_transition" begin
         url_in = _test_constraint_unit_setup()
-        object_parameter_values = [["unit", "unit_ab", "online_variable_type", "unit_online_variable_type_integer"]]
+        object_parameter_values = [
+            ["unit", "unit_ab", "online_variable_type", "unit_online_variable_type_integer"],
+            ["unit", "unit_ab", "start_up_cost", 1],
+        ]
         SpineInterface.import_data(url_in; object_parameter_values=object_parameter_values)
         m = run_spineopt(url_in; log_level=0, optimize=false)
         var_units_on = m.ext[:spineopt].variables[:units_on]

--- a/test/expressions/expression.jl
+++ b/test/expressions/expression.jl
@@ -142,8 +142,8 @@ function test_expression_capacity_margin()
             unit_ab = unit(:unit_ab)
             d_f = direction(:from_node)
             d_t = direction(:to_node)
-            var_uon_b = var_units_on[unit_b, s, t]
-            var_uon_ab = var_units_on[unit_ab, s, t2]
+            var_uon_b = get(var_units_on, (unit_b, s, t), 1)
+            var_uon_ab = get(var_units_on, (unit_ab, s, t2), 1)
             var_uff_cb = var_unit_flow[unit_cb, n, d_f, s, t]
             var_uft_cb = var_unit_flow[unit_cb, n, d_t, s, t]
      

--- a/test/run_spineopt.jl
+++ b/test/run_spineopt.jl
@@ -890,7 +890,8 @@ function _test_only_linear_model_has_duals()
         objects = [["output", "bound_units_on"]]
         relationships = [["report__output", ["report_x", "bound_units_on"]]]
         object_parameter_values = [
-            ["unit", "unit_ab", "online_variable_type", "unit_online_variable_type_binary"]
+            ["unit", "unit_ab", "online_variable_type", "unit_online_variable_type_binary"],
+            ["unit", "unit_ab", "units_on_cost", 1],  # To have units_on variables
         ]
         SpineInterface.import_data(
             url_in; objects=objects, relationships=relationships, object_parameter_values=object_parameter_values


### PR DESCRIPTION
Only creates units_on, units_started_up, units_started_up, units_out_of_service, units_taken_out_of_service, and units_returned_to_service if needed.

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted according to SpineOpt's style
- [x] Unit tests pass
