### PR TITLE
Avoid double dipping into indices functions

### DIFF
--- a/src/constraints/constraint_connection_flow_capacity.jl
+++ b/src/constraints/constraint_connection_flow_capacity.jl
@@ -64,10 +64,10 @@ function add_constraint_connection_flow_capacity!(m::Model)
         (connection=conn, node=ng, direction=d, stochastic_path=s_path, t=t) => @constraint(
             m,
             + sum(
-                connection_flow[conn, n, d, s, t] * duration(t)
-                for (conn, n, d, s, t) in connection_flow_indices(
-                    m; connection=conn, direction=d, node=ng, stochastic_scenario=s_path, t=t_in_t(m; t_long=t)
-                );
+                get(connection_flow, (conn, n, d, s, t), 0) * duration(t)
+                for n in members(ng)
+                for s in s_path
+                for t in t_in_t(m; t_long=t);
                 init=0,
             )
             <=
@@ -81,10 +81,9 @@ function add_constraint_connection_flow_capacity!(m::Model)
                 )
                 * (
                     + sum(
-                        connections_invested_available[conn, s, t1]
-                        for (conn, s, t1) in connections_invested_available_indices(
-                            m; connection=conn, stochastic_scenario=s_path, t=t_in_t(m; t_short=t)
-                        );
+                        get(connections_invested_available, (conn, s, t1), 0)
+                        for s in s_path
+                        for t1 in t_in_t(m; t_short=t);
                         init=0,
                     )
                     + number_of_connections(
@@ -96,9 +95,9 @@ function add_constraint_connection_flow_capacity!(m::Model)
                         _default=_default_number_of_connections(conn),
                     )
                 )
-                for (conn, _n, d, s, t) in connection_flow_indices(
-                    m; connection=conn, direction=d, node=ng, stochastic_scenario=s_path, t=t_in_t(m; t_long=t)
-                );
+                for s in s_path
+                for t in t_in_t(m; t_long=t)
+                if any(haskey(connection_flow, (conn, n, d, s, t)) for n in members(ng));
                 init=0,
             )
             * duration(t)

--- a/src/constraints/constraint_nodal_balance.jl
+++ b/src/constraints/constraint_nodal_balance.jl
@@ -66,10 +66,9 @@ function add_constraint_nodal_balance!(m::Model)
             + node_injection[n, s, t]
             # Commodity flows from connections
             + sum(
-                connection_flow[conn, n1, d, s, t]
-                for (conn, n1, d, s, t) in connection_flow_indices(
-                    m; node=n, direction=direction(:to_node), stochastic_scenario=s, t=t
-                )
+                get(connection_flow, (conn, n1, d, s, t), 0)
+                for n1 in members(n)
+                for (conn, d) in connection__to_node(node=n1)
                 if !_issubset(
                     connection__from_node(connection=conn, direction=direction(:from_node)), _internal_nodes(n)
                 );
@@ -77,10 +76,9 @@ function add_constraint_nodal_balance!(m::Model)
             )
             # Commodity flows to connections
             - sum(
-                connection_flow[conn, n1, d, s, t]
-                for (conn, n1, d, s, t) in connection_flow_indices(
-                    m; node=n, direction=direction(:from_node), stochastic_scenario=s, t=t
-                )
+                get(connection_flow, (conn, n1, d, s, t), 0)
+                for n1 in members(n)
+                for (conn, d) in connection__from_node(node=n1)
                 if !_issubset(connection__to_node(connection=conn, direction=direction(:to_node)), _internal_nodes(n));
                 init=0,
             )

--- a/src/constraints/constraint_ratio_unit_flow.jl
+++ b/src/constraints/constraint_ratio_unit_flow.jl
@@ -71,20 +71,17 @@ function add_constraint_ratio_unit_flow!(m::Model, ratio, units_on_coefficient, 
         (unit=u, node1=ng1, node2=ng2, stochastic_path=s_path, t=t) => sense_constraint(
             m,
             + sum(
-                unit_flow[u, n1, d1, s, t_short] * duration(t_short)
-                for (u, n1, d1, s, t_short) in unit_flow_indices(
-                    m; unit=u, node=ng1, direction=d1, stochastic_scenario=s_path, t=t_in_t(m; t_long=t)
-                );
+                get(unit_flow, (u, n1, d1, s, t_short), 0)
+                * duration(t_short)
+                for n1 in members(ng1), s in s_path, t_short in t_in_t(m; t_long=t);
                 init=0,
             ),
             sense,
             + sum(
-                unit_flow[u, n2, d2, s, t_short]
+                get(unit_flow, (u, n2, d2, s, t_short), 0)
                 * duration(t_short)
                 * ratio(m; unit=u, node1=ng1, node2=ng2, stochastic_scenario=s, analysis_time=t0, t=t)
-                for (u, n2, d2, s, t_short) in unit_flow_indices(
-                    m; unit=u, node=ng2, direction=d2, stochastic_scenario=s_path, t=t_in_t(m; t_long=t)
-                );
+                for n2 in members(ng2), s in s_path, t_short in t_in_t(m; t_long=t);
                 init=0,
             )
             + sum(

--- a/src/constraints/constraint_unit_flow_capacity.jl
+++ b/src/constraints/constraint_unit_flow_capacity.jl
@@ -157,10 +157,8 @@ end
 function _term_unit_flow(m, u, ng, d, s_path, t)
     @fetch unit_flow = m.ext[:spineopt].variables
     sum(
-        unit_flow[u, n, d, s, t_over] * overlap_duration(t_over, t)
-        for (u, n, d, s, t_over) in unit_flow_indices(
-            m; unit=u, node=ng, direction=d, stochastic_scenario=s_path, t=t_overlaps_t(m; t=t)
-        )
+        get(unit_flow, (u, n, d, s, t_over), 0) * overlap_duration(t_over, t)
+        for n in members(ng), s in s_path, t_over in t_overlaps_t(m; t=t)
         if _is_regular_node(n, d);
         init=0,
     )


### PR DESCRIPTION
The idea is to use Base.get and Base.haskey to check for indices instead of double dipping into the indices functions.

I did it for some constraints but the same idea could be applied to a lot of constraints for a mild speed up.

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted according to SpineOpt's style
- [x] Unit tests pass
