### PR TITLE
Performance: Use upper bound for connection flow instead of the connection capacity constraint when possible

### DIFF
--- a/src/constraints/constraint_connection_flow_capacity.jl
+++ b/src/constraints/constraint_connection_flow_capacity.jl
@@ -153,6 +153,7 @@ function constraint_connection_flow_capacity_indices(m::Model)
     (
         (connection=conn, node=ng, direction=d, stochastic_path=path, t=t)
         for (conn, ng, d) in _connection_node_direction(m)
+        if members(ng) != [ng]
         for (t, path) in t_lowest_resolution_path(
             m,
             connection_flow_indices(m; connection=conn, node=ng, direction=d),

--- a/src/constraints/constraint_connection_flow_capacity.jl
+++ b/src/constraints/constraint_connection_flow_capacity.jl
@@ -120,7 +120,7 @@ function _term_connection_flow_capacity(m, conn, ng, d, s_path, t)
 end
 
 function _term_total_number_of_connections(m, conn, ng, d, s_path, t)
-    @fetch connections_invested_available = m.ext[:spineopt].variables
+    @fetch connection_flow, connections_invested_available = m.ext[:spineopt].variables
     t0 = _analysis_time(m)
     (
         + sum(
@@ -139,9 +139,8 @@ function _term_total_number_of_connections(m, conn, ng, d, s_path, t)
                     _default=_default_number_of_connections(conn),
                 )
             )
-            for (conn, _n, _d, s, t) in connection_flow_indices(
-                m; connection=conn, node=ng, direction=d, stochastic_scenario=s_path, t=t_in_t(m; t_long=t)
-            );
+            for s in s_path, t in t_in_t(m; t_long=t)
+            if any(haskey(connection_flow, (conn, n, d, s, t)) for n in members(ng));
             init=0,
         )
     )
