### PR TITLE
Performance: don't collect time indices twice

### DIFF
--- a/src/data_structure/preprocess_data_structure.jl
+++ b/src/data_structure/preprocess_data_structure.jl
@@ -545,36 +545,17 @@ function generate_variable_indexing_support()
     node_with_min_capacity_margin_penalty = ObjectClass(
         :node_with_min_capacity_margin_slack_penalty, collect(indices(min_capacity_margin_penalty))
     )
-    unit__node__direction__temporal_block = RelationshipClass(
-        :unit__node__direction__temporal_block,
-        [:unit, :node, :direction, :temporal_block],
-        unique(
-            (u, n, d, tb)
-            for (u, n, d) in Iterators.flatten((unit__from_node(), unit__to_node()))
-            for tb in node__temporal_block(node=n)
-        ),
+    unit__node__direction = RelationshipClass(
+        :unit__node__direction, [:unit, :node, :direction], [unit__from_node(); unit__to_node()]
     )
-    connection__node__direction__temporal_block = RelationshipClass(
-        :connection__node__direction__temporal_block,
-        [:connection, :node, :direction, :temporal_block],
-        unique(
-            (conn, n, d, tb)
-            for (conn, n, d) in Iterators.flatten((connection__from_node(), connection__to_node()))
-            for tb in node__temporal_block(node=n)
-        ),
-    )
-    node_with_state__temporal_block = RelationshipClass(
-        :node_with_state__temporal_block,
-        [:node, :temporal_block],
-        unique((node=n, temporal_block=tb)
-        for n in node(has_state=true) for tb in node__temporal_block(node=n)),
+    connection__node__direction = RelationshipClass(
+        :connection__node__direction, [:connection, :node, :direction], [connection__from_node(); connection__to_node()]
     )
     @eval begin
         node_with_slack_penalty = $node_with_slack_penalty
         node_with_min_capacity_margin_penalty = $node_with_min_capacity_margin_penalty
-        unit__node__direction__temporal_block = $unit__node__direction__temporal_block
-        connection__node__direction__temporal_block = $connection__node__direction__temporal_block
-        node_with_state__temporal_block = $node_with_state__temporal_block
+        unit__node__direction = $unit__node__direction
+        connection__node__direction = $connection__node__direction
     end
 end
 

--- a/src/variables/variable_connection_flow.jl
+++ b/src/variables/variable_connection_flow.jl
@@ -40,11 +40,11 @@ function connection_flow_indices(
     node = members(node)
     (
         (connection=conn, node=n, direction=d, stochastic_scenario=s, t=t)
-        for (conn, n, d, tb) in connection__node__direction__temporal_block(
-            connection=connection, node=node, direction=direction, temporal_block=temporal_block, _compact=false
+        for (conn, n, d) in connection__node__direction(
+            connection=connection, node=node, direction=direction, _compact=false
         )
         for (n, s, t) in node_stochastic_time_indices(
-            m; node=n, stochastic_scenario=stochastic_scenario, temporal_block=tb, t=t
+            m; node=n, stochastic_scenario=stochastic_scenario, temporal_block=temporal_block, t=t
         )
     )
 end

--- a/src/variables/variable_connection_intact_flow.jl
+++ b/src/variables/variable_connection_intact_flow.jl
@@ -38,15 +38,14 @@ function connection_intact_flow_indices(
     temporal_block=temporal_block(representative_periods_mapping=nothing),
 )
     use_connection_intact_flow(model=m.ext[:spineopt].instance) || return ()
-    node = members(node)
-    (
-        (connection=conn, node=n, direction=d, stochastic_scenario=s, t=t)
-        for (conn, n, d, tb) in connection__node__direction__temporal_block(
-            connection=connection, node=node, direction=direction, temporal_block=temporal_block, _compact=false
-        )
-        for (n, s, t) in node_stochastic_time_indices(
-            m; node=n, stochastic_scenario=stochastic_scenario, temporal_block=tb, t=t
-        )
+    connection_flow_indices(
+        m;
+        connection=connection,
+        node=node,
+        direction=direction,
+        stochastic_scenario=stochastic_scenario,
+        t=t,
+        temporal_block=temporal_block,
     )
 end
 

--- a/src/variables/variable_node_state.jl
+++ b/src/variables/variable_node_state.jl
@@ -24,11 +24,11 @@ A set of tuples for indexing the `node_state` variable where filtering options c
 for `node`, `s`, and `t`.
 """
 function node_state_indices(m::Model; node=anything, stochastic_scenario=anything, t=anything, temporal_block=anything)
+    node = intersect(node, SpineOpt.node(has_state=true))
     (
         (node=n, stochastic_scenario=s, t=t)
-        for (n, tb) in node_with_state__temporal_block(node=node, temporal_block=temporal_block, _compact=false)
         for (n, s, t) in node_stochastic_time_indices(
-            m; node=n, stochastic_scenario=stochastic_scenario, temporal_block=tb, t=t
+            m; node=node, stochastic_scenario=stochastic_scenario, temporal_block=temporal_block, t=t
         )
     )
 end

--- a/src/variables/variable_unit_flow.jl
+++ b/src/variables/variable_unit_flow.jl
@@ -41,11 +41,9 @@ function unit_flow_indices(
     node = members(node)
     (
         (unit=u, node=n, direction=d, stochastic_scenario=s, t=t)
-        for (u, n, d, tb) in unit__node__direction__temporal_block(
-            unit=unit, node=node, direction=direction, temporal_block=temporal_block, _compact=false
-        )
+        for (u, n, d) in unit__node__direction(unit=unit, node=node, direction=direction, _compact=false)
         for (n, s, t) in node_stochastic_time_indices(
-            m; node=n, stochastic_scenario=stochastic_scenario, temporal_block=tb, t=t
+            m; node=n, stochastic_scenario=stochastic_scenario, temporal_block=temporal_block, t=t
         )
     )
 end

--- a/src/variables/variable_unit_flow_op.jl
+++ b/src/variables/variable_unit_flow_op.jl
@@ -44,12 +44,9 @@ function unit_flow_op_indices(
     (
         (unit=u, node=n, direction=d, i=i, stochastic_scenario=s, t=t)
         for (u, n, d) in indices(operating_points; unit=unit, node=node, direction=direction)
-        for (u, n, d, tb) in unit__node__direction__temporal_block(
-            unit=u, node=n, direction=d, temporal_block=temporal_block, _compact=false
-        )
         for i in intersect(i, 1:length(operating_points(unit=u, node=n, direction=d)))
         for (n, s, t) in node_stochastic_time_indices(
-            m; node=n, stochastic_scenario=stochastic_scenario, temporal_block=tb, t=t
+            m; node=n, stochastic_scenario=stochastic_scenario, temporal_block=temporal_block, t=t
         )
     )
 end


### PR DESCRIPTION
Some variable indices functions were collecting the temporal block twice so to say.

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted according to SpineOpt's style
- [x] Unit tests pass
