### PR TITLE
Get rid of FlexParameter

### DIFF
--- a/src/data_structure/temporal_structure.jl
+++ b/src/data_structure/temporal_structure.jl
@@ -829,6 +829,6 @@ function _t_extreme_resolution_sets!(m, t_dict, kw)
     t_dict
 end
 
-function (x::Union{Parameter,FlexParameter})(m::Model; kwargs...)
+function (x::Parameter)(m::Model; kwargs...)
     m.ext[:spineopt].temporal_structure[:call_update](x; kwargs...)
 end

--- a/src/util/misc.jl
+++ b/src/util/misc.jl
@@ -70,18 +70,11 @@ macro fetch(expr)
     esc(Expr(:(=), keys, values))
 end
 
-struct FlexParameter
-    as_number
-    as_call
-end
-
 as_number(p::Parameter; kwargs...) = p(; kwargs...)
-as_number(x::FlexParameter; kwargs...) = x.as_number(; kwargs...)
 
 as_call(p::Parameter; kwargs...) = p[kwargs]
-as_call(x::FlexParameter; kwargs...) = x.as_call(; kwargs...)
 
-constant(x::Number) = FlexParameter((; kwargs...) -> x, (; kwargs...) -> Call(x))
+constant(x::Number) = (m; kwargs...) -> x
 
 """
     build_sense_constraint(lhs, sense::Symbol, rhs)

--- a/src/variables/variable_common.jl
+++ b/src/variables/variable_common.jl
@@ -38,8 +38,8 @@ function add_variable!(
     indices::Function;
     bin::Union{Function,Nothing}=nothing,
     int::Union{Function,Nothing}=nothing,
-    lb::Union{FlexParameter,Parameter,Nothing}=nothing,
-    ub::Union{FlexParameter,Parameter,Nothing}=nothing,
+    lb::Union{Parameter,Function,Nothing}=nothing,
+    ub::Union{Parameter,Function,Nothing}=nothing,
     initial_value::Union{Parameter,Nothing}=nothing,
     fix_value::Union{Parameter,Nothing}=nothing,
     internal_fix_value::Union{Parameter,Nothing}=nothing,

--- a/src/variables/variable_connection_flow.jl
+++ b/src/variables/variable_connection_flow.jl
@@ -49,29 +49,16 @@ function connection_flow_indices(
     )
 end
 
-function connection_flow_ub_as_number(; connection, node, direction, kwargs...)
+function connection_flow_ub(m; connection, node, direction, kwargs...)
     any(
         connection_flow_capacity(
             ; connection=connection, node=ng, direction=direction, kwargs..., _strict=false
         ) !== nothing
         for ng in groups(node)
     ) && return nothing
-    connection_flow_capacity(; connection=connection, node=node, direction=direction, kwargs..., _default=NaN) * (
-        + number_of_connections(; connection=connection, kwargs..., _default=1)
-        + candidate_connections(; connection=connection, kwargs..., _default=0)
-    )
-end
-
-function connection_flow_ub_as_call(; connection, node, direction, kwargs...)
-    any(
-        connection_flow_capacity(
-            ; connection=connection, node=ng, direction=direction, kwargs..., _strict=false
-        ) !== nothing
-        for ng in groups(node)
-    ) && return nothing
-    connection_flow_capacity[(connection=connection, node=node, direction=direction, kwargs..., _default=NaN)] * (
-        + number_of_connections[(connection=connection, kwargs..., _default=1)]
-        + Call(something, [candidate_connections[(connection=connection, kwargs..., _default=0)], 0])
+    connection_flow_capacity(m; connection=connection, node=node, direction=direction, kwargs..., _default=NaN) * (
+        + number_of_connections(m; connection=connection, kwargs..., _default=1)
+        + candidate_connections(m; connection=connection, kwargs..., _default=0)
     )
 end
 
@@ -105,7 +92,7 @@ function add_variable_connection_flow!(m::Model)
         :connection_flow,
         connection_flow_indices;
         lb=constant(0),
-        ub=FlexParameter(connection_flow_ub_as_number, connection_flow_ub_as_call),
+        ub=connection_flow_ub,
         fix_value=fix_connection_flow,
         initial_value=initial_connection_flow,
         non_anticipativity_time=connection_flow_non_anticipativity_time,

--- a/src/variables/variable_node_state.jl
+++ b/src/variables/variable_node_state.jl
@@ -30,17 +30,10 @@ function node_state_indices(m::Model; node=anything, stochastic_scenario=anythin
     )
 end
 
-function node_state_ub_as_number(; node, kwargs...)
-    node_state_cap(; node=node, kwargs..., _default=NaN) * (
-        + number_of_storages(; node=node, kwargs..., _default=_default_nb_of_storages(node))
-        + candidate_storages(; node=node, kwargs..., _default=0)
-    )
-end
-
-function node_state_ub_as_call(; node, kwargs...)
-    node_state_cap[(node=node, kwargs..., _default=NaN)] * (
-        + number_of_storages[(node=node, kwargs..., _default=_default_nb_of_storages(node))]
-        + Call(something, [candidate_storages[(node=node, kwargs..., _default=0)], 0])
+function node_state_ub(m; node, kwargs...)
+    node_state_cap(m; node=node, kwargs..., _default=NaN) * (
+        + number_of_storages(m; node=node, kwargs..., _default=_default_nb_of_storages(node))
+        + candidate_storages(m; node=node, kwargs..., _default=0)
     )
 end
 
@@ -57,7 +50,7 @@ function add_variable_node_state!(m::Model)
         :node_state,
         node_state_indices;
         lb=node_state_min,
-        ub=FlexParameter(node_state_ub_as_number, node_state_ub_as_call),
+        ub=node_state_ub,
         fix_value=fix_node_state,
         initial_value=initial_node_state,
     )

--- a/src/variables/variable_unit_flow.jl
+++ b/src/variables/variable_unit_flow.jl
@@ -48,25 +48,14 @@ function unit_flow_indices(
     )
 end
 
-function unit_flow_ub_as_number(; unit, node, direction, kwargs...)
+function unit_flow_ub(m; unit, node, direction, kwargs...)
     any(
         unit_flow_capacity(; unit=unit, node=ng, direction=direction, kwargs..., _strict=false) !== nothing
         for ng in groups(node)
     ) && return nothing
-    unit_flow_capacity(; unit=unit, node=node, direction=direction, kwargs..., _default=NaN) * (
-        + number_of_units(; unit=unit, kwargs..., _default=1)
-        + candidate_units(; unit=unit, kwargs..., _default=0)
-    )
-end
-
-function unit_flow_ub_as_call(; unit, node, direction, kwargs...)
-    any(
-        unit_flow_capacity(; unit=unit, node=ng, direction=direction, kwargs..., _strict=false) !== nothing
-        for ng in groups(node)
-    ) && return nothing
-    unit_flow_capacity[(unit=unit, node=node, direction=direction, kwargs..., _default=NaN)] * (
-        + number_of_units[(unit=unit, kwargs..., _default=1)]
-        + Call(something, [candidate_units[(unit=unit, kwargs..., _default=0)], 0])
+    unit_flow_capacity(m; unit=unit, node=node, direction=direction, kwargs..., _default=NaN) * (
+        + number_of_units(m; unit=unit, kwargs..., _default=1)
+        + candidate_units(m; unit=unit, kwargs..., _default=0)
     )
 end
 
@@ -108,7 +97,7 @@ function add_variable_unit_flow!(m::Model)
         :unit_flow,
         unit_flow_indices;
         lb=min_unit_flow,
-        ub=FlexParameter(unit_flow_ub_as_number, unit_flow_ub_as_call),
+        ub=unit_flow_ub,
         fix_value=fix_unit_flow,
         initial_value=initial_unit_flow,
         non_anticipativity_time=unit_flow_non_anticipativity_time,


### PR DESCRIPTION
As per title, FlexParameter is not needed and introduces a round-about. This PR eliminates it.

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted according to SpineOpt's style
- [x] Unit tests pass