@@ -153,7 +152,7 @@ function constraint_connection_flow_capacity_indices(m::Model)
     (
         (connection=conn, node=ng, direction=d, stochastic_path=path, t=t)
         for (conn, ng, d) in _connection_node_direction(m)
-        if members(ng) != [ng]
+        if members(ng) != [ng] || is_candidate(connection=conn)
         for (t, path) in t_lowest_resolution_path(
             m,
             connection_flow_indices(m; connection=conn, node=ng, direction=d),

--- a/src/variables/variable_connection_flow.jl
+++ b/src/variables/variable_connection_flow.jl
@@ -49,6 +49,32 @@ function connection_flow_indices(
     )
 end
 
+function connection_flow_ub_as_number(; connection, node, direction, kwargs...)
+    any(
+        connection_flow_capacity(
+            ; connection=connection, node=ng, direction=direction, kwargs..., _strict=false
+        ) !== nothing
+        for ng in groups(node)
+    ) && return nothing
+    connection_flow_capacity(; connection=connection, node=node, direction=direction, kwargs..., _default=NaN) * (
+        + number_of_connections(; connection=connection, kwargs..., _default=1)
+        + candidate_connections(; connection=connection, kwargs..., _default=0)
+    )
+end
+
+function connection_flow_ub_as_call(; connection, node, direction, kwargs...)
+    any(
+        connection_flow_capacity(
+            ; connection=connection, node=ng, direction=direction, kwargs..., _strict=false
+        ) !== nothing
+        for ng in groups(node)
+    ) && return nothing
+    connection_flow_capacity[(connection=connection, node=node, direction=direction, kwargs..., _default=NaN)] * (
+        + number_of_connections[(connection=connection, kwargs..., _default=1)]
+        + Call(something, [candidate_connections[(connection=connection, kwargs..., _default=0)], 0])
+    )
+end
+
 function _fix_ratio_out_in_connection_flow_simple(conn, n_to, n_from)
     (
         _similar(n_to, n_from)
@@ -79,6 +105,7 @@ function add_variable_connection_flow!(m::Model)
         :connection_flow,
         connection_flow_indices;
         lb=constant(0),
+        ub=FlexParameter(connection_flow_ub_as_number, connection_flow_ub_as_call),
         fix_value=fix_connection_flow,
         initial_value=initial_connection_flow,
         non_anticipativity_time=connection_flow_non_anticipativity_time,

--- a/src/variables/variable_storages_invested_available.jl
+++ b/src/variables/variable_storages_invested_available.jl
@@ -30,7 +30,7 @@ function storages_invested_available_indices(
     t=anything,
     temporal_block=anything,
 )
-    node=members(node)
+    node = members(node)
     (
         (node=n, stochastic_scenario=s, t=t)
         for (n, tb) in node__investment_temporal_block(

--- a/test/constraints/constraint_connection.jl
+++ b/test/constraints/constraint_connection.jl
@@ -91,14 +91,23 @@ function test_constraint_connection_flow_capacity()
     @testset "constraint_connection_flow_capacity_basic" begin
         url_in = _test_constraint_connection_setup()
         connection_capacity = 200
+        objects = [["node", "node_group_a"], ["node", "node_a_bis"]]
+        object_groups = [("node", "node_group_a", "node_a"), ("node", "node_group_a", "node_a_bis")]
         relationships = [
-            ["connection__to_node", ["connection_ab", "node_a"]],
+            ["connection__from_node", ["connection_ab", "node_group_a"]],
+            ["connection__from_node", ["connection_ab", "node_a_bis"]],
+            ["node__temporal_block", ["node_group_a", "hourly"]],
+            ["node__temporal_block", ["node_a_bis", "hourly"]],
+            ["node__stochastic_structure", ["node_group_a", "stochastic"]],
+            ["node__stochastic_structure", ["node_a_bis", "stochastic"]],
         ]
         relationship_parameter_values = [
-            ["connection__from_node", ["connection_ab", "node_a"], "connection_capacity", connection_capacity],
+            ["connection__from_node", ["connection_ab", "node_group_a"], "connection_capacity", connection_capacity],
         ]
         SpineInterface.import_data(
             url_in;
+            objects=objects,
+            object_groups=object_groups,
             relationships=relationships,
             relationship_parameter_values=relationship_parameter_values,
         )
@@ -109,10 +118,12 @@ function test_constraint_connection_flow_capacity()
         scenarios = (stochastic_scenario(:parent), stochastic_scenario(:child))
         time_slices = time_slice(m; temporal_block=temporal_block(:hourly))
         @testset for (s, t) in zip(scenarios, time_slices)
-            key_from = (connection(:connection_ab), node(:node_a), direction(:from_node), s, t)
-            var_conn_flow = var_connection_flow[key_from...]
-            expected_con = @build_constraint(var_conn_flow <= connection_capacity)
-            con_key = (connection(:connection_ab), node(:node_a), direction(:from_node), [s], t)
+            key_a = (connection(:connection_ab), node(:node_a), direction(:from_node), s, t)
+            key_a_bis = (connection(:connection_ab), node(:node_a_bis), direction(:from_node), s, t)
+            var_conn_flow_a = var_connection_flow[key_a...]
+            var_conn_flow_a_bis = var_connection_flow[key_a_bis...]
+            expected_con = @build_constraint(var_conn_flow_a + var_conn_flow_a_bis <= connection_capacity)
+            con_key = (connection(:connection_ab), node(:node_group_a), direction(:from_node), [s], t)
             observed_con = constraint_object(constraint[con_key...])
             @test _is_constraint_equal(observed_con, expected_con)
         end
@@ -164,20 +175,32 @@ end
 
 function test_constraint_connection_flow_capacity_bidirectional()
     @testset "constraint_connection_flow_capacity_bidirectional_basic" begin
-    # When both directions are bounded by positive capacities
+        # When both directions are bounded by positive capacities
         url_in = _test_constraint_connection_setup()
-        connection_capacity_from_a = 100
-        connection_capacity_to_a = 200
+        conn_cap_from_a = 100
+        conn_cap_to_a = 200
+        objects = [["node", "node_group_a"], ["node", "node_a_bis"]]
+        object_groups = [("node", "node_group_a", "node_a"), ("node", "node_group_a", "node_a_bis")]
         relationships = [
+            ["connection__from_node", ["connection_ab", "node_group_a"]],
+            ["connection__from_node", ["connection_ab", "node_a_bis"]],
+            ["node__temporal_block", ["node_group_a", "hourly"]],
+            ["node__temporal_block", ["node_a_bis", "hourly"]],
+            ["node__stochastic_structure", ["node_group_a", "stochastic"]],
+            ["node__stochastic_structure", ["node_a_bis", "stochastic"]],
+            ["connection__to_node", ["connection_ab", "node_group_a"]],
             ["connection__to_node", ["connection_ab", "node_a"]],
+            ["connection__to_node", ["connection_ab", "node_a_bis"]],
         ]
         object_parameter_values = [["model", "instance", "use_tight_compact_formulations", true]]
         relationship_parameter_values = [
-            ["connection__from_node", ["connection_ab", "node_a"], "connection_capacity", connection_capacity_from_a],
-            ["connection__to_node", ["connection_ab", "node_a"], "connection_capacity", connection_capacity_to_a],
+            ["connection__from_node", ["connection_ab", "node_group_a"], "connection_capacity", conn_cap_from_a],
+            ["connection__to_node", ["connection_ab", "node_group_a"], "connection_capacity", conn_cap_to_a],
         ]
         SpineInterface.import_data(
             url_in;
+            objects=objects,
+            object_groups=object_groups,
             relationships=relationships,
             object_parameter_values=object_parameter_values,
             relationship_parameter_values=relationship_parameter_values,
@@ -189,23 +212,25 @@ function test_constraint_connection_flow_capacity_bidirectional()
         scenarios = (stochastic_scenario(:parent), stochastic_scenario(:child))
         time_slices = time_slice(m; temporal_block=temporal_block(:hourly))
         @testset for (s, t) in zip(scenarios, time_slices)
-            key_from = (connection(:connection_ab), node(:node_a), direction(:from_node), s, t)
-            key_to = (connection(:connection_ab), node(:node_a), direction(:to_node), s, t)
+            key_from_a = (connection(:connection_ab), node(:node_a), direction(:from_node), s, t)
+            key_from_a_bis = (connection(:connection_ab), node(:node_a_bis), direction(:from_node), s, t)
+            key_to_a = (connection(:connection_ab), node(:node_a), direction(:to_node), s, t)
+            key_to_a_bis = (connection(:connection_ab), node(:node_a_bis), direction(:to_node), s, t)
             lhs = (
-                + var_connection_flow[key_from...] / connection_capacity_from_a
-                + var_connection_flow[key_to...] / connection_capacity_to_a
+                + sum(var_connection_flow[k...] for k in (key_from_a, key_from_a_bis)) / conn_cap_from_a
+                + sum(var_connection_flow[k...] for k in (key_to_a, key_to_a_bis)) / conn_cap_to_a
             )
             rhs = 1
             expected_con = @build_constraint(lhs <= rhs)
-            con_key = (connection(:connection_ab), node(:node_a), direction(), [s], t)
+            con_key = (connection(:connection_ab), node(:node_group_a), direction(), [s], t)
             observed_con = constraint_object(constraint[con_key...])
             @test _is_constraint_equal(observed_con, expected_con)
         end
     end
     @testset "constraint_connection_flow_capacity_bidirectional_with_investments" begin
         url_in = _test_constraint_connection_setup()
-        connection_capacity_from_a = 100
-        connection_capacity_to_a = 200
+        conn_cap_from_a = 100
+        conn_cap_to_a = 200
         objects = [["temporal_block", "investments_daily"]]
         relationships = [
             ["connection__to_node", ["connection_ab", "node_a"]],
@@ -219,8 +244,8 @@ function test_constraint_connection_flow_capacity_bidirectional()
             ["model", "instance", "use_tight_compact_formulations", true],
         ]
         relationship_parameter_values = [
-            ["connection__from_node", ["connection_ab", "node_a"], "connection_capacity", connection_capacity_from_a],
-            ["connection__to_node", ["connection_ab", "node_a"], "connection_capacity", connection_capacity_to_a],
+            ["connection__from_node", ["connection_ab", "node_a"], "connection_capacity", conn_cap_from_a],
+            ["connection__to_node", ["connection_ab", "node_a"], "connection_capacity", conn_cap_to_a],
         ]
         SpineInterface.import_data(
             url_in;
@@ -244,8 +269,8 @@ function test_constraint_connection_flow_capacity_bidirectional()
             invest_key = (connection(:connection_ab), stochastic_scenario(:parent), daily_t)
             var_conn_invest_avail = var_connections_invested_available[invest_key...]
             lhs = (
-                + var_connection_flow[key_from...] / connection_capacity_from_a
-                + var_connection_flow[key_to...] / connection_capacity_to_a
+                + var_connection_flow[key_from...] / conn_cap_from_a
+                + var_connection_flow[key_to...] / conn_cap_to_a
             )
             rhs = var_conn_invest_avail
             expected_con = @build_constraint(lhs <= rhs)
@@ -512,51 +537,6 @@ function test_constraint_node_voltage_angle()
             )
             con = constraint[con_key...]
             observed_con = constraint_object(con)
-            @test _is_constraint_equal(observed_con, expected_con)
-        end
-    end
-end
-
-function test_constraint_connection_flow_capacity_investments()
-    @testset "constraint_connection_flow_capacity_investments" begin
-        url_in = _test_constraint_connection_setup()
-        connection_capacity = 200
-        object_parameter_values = [
-            ["connection", "connection_ab", "candidate_connections", 1],
-            [
-                "connection",
-                "connection_ab",
-                "connection_investment_lifetime",
-                Dict("type" => "duration", "data" => "60m"),
-            ],
-        ]
-        relationships = [
-            ["connection__investment_temporal_block", ["connection_ab", "hourly"]],
-            ["connection__investment_stochastic_structure", ["connection_ab", "stochastic"]],
-        ]
-        relationship_parameter_values =
-            [["connection__from_node", ["connection_ab", "node_a"], "connection_capacity", connection_capacity]]
-        SpineInterface.import_data(
-            url_in;
-            object_parameter_values=object_parameter_values,
-            relationships=relationships,
-            relationship_parameter_values=relationship_parameter_values,
-        )
-        m = run_spineopt(url_in; log_level=0, optimize=false)
-        var_connection_flow = m.ext[:spineopt].variables[:connection_flow]
-        var_connections_invested_available = m.ext[:spineopt].variables[:connections_invested_available]
-        constraint = m.ext[:spineopt].constraints[:connection_flow_capacity]
-        @test length(constraint) == 2
-        scenarios = (stochastic_scenario(:parent), stochastic_scenario(:child))
-        time_slices = time_slice(m; temporal_block=temporal_block(:hourly))
-        @testset for (s, t) in zip(scenarios, time_slices)
-            key = (connection(:connection_ab), node(:node_a), direction(:from_node), s, t)
-            invest_key = (connection(:connection_ab), s, t)
-            var_conn_flow = var_connection_flow[key...]
-            var_conn_inv_a = var_connections_invested_available[invest_key...]
-            expected_con = @build_constraint(var_conn_flow <= connection_capacity * var_conn_inv_a)
-            con_key = (connection(:connection_ab), node(:node_a), direction(:from_node), [s], t)
-            observed_con = constraint_object(constraint[con_key...])
             @test _is_constraint_equal(observed_con, expected_con)
         end
     end
@@ -1753,7 +1733,6 @@ end
     test_constraint_fix_node_pressure_point()
     test_constraint_connection_unitary_gas_flow()
     test_constraint_node_voltage_angle()
-    test_constraint_connection_flow_capacity_investments()
     test_constraint_connection_intact_flow_ptdf()
     test_constraint_connection_flow_lodf()
     test_contraints_ptdf_lodf_duration()


### PR DESCRIPTION

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted according to SpineOpt's style
- [x] Unit tests pass
