### PR TITLE
Introduce simple fix ratios

### DIFF
--- a/src/constraints/constraint_ratio_out_in_connection_flow.jl
+++ b/src/constraints/constraint_ratio_out_in_connection_flow.jl
@@ -121,7 +121,7 @@ function constraint_ratio_out_in_connection_flow_indices(m::Model, ratio_out_in)
     (
         (connection=conn, node1=ng_out, node2=ng_in, stochastic_path=path, t=t)
         for (conn, ng_out, ng_in) in indices(ratio_out_in)
-        if _fix_connection_flow_ratio(conn, ng_out, ng_in) === nothing
+        if _fix_ratio_out_in_connection_flow_simple(conn, ng_out, ng_in) === nothing
         for (t, path_out) in t_lowest_resolution_path(
             m, connection_flow_indices(m; connection=conn, node=ng_out, direction=direction(:to_node))
         )

--- a/src/constraints/constraint_ratio_out_in_connection_flow.jl
+++ b/src/constraints/constraint_ratio_out_in_connection_flow.jl
@@ -121,7 +121,7 @@ function constraint_ratio_out_in_connection_flow_indices(m::Model, ratio_out_in)
     (
         (connection=conn, node1=ng_out, node2=ng_in, stochastic_path=path, t=t)
         for (conn, ng_out, ng_in) in indices(ratio_out_in)
-        if !_is_delayless_lossless(conn, ng_out, ng_in)
+        if _fix_connection_flow_ratio(conn, ng_out, ng_in) === nothing
         for (t, path_out) in t_lowest_resolution_path(
             m, connection_flow_indices(m; connection=conn, node=ng_out, direction=direction(:to_node))
         )

--- a/src/constraints/constraint_ratio_out_in_connection_flow.jl
+++ b/src/constraints/constraint_ratio_out_in_connection_flow.jl
@@ -121,6 +121,7 @@ function constraint_ratio_out_in_connection_flow_indices(m::Model, ratio_out_in)
     (
         (connection=conn, node1=ng_out, node2=ng_in, stochastic_path=path, t=t)
         for (conn, ng_out, ng_in) in indices(ratio_out_in)
+        if !_is_delayless_lossless(conn, ng_out, ng_in)
         for (t, path_out) in t_lowest_resolution_path(
             m, connection_flow_indices(m; connection=conn, node=ng_out, direction=direction(:to_node))
         )

--- a/src/constraints/constraint_ratio_unit_flow.jl
+++ b/src/constraints/constraint_ratio_unit_flow.jl
@@ -239,6 +239,7 @@ function constraint_ratio_unit_flow_indices(m::Model, ratio, d1, d2)
     (
         (unit=u, node1=n1, node2=n2, stochastic_path=path, t=t)
         for (u, n1, n2) in indices(ratio)
+        if _fix_unit_flow_ratio(u, n1, n2, ratio) === nothing
         for (t, path) in t_lowest_resolution_path(
             m,
             unit_flow_indices(m; unit=u, node=[n1, n2]),

--- a/src/constraints/constraint_ratio_unit_flow.jl
+++ b/src/constraints/constraint_ratio_unit_flow.jl
@@ -239,7 +239,7 @@ function constraint_ratio_unit_flow_indices(m::Model, ratio, d1, d2)
     (
         (unit=u, node1=n1, node2=n2, stochastic_path=path, t=t)
         for (u, n1, n2) in indices(ratio)
-        if _fix_unit_flow_ratio(u, n1, n2, ratio) === nothing
+        if _fix_ratio_out_in_unit_flow_simple(u, n1, n2, ratio) === nothing
         for (t, path) in t_lowest_resolution_path(
             m,
             unit_flow_indices(m; unit=u, node=[n1, n2]),

--- a/src/run_spineopt_standard.jl
+++ b/src/run_spineopt_standard.jl
@@ -554,6 +554,7 @@ end
 The value of a JuMP variable, rounded if necessary.
 """
 _variable_value(v::VariableRef) = (is_integer(v) || is_binary(v)) ? round(Int, JuMP.value(v)) : JuMP.value(v)
+_variable_value(e::AffExpr) = value(e)
 _variable_value(x::Call) = realize(x)
 
 """

--- a/src/run_spineopt_standard.jl
+++ b/src/run_spineopt_standard.jl
@@ -458,10 +458,10 @@ function _load_variable_values!(m::Model, values)
 end
 
 function _load_variable_value!(m::Model, name::Symbol, indices::Function, values)
-    var_history = m.ext[:spineopt].variables_definition[name][:required_history]
+    history_time_slices = m.ext[:spineopt].variables_definition[name][:history_time_slices]
     m.ext[:spineopt].values[name] = Dict(
         ind => values[string(name)][string(ind)]
-        for ind in indices(m; t=vcat(var_history, time_slice(m)), temporal_block=anything)
+        for ind in indices(m; t=vcat(history_time_slices, time_slice(m)), temporal_block=anything)
     )
 end
 
@@ -1061,10 +1061,10 @@ end
 function _update_variable_names!(m, names=keys(m.ext[:spineopt].variables))
     for name in names   
         var = m.ext[:spineopt].variables[name]
-        var_history = m.ext[:spineopt].variables_definition[name][:required_history]
+        history_time_slices = m.ext[:spineopt].variables_definition[name][:history_time_slices]
         # NOTE: only update names for the representative variables
         # This is achieved by using the indices function from the variable definition
-        for ind in m.ext[:spineopt].variables_definition[name][:indices](m; t=[time_slice(m); var_history])
+        for ind in m.ext[:spineopt].variables_definition[name][:indices](m; t=[time_slice(m); history_time_slices])
             _set_name(var[ind], _base_name(name, ind))
         end
     end
@@ -1086,7 +1086,7 @@ function _sanitize_constraint_name(constraint_name)
 end
 
 _set_name(x::Union{VariableRef,ConstraintRef}, name) = set_name(x, name)
-_set_name(::Union{Call,Nothing}, name) = nothing
+_set_name(::Union{Call,AffExpr,Nothing}, name) = nothing
 
 function _fix_history!(m::Model)
     for (name, definition) in m.ext[:spineopt].variables_definition
@@ -1157,9 +1157,9 @@ end
 function unfix_history!(m::Model)
     for (name, definition) in m.ext[:spineopt].variables_definition
         var = m.ext[:spineopt].variables[name]
-        var_history = m.ext[:spineopt].variables_definition[name][:required_history]
+        history_time_slices = m.ext[:spineopt].variables_definition[name][:history_time_slices]
         indices = definition[:indices]
-        for history_ind in indices(m; t=var_history)
+        for history_ind in indices(m; t=history_time_slices)
             _unfix(var[history_ind])
         end
     end

--- a/src/util/misc.jl
+++ b/src/util/misc.jl
@@ -281,6 +281,9 @@ function _version_and_git_hash(pkg)
 end
 
 # Base
+_ObjectArrayLike = Union{ObjectLike,Array{T,1} where T<:ObjectLike}
+_RelationshipArrayLike{K} = NamedTuple{K,V} where {K,V<:Tuple{Vararg{_ObjectArrayLike}}}
+
 function Base.get(d::Dict{K,V}, key::Tuple{Vararg{ObjectLike}}, default) where {J,K<:RelationshipLike{J},V}
     Base.get(d, NamedTuple{J}(key), default)
 end
@@ -288,15 +291,11 @@ function Base.get(f::Function, d::Dict{K,V}, key::Tuple{Vararg{ObjectLike}}) whe
     Base.get(f, d, NamedTuple{J}(key))
 end
 
-Base.getindex(d::Dict{K,V}, key::ObjectLike...) where {J,K<:RelationshipLike{J},V} = getindex(d, NamedTuple{J}(key))
-
 function Base.haskey(d::Dict{K,V}, key::Tuple{Vararg{ObjectLike}}) where {J,K<:RelationshipLike{J},V}
     Base.haskey(d, NamedTuple{J}(key))
 end
 
-_ObjectArrayLike = Union{ObjectLike,Array{T,1} where T<:ObjectLike}
-_RelationshipArrayLike{K} = NamedTuple{K,V} where {K,V<:Tuple{Vararg{_ObjectArrayLike}}}
-
+Base.getindex(d::Dict{K,V}, key::ObjectLike...) where {J,K<:RelationshipLike{J},V} = getindex(d, NamedTuple{J}(key))
 function Base.getindex(d::Dict{K,V}, key::_ObjectArrayLike...) where {J,K<:_RelationshipArrayLike{J},V}
     Base.getindex(d, NamedTuple{J}(key))
 end

--- a/src/util/misc.jl
+++ b/src/util/misc.jl
@@ -280,6 +280,32 @@ function _version_and_git_hash(pkg)
     version, git_hash
 end
 
+"""
+    _similar(node1, node2)
+
+A Boolean indicating whether or not two nodes are 'similar', in the sense they are single nodes
+(i.e. not groups) with the same temporal and stochastic structure.
+"""
+function _similar(node1, node2)
+    (
+        members(node1) == [node1]
+        && members(node2) == [node2]
+        && node__temporal_block(node=node1) == node__temporal_block(node=node2)
+        && node__stochastic_structure(node=node1) == node__stochastic_structure(node=node2)
+    )
+end
+
+"""
+    _get_max_duration(m::Model, lookback_params::Vector{Parameter})
+
+The maximum duration from a list of parameters.
+"""
+function _get_max_duration(m::Model, lookback_params::Vector{Parameter})
+    max_vals = (maximum_parameter_value(p) for p in lookback_params)
+    dur_unit = _model_duration_unit(m.ext[:spineopt].instance)
+    reduce(max, (val for val in max_vals if val !== nothing); init=dur_unit(1))
+end
+
 # Base
 _ObjectArrayLike = Union{ObjectLike,Array{T,1} where T<:ObjectLike}
 _RelationshipArrayLike{K} = NamedTuple{K,V} where {K,V<:Tuple{Vararg{_ObjectArrayLike}}}

--- a/src/variables/variable_binary_gas_connection_flow.jl
+++ b/src/variables/variable_binary_gas_connection_flow.jl
@@ -65,6 +65,6 @@ function add_variable_binary_gas_connection_flow!(m::Model)
         binary_gas_connection_flow_indices;
         bin=set_bin,
         fix_value=fix_binary_gas_connection_flow,
-        initial_value=initial_binary_gas_connection_flow
+        initial_value=initial_binary_gas_connection_flow,
     )
 end

--- a/test/run_examples.jl
+++ b/test/run_examples.jl
@@ -14,7 +14,7 @@ objective_function_reference_values = Dict(
         SpineInterface.close_connection(db_url)
         SpineInterface.open_connection(db_url)
         import_data(db_url, input_data, "No comment")
-        m = run_spineopt(db_url, nothing; log_level=0)        
+        m = run_spineopt(db_url, nothing; log_level=0)
         @test termination_status(m) == MOI.OPTIMAL
         obj_fn_val = get(objective_function_reference_values, basename(path), nothing)
         if obj_fn_val !== nothing


### PR DESCRIPTION
In the most simple case where we have `unit_flow[from_node] == ratio * unit_flow[to_node]`, we actually can use just one flow variable and replace the constraint by an expression. This should save some time.

So in the example above we can have `unit_flow[to_node]` pointing to a variable, and `unit_flow[from_node]` pointing to the expression `ratio * that_variable`.


## Checklist before merging
- [x] Documentation is up-to-date
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted according to SpineOpt's style
- [x] Unit tests pass
