### PR TITLE
Pass the analysis time more seamlessly to parameter calls

### DIFF
--- a/src/constraints/constraint_candidate_connection_flow_lb.jl
+++ b/src/constraints/constraint_candidate_connection_flow_lb.jl
@@ -46,7 +46,6 @@ end
 
 function _build_constraint_candidate_connection_flow_lb(m::Model, conn, n, d, s_path, t)
     @fetch connection_flow, connection_intact_flow, connections_invested_available = m.ext[:spineopt].variables
-    t0 = _analysis_time(m)
     @build_constraint(
         + sum(
             connection_flow[conn, n, d, s, t] * duration(t)
@@ -74,9 +73,7 @@ function _build_constraint_candidate_connection_flow_lb(m::Model, conn, n, d, s_
             )
         )
         * sum(
-            connection_capacity(
-                m; connection=conn, node=n, direction=d, stochastic_scenario=s, analysis_time=t0, t=t, _default=1e6
-            )
+            connection_capacity(m; connection=conn, node=n, direction=d, stochastic_scenario=s, t=t, _default=1e6)
             * duration(t)
             for (conn, n, d, s, t) in connection_intact_flow_indices(
                 m; connection=conn, direction=d, node=n, stochastic_scenario=s_path, t=t_in_t(m; t_long=t)

--- a/src/constraints/constraint_common.jl
+++ b/src/constraints/constraint_common.jl
@@ -71,32 +71,29 @@ past_units_on_indices(args...) = past_unit_indices(units_on_indices, args...)
 past_units_out_of_service_indices(args...) = past_unit_indices(units_out_of_service_indices, args...)
 
 function past_unit_indices(indices, m, u, s_path, t, min_time)
-    t0 = _analysis_time(m)
     indices(
         m;
         unit=u,
         stochastic_scenario=s_path,
-        t=to_time_slice(
-            m; t=TimeSlice(end_(t) - min_time(unit=u, analysis_time=t0, stochastic_scenario=s_path, t=t), end_(t))
-        ),
+        t=to_time_slice(m; t=TimeSlice(end_(t) - min_time(unit=u, stochastic_scenario=s_path, t=t), end_(t))),
         temporal_block=anything
     )    
 end
 
-function _minimum_operating_point(m, u, ng, d, s, t0, t)
-    minimum_operating_point(m; unit=u, node=ng, direction=d, stochastic_scenario=s, analysis_time=t0, t=t, _default=0)
+function _minimum_operating_point(m, u, ng, d, s, t)
+    minimum_operating_point(m; unit=u, node=ng, direction=d, stochastic_scenario=s, t=t, _default=0)
 end
 
-function _unit_flow_capacity(m, u, ng, d, s, t0, t)
-    unit_flow_capacity(m; unit=u, node=ng, direction=d, stochastic_scenario=s, analysis_time=t0, t=t)
+function _unit_flow_capacity(m, u, ng, d, s, t)
+    unit_flow_capacity(m; unit=u, node=ng, direction=d, stochastic_scenario=s, t=t)
 end
 
-function _start_up_limit(m, u, ng, d, s, t0, t)
-    start_up_limit(m; unit=u, node=ng, direction=d, stochastic_scenario=s, analysis_time=t0, t=t, _default=1)
+function _start_up_limit(m, u, ng, d, s, t)
+    start_up_limit(m; unit=u, node=ng, direction=d, stochastic_scenario=s, t=t, _default=1)
 end
 
-function _shut_down_limit(m, u, ng, d, s, t0, t)
-    shut_down_limit(m; unit=u, node=ng, direction=d, stochastic_scenario=s, analysis_time=t0, t=t, _default=1)
+function _shut_down_limit(m, u, ng, d, s, t)
+    shut_down_limit(m; unit=u, node=ng, direction=d, stochastic_scenario=s, t=t, _default=1)
 end
 
 """

--- a/src/constraints/constraint_compression_ratio.jl
+++ b/src/constraints/constraint_compression_ratio.jl
@@ -41,7 +41,6 @@ end
 
 function _build_constraint_compression_ratio(m::Model, conn, n_orig, n_dest, s_path, t)
     @fetch node_pressure = m.ext[:spineopt].variables
-    t0 = _analysis_time(m)
     @build_constraint(
         + sum(
             node_pressure[n_dest, s, t] * duration(t)
@@ -53,9 +52,7 @@ function _build_constraint_compression_ratio(m::Model, conn, n_orig, n_dest, s_p
         <=
         + sum(
             node_pressure[n_orig, s, t]
-            * compression_factor(
-                m; connection=conn, node1=n_orig, node2=n_dest, stochastic_scenario=s, analysis_time=t0, t=t
-            )
+            * compression_factor(m; connection=conn, node1=n_orig, node2=n_dest, stochastic_scenario=s, t=t)
             * duration(t)
             for (n_orig, s, t) in node_pressure_indices(
                 m; node=n_orig, stochastic_scenario=s_path, t=t_in_t(m; t_long=t)

--- a/src/constraints/constraint_connection_flow_capacity.jl
+++ b/src/constraints/constraint_connection_flow_capacity.jl
@@ -105,12 +105,9 @@ end
 
 function _term_connection_flow_capacity(m, conn, ng, d, s_path, t)
     @fetch connection_flow = m.ext[:spineopt].variables
-    t0 = _analysis_time(m)
     (
         sum(
-            connection_flow_capacity(
-                m; connection=conn, node=ng, direction=d, stochastic_scenario=s, analysis_time=t0, t=t
-            )
+            connection_flow_capacity(m; connection=conn, node=ng, direction=d, stochastic_scenario=s, t=t)
             for s in s_path, t in t_in_t(m; t_long=t)
             if any(haskey(connection_flow, (conn, n, d, s, t)) for n in members(ng));
             init=0,
@@ -121,7 +118,6 @@ end
 
 function _term_total_number_of_connections(m, conn, ng, d, s_path, t)
     @fetch connection_flow, connections_invested_available = m.ext[:spineopt].variables
-    t0 = _analysis_time(m)
     (
         + sum(
             + (
@@ -131,12 +127,7 @@ function _term_total_number_of_connections(m, conn, ng, d, s_path, t)
                     init=0,
                 )
                 + number_of_connections(
-                    m;
-                    connection=conn,
-                    stochastic_scenario=s,
-                    analysis_time=t0,
-                    t=t,
-                    _default=_default_number_of_connections(conn),
+                    m; connection=conn, stochastic_scenario=s, t=t, _default=_default_nb_of_conns(conn)
                 )
             )
             for s in s_path, t in t_in_t(m; t_long=t)
@@ -146,7 +137,7 @@ function _term_total_number_of_connections(m, conn, ng, d, s_path, t)
     )
 end
 
-_default_number_of_connections(conn) = is_candidate(connection=conn) ? 0 : 1
+_default_nb_of_conns(conn) = is_candidate(connection=conn) ? 0 : 1
 
 function constraint_connection_flow_capacity_indices(m::Model)    
     (

--- a/src/constraints/constraint_connection_flow_intact_flow.jl
+++ b/src/constraints/constraint_connection_flow_intact_flow.jl
@@ -60,7 +60,6 @@ end
 
 function _build_constraint_connection_flow_intact_flow(m, conn, ng, s_path, t)
     @fetch connection_flow, connection_intact_flow = m.ext[:spineopt].variables
-    t0 = _analysis_time(m)
     @build_constraint(
         + sum(
             + connection_flow[conn, n, direction(:from_node), s, t] * duration(t)

--- a/src/constraints/constraint_connection_flow_lodf.jl
+++ b/src/constraints/constraint_connection_flow_lodf.jl
@@ -57,16 +57,12 @@ function add_constraint_connection_flow_lodf!(m::Model)
 end
 
 function _build_constraint_connection_flow_lodf(m::Model, conn_cont, conn_mon, s_path, t)
-    t0 = _analysis_time(m)
     @fetch connection_flow = m.ext[:spineopt].variables
     @build_constraint(
         - connection_minimum_emergency_capacity(m, conn_mon, s_path, t)
         <=
         + connection_post_contingency_flow(m, connection_flow, conn_cont, conn_mon, s_path, t, sum)
-        * maximum(
-            connection_availability_factor(m; connection=conn_mon, stochastic_scenario=s, analysis_time=t0, t=t)
-            for s in s_path
-        )
+        * maximum(connection_availability_factor(m; connection=conn_mon, stochastic_scenario=s, t=t) for s in s_path)
         <=
         + connection_minimum_emergency_capacity(m, conn_mon, s_path, t)
     )
@@ -105,15 +101,10 @@ function connection_post_contingency_flow(m, connection_flow, conn_cont, conn_mo
 end
 
 function connection_minimum_emergency_capacity(m, conn_mon, s_path, t)
-    t0 = _analysis_time(m)
     minimum(
-        + connection_emergency_capacity(
-            m; connection=conn_mon, node=n_mon, direction=d, stochastic_scenario=s, analysis_time=t0, t=t
-        )
-        * connection_availability_factor(m; connection=conn_mon, stochastic_scenario=s, analysis_time=t0, t=t)
-        * connection_conv_cap_to_flow(
-            m; connection=conn_mon, node=n_mon, direction=d, stochastic_scenario=s, analysis_time=t0, t=t
-        )
+        + connection_emergency_capacity(m; connection=conn_mon, node=n_mon, direction=d, stochastic_scenario=s, t=t)
+        * connection_availability_factor(m; connection=conn_mon, stochastic_scenario=s, t=t)
+        * connection_conv_cap_to_flow(m; connection=conn_mon, node=n_mon, direction=d, stochastic_scenario=s, t=t)
         for (conn_mon, n_mon, d) in indices(connection_emergency_capacity; connection=conn_mon)
         for s in s_path
     )

--- a/src/constraints/constraint_connection_intact_flow_capacity.jl
+++ b/src/constraints/constraint_connection_intact_flow_capacity.jl
@@ -48,7 +48,6 @@ end
 
 function _build_constraint_connection_intact_flow_capacity(m::Model, conn, ng, d, s_path, t)
     @fetch connection_intact_flow = m.ext[:spineopt].variables
-    t0 = _analysis_time(m)
     @build_constraint(
         + sum(
             connection_intact_flow[conn, n, d, s, t] * duration(t)
@@ -59,24 +58,13 @@ function _build_constraint_connection_intact_flow_capacity(m::Model, conn, ng, d
         )
         <=
         sum(
-            + connection_capacity(
-                m; connection=conn, node=ng, direction=d, stochastic_scenario=s, analysis_time=t0, t=t
-            )
-            * connection_availability_factor(m; connection=conn, stochastic_scenario=s, analysis_time=t0, t=t)
-            * connection_conv_cap_to_flow(
-                m; connection=conn, node=ng, direction=d, stochastic_scenario=s, analysis_time=t0, t=t
-            )
+            + connection_capacity(m; connection=conn, node=ng, direction=d, stochastic_scenario=s, t=t)
+            * connection_availability_factor(m; connection=conn, stochastic_scenario=s, t=t)
+            * connection_conv_cap_to_flow(m; connection=conn, node=ng, direction=d, stochastic_scenario=s, t=t)
             * (
-                + candidate_connections(
-                    m; connection=conn, stochastic_scenario=s, analysis_time=t0, t=t, _default=0
-                )
+                + candidate_connections(m; connection=conn, stochastic_scenario=s, t=t, _default=0)
                 + number_of_connections(
-                    m;
-                    connection=conn,
-                    stochastic_scenario=s,
-                    analysis_time=t0,
-                    t=t,
-                    _default=_default_number_of_connections(conn),
+                    m; connection=conn, stochastic_scenario=s, t=t, _default=_default_nb_of_conns(conn)
                 )
             )
             for (conn, n, d, s, t) in connection_intact_flow_indices(

--- a/src/constraints/constraint_connection_lifetime.jl
+++ b/src/constraints/constraint_connection_lifetime.jl
@@ -55,7 +55,6 @@ function constraint_connection_lifetime_indices(m::Model)
 end
 
 function _past_connections_invested_available_indices(m, conn, s_path, t)
-    t0 = _analysis_time(m)
     connections_invested_available_indices(
         m;
         connection=conn,
@@ -63,10 +62,7 @@ function _past_connections_invested_available_indices(m, conn, s_path, t)
         t=to_time_slice(
             m;
             t=TimeSlice(
-                end_(t) - connection_investment_lifetime(
-                    connection=conn, analysis_time=t0, stochastic_scenario=s_path, t=t
-                ),
-                end_(t)
+                end_(t) - connection_investment_lifetime(connection=conn, stochastic_scenario=s_path, t=t), end_(t)
             )
         )
     )

--- a/src/constraints/constraint_connections_invested_available.jl
+++ b/src/constraints/constraint_connections_invested_available.jl
@@ -40,10 +40,9 @@ end
 
 function _build_constraint_connections_invested_available(m::Model, conn, s, t)
     @fetch connections_invested_available = m.ext[:spineopt].variables
-    t0 = _analysis_time(m)
     @build_constraint(
         + connections_invested_available[conn, s, t]
         <=
-        + candidate_connections(m; connection=conn, stochastic_scenario=s, analysis_time=t0, t=t)
+        + candidate_connections(m; connection=conn, stochastic_scenario=s, t=t)
     )
 end

--- a/src/constraints/constraint_fix_node_pressure_point.jl
+++ b/src/constraints/constraint_fix_node_pressure_point.jl
@@ -155,7 +155,6 @@ end
 
 function _build_constraint_fix_node_pressure_point(m::Model, conn, n_orig, n_dest, s_path, t, j)
     @fetch node_pressure, connection_flow, binary_gas_connection_flow = m.ext[:spineopt].variables
-    t0 = _analysis_time(m)
     @build_constraint(
         (
             sum(
@@ -187,9 +186,7 @@ function _build_constraint_fix_node_pressure_point(m::Model, conn, n_orig, n_des
         <=
         + sum(
             + node_pressure[n_orig, s, t]
-            * fixed_pressure_constant_1(
-                m; connection=conn, node1=n_orig, node2=n_dest, i=j, stochastic_scenario=s, analysis_time=t0, t=t
-            )
+            * fixed_pressure_constant_1(m; connection=conn, node1=n_orig, node2=n_dest, i=j, stochastic_scenario=s, t=t)
             for (n_orig, s, t) in node_pressure_indices(
                 m; node=n_orig, stochastic_scenario=s_path, t=t_in_t(m; t_long=t)
             );
@@ -197,9 +194,7 @@ function _build_constraint_fix_node_pressure_point(m::Model, conn, n_orig, n_des
         )
         - sum(
             + node_pressure[n_dest, s, t]
-            * fixed_pressure_constant_0(
-                m; connection=conn, node1=n_orig, node2=n_dest, i=j, stochastic_scenario=s, analysis_time=t0, t=t
-            )
+            * fixed_pressure_constant_0(m; connection=conn, node1=n_orig, node2=n_dest, i=j, stochastic_scenario=s, t=t)
             for (n_dest, s, t) in node_pressure_indices(
                 m; node=n_dest, stochastic_scenario=s_path, t=t_in_t(m; t_long=t)
             );

--- a/src/constraints/constraint_investment_group_capacity_invested_available.jl
+++ b/src/constraints/constraint_investment_group_capacity_invested_available.jl
@@ -32,11 +32,10 @@ function add_constraint_investment_group_minimum_capacity_invested_available!(m:
 end
 
 function _build_constraint_investment_group_minimum_capacity_invested_available(m::Model, ig, s, t)
-    t0 = _analysis_time(m)
     @build_constraint(
         _group_capacity_invested_available(m, ig, s, t)
         >=
-        minimum_capacity_invested_available(m; investment_group=ig, stochastic_scenario=s, analysis_time=t0, t=t)
+        minimum_capacity_invested_available(m; investment_group=ig, stochastic_scenario=s, t=t)
     )
 end
 
@@ -63,11 +62,10 @@ function add_constraint_investment_group_maximum_capacity_invested_available!(m:
 end
 
 function _build_constraint_investment_group_maximum_capacity_invested_available(m::Model, ig, s, t)
-    t0 = _analysis_time(m)
     @build_constraint(
         _group_capacity_invested_available(m, ig, s, t)
         <=
-        maximum_capacity_invested_available(m; investment_group=ig, stochastic_scenario=s, analysis_time=t0, t=t)
+        maximum_capacity_invested_available(m; investment_group=ig, stochastic_scenario=s, t=t)
     )
 end
 
@@ -90,12 +88,11 @@ function _capacity_entities_invested_available_s_t(m)
 end
 
 function _group_capacity_invested_available(m, ig, s, t)
-    t0 = _analysis_time(m)
     @fetch units_invested_available, connections_invested_available = m.ext[:spineopt].variables
     (
         + sum(
             + units_invested_available[u, s, t]
-            * unit_capacity(m; unit=u, node=n, direction=d, stochastic_scenario=s, analysis_time=t0, t=t)
+            * unit_capacity(m; unit=u, node=n, direction=d, stochastic_scenario=s, t=t)
             for (u, s, t) in units_invested_available_indices(
                 m; unit=unit__investment_group(investment_group=ig), stochastic_scenario=s, t=t_in_t(m; t_long=t)
             )
@@ -119,7 +116,7 @@ function _group_capacity_invested_available(m, ig, s, t)
         )
         + sum(
             + connections_invested_available[conn, s, t]
-            * connection_capacity(m; connection=conn, node=n, direction=d, stochastic_scenario=s, analysis_time=t0, t=t)
+            * connection_capacity(m; connection=conn, node=n, direction=d, stochastic_scenario=s, t=t)
             for (conn, s, t) in connections_invested_available_indices(
                 m;
                 connection=connection__investment_group(investment_group=ig),

--- a/src/constraints/constraint_investment_group_entities_invested_available.jl
+++ b/src/constraints/constraint_investment_group_entities_invested_available.jl
@@ -32,11 +32,10 @@ function add_constraint_investment_group_minimum_entities_invested_available!(m:
 end
 
 function _build_constraint_investment_group_minimum_entities_invested_available(m::Model, ig, s, t)
-    t0 = _analysis_time(m)
     @build_constraint(
         _group_entities_invested_available(m, ig, s, t)
         >=
-        minimum_entities_invested_available(m; investment_group=ig, stochastic_scenario=s, analysis_time=t0, t=t)
+        minimum_entities_invested_available(m; investment_group=ig, stochastic_scenario=s, t=t)
     )
 end
 
@@ -63,11 +62,10 @@ function add_constraint_investment_group_maximum_entities_invested_available!(m:
 end
 
 function _build_constraint_investment_group_maximum_entities_invested_available(m::Model, ig, s, t)
-    t0 = _analysis_time(m)
     @build_constraint(
         _group_entities_invested_available(m, ig, s, t)
         <=
-        maximum_entities_invested_available(m; investment_group=ig, stochastic_scenario=s, analysis_time=t0, t=t)
+        maximum_entities_invested_available(m; investment_group=ig, stochastic_scenario=s, t=t)
     )
 end
 

--- a/src/constraints/constraint_max_node_pressure.jl
+++ b/src/constraints/constraint_max_node_pressure.jl
@@ -37,11 +37,10 @@ end
 
 function _build_constraint_max_node_pressure(m::Model, ng, s_path, t)
     @fetch node_pressure = m.ext[:spineopt].variables
-    t0 = _analysis_time(m)
     @build_constraint(
         sum(
             + node_pressure[n, s, t]
-            - max_node_pressure(m; node=ng, stochastic_scenario=s, analysis_time=t0, t=t)
+            - max_node_pressure(m; node=ng, stochastic_scenario=s, t=t)
             for (n, s, t) in node_pressure_indices(m; node=ng, stochastic_scenario=s_path, t=t);
             init=0,
         )

--- a/src/constraints/constraint_max_node_voltage_angle.jl
+++ b/src/constraints/constraint_max_node_voltage_angle.jl
@@ -45,11 +45,10 @@ end
 
 function _build_constraint_max_node_voltage_angle(m::Model, ng, s_path, t)
     @fetch node_voltage_angle = m.ext[:spineopt].variables
-    t0 = _analysis_time(m)
     @build_constraint(
         sum(
             + node_voltage_angle[n, s, t]
-            - max_voltage_angle(m; node=ng, stochastic_scenario=s, analysis_time=t0, t=t)
+            - max_voltage_angle(m; node=ng, stochastic_scenario=s, t=t)
             for (n, s, t) in node_voltage_angle_indices(m; node=ng, stochastic_scenario=s_path, t=t);
             init=0,
         )

--- a/src/constraints/constraint_min_capacity_margin.jl
+++ b/src/constraints/constraint_min_capacity_margin.jl
@@ -46,7 +46,6 @@ end
 function _build_constraint_min_capacity_margin(m::Model, n, s_path, t)
     @fetch min_capacity_margin_slack = m.ext[:spineopt].variables
     @fetch capacity_margin = m.ext[:spineopt].expressions    
-    t0 = _analysis_time(m)
     @build_constraint(
         + capacity_margin[n, s_path, t]
         + sum(
@@ -56,7 +55,7 @@ function _build_constraint_min_capacity_margin(m::Model, n, s_path, t)
         )
         >=
         + sum(
-            min_capacity_margin(m; node=n, stochastic_scenario=s, analysis_time=t0, t=t)
+            min_capacity_margin(m; node=n, stochastic_scenario=s, t=t)
             for (n, s, t) in node_stochastic_time_indices(m; node=n, stochastic_scenario=s_path, t=t);
             init=0,
         )

--- a/src/constraints/constraint_min_down_time.jl
+++ b/src/constraints/constraint_min_down_time.jl
@@ -42,10 +42,9 @@ end
 
 function _build_constraint_min_down_time(m::Model, u, s_path, t)
     @fetch units_invested_available, units_on, units_shut_down, nonspin_units_started_up = m.ext[:spineopt].variables
-    t0 = _analysis_time(m)
     @build_constraint(
         + sum(
-            + number_of_units(m; unit=u, stochastic_scenario=s, analysis_time=t0, t=t)
+            + number_of_units(m; unit=u, stochastic_scenario=s, t=t)
             + sum(
                 units_invested_available[u, s, t1]
                 for (u, s, t1) in units_invested_available_indices(

--- a/src/constraints/constraint_min_node_pressure.jl
+++ b/src/constraints/constraint_min_node_pressure.jl
@@ -37,11 +37,10 @@ end
 
 function _build_constraint_min_node_pressure(m::Model, ng, s_path, t)
     @fetch node_pressure = m.ext[:spineopt].variables
-    t0 = _analysis_time(m)
     @build_constraint(
         sum(
             + node_pressure[ng, s, t]
-            - min_node_pressure(m; node=ng, stochastic_scenario=s, analysis_time=t0, t=t)
+            - min_node_pressure(m; node=ng, stochastic_scenario=s, t=t)
             for (ng, s, t) in node_pressure_indices(m; node=ng, stochastic_scenario=s_path, t=t);
             init=0,
         )

--- a/src/constraints/constraint_min_node_voltage_angle.jl
+++ b/src/constraints/constraint_min_node_voltage_angle.jl
@@ -43,11 +43,10 @@ end
 
 function _build_constraint_min_node_voltage_angle(m::Model, ng, s_path, t)
     @fetch node_voltage_angle = m.ext[:spineopt].variables
-    t0 = _analysis_time(m)
     @build_constraint(
         sum(
             + node_voltage_angle[ng, s, t]
-            - min_voltage_angle(m; node=ng, stochastic_scenario=s, analysis_time=t0, t=t)
+            - min_voltage_angle(m; node=ng, stochastic_scenario=s, t=t)
             for (ng, s, t) in node_voltage_angle_indices(m; node=ng, stochastic_scenario=s_path, t=t);
             init=0,
         )

--- a/src/constraints/constraint_min_scheduled_outage_duration.jl
+++ b/src/constraints/constraint_min_scheduled_outage_duration.jl
@@ -37,7 +37,6 @@ end
 
 function _build_constraint_min_scheduled_outage_duration(m::Model, u, s_path, t)
     @fetch units_out_of_service = m.ext[:spineopt].variables
-    t0 = _analysis_time(m)
     @build_constraint(
         + sum(
             + units_out_of_service[u, s, t] * duration(t)
@@ -47,8 +46,8 @@ function _build_constraint_min_scheduled_outage_duration(m::Model, u, s_path, t)
         >=
         + maximum(
             (
-                + scheduled_outage_duration(m; unit=u, stochastic_scenario=s, analysis_time=t0, t=t)
-                * number_of_units(m; unit=u, stochastic_scenario=s, analysis_time=t0, t=t)
+                + scheduled_outage_duration(m; unit=u, stochastic_scenario=s, t=t)
+                * number_of_units(m; unit=u, stochastic_scenario=s, t=t)
             ) / _model_duration_unit(m.ext[:spineopt].instance)(1)
             for s in s_path;
             init=0,

--- a/src/constraints/constraint_min_up_time.jl
+++ b/src/constraints/constraint_min_up_time.jl
@@ -42,7 +42,6 @@ end
 
 function _build_constraint_min_up_time(m::Model, u, s_path, t)
     @fetch units_on, units_started_up, nonspin_units_shut_down = m.ext[:spineopt].variables
-    t0 = _analysis_time(m)
     @build_constraint(
         + sum(
             + units_on[u, s, t]

--- a/src/constraints/constraint_minimum_operating_point.jl
+++ b/src/constraints/constraint_minimum_operating_point.jl
@@ -74,7 +74,6 @@ end
 
 function _build_constraint_minimum_operating_point(m::Model, u, ng, d, s_path, t)
     @fetch unit_flow, nonspin_units_started_up, nonspin_units_shut_down = m.ext[:spineopt].variables
-    t0 = _analysis_time(m)
     @build_constraint(
         + sum(
             + unit_flow[u, n, d, s, t_short] * duration(t_short)
@@ -107,9 +106,9 @@ function _build_constraint_minimum_operating_point(m::Model, u, ng, d, s_path, t
                 )
             )
             * min(duration(t), duration(t_over))
-            * minimum_operating_point(m; unit=u, node=ng, direction=d, stochastic_scenario=s, analysis_time=t0, t=t)
-            * unit_capacity(m; unit=u, node=ng, direction=d, stochastic_scenario=s, analysis_time=t0, t=t)
-            * unit_conv_cap_to_flow(m; unit=u, node=ng, direction=d, stochastic_scenario=s, analysis_time=t0, t=t)
+            * minimum_operating_point(m; unit=u, node=ng, direction=d, stochastic_scenario=s, t=t)
+            * unit_capacity(m; unit=u, node=ng, direction=d, stochastic_scenario=s, t=t)
+            * unit_conv_cap_to_flow(m; unit=u, node=ng, direction=d, stochastic_scenario=s, t=t)
             for (u, s, t_over) in unit_stochastic_time_indices(
                 m; unit=u, stochastic_scenario=s_path, t=t_overlaps_t(m; t=t)
             );

--- a/src/constraints/constraint_node_state_capacity.jl
+++ b/src/constraints/constraint_node_state_capacity.jl
@@ -42,7 +42,6 @@ end
 
 function _build_constraint_node_state_capacity(m::Model, ng, s_path, t)
     @fetch node_state, storages_invested_available = m.ext[:spineopt].variables
-    t0 = _analysis_time(m)
     @build_constraint(
         + sum(
             + node_state[n, s, t]
@@ -51,11 +50,9 @@ function _build_constraint_node_state_capacity(m::Model, ng, s_path, t)
         )
         <=
         + sum(
-            + node_state_cap(m; node=ng, stochastic_scenario=s, analysis_time=t0, t=t)
+            + node_state_cap(m; node=ng, stochastic_scenario=s, t=t)
             * (
-                + number_of_storages(
-                    m; node=ng, stochastic_scenario=s, analysis_time=t0, t=t, _default=_default_nb_of_storages(n)
-                )
+                + number_of_storages(m; node=ng, stochastic_scenario=s, t=t, _default=_default_nb_of_storages(n))
                 + sum(
                     storages_invested_available[n, s, t1]
                     for (n, s, t1) in storages_invested_available_indices(

--- a/src/constraints/constraint_node_voltage_angle.jl
+++ b/src/constraints/constraint_node_voltage_angle.jl
@@ -48,7 +48,6 @@ end
 
 function _build_constraint_node_voltage_angle(m::Model, conn, n_to, n_from, s_path, t)
     @fetch node_voltage_angle, connection_flow = m.ext[:spineopt].variables
-    t0 = _analysis_time(m)
     @build_constraint(
         sum(
             connection_flow[conn, n_from, d_from, s, t]
@@ -65,8 +64,8 @@ function _build_constraint_node_voltage_angle(m::Model, conn, n_to, n_from, s_pa
         ==
         sum(
             (
-                + connection_reactance_base(m; connection=conn, stochastic_scenario=s, analysis_time=t0, t=t)
-                / connection_reactance(m; connection=conn, stochastic_scenario=s, analysis_time=t0, t=t)
+                + connection_reactance_base(m; connection=conn, stochastic_scenario=s, t=t)
+                / connection_reactance(m; connection=conn, stochastic_scenario=s, t=t)
             )
             for s in s_path
         )

--- a/src/constraints/constraint_non_spinning_reserves_bounds.jl
+++ b/src/constraints/constraint_non_spinning_reserves_bounds.jl
@@ -32,15 +32,10 @@ end
 
 function _build_constraint_non_spinning_reserves_lower_bound(m::Model, u, ng, d, s_path, t)
     @fetch unit_flow, nonspin_units_started_up, nonspin_units_shut_down = m.ext[:spineopt].variables
-    t0 = _analysis_time(m)
     @build_constraint(
         sum(
-            + minimum_operating_point(
-                m; unit=u, node=ng, direction=d, stochastic_scenario=s, analysis_time=t0, t=t_over, _default=0
-            )
-            * unit_capacity(
-                m; unit=u, node=ng, direction=d, stochastic_scenario=s, analysis_time=t0, t=t_over
-            )
+            + minimum_operating_point(m; unit=u, node=ng, direction=d, stochastic_scenario=s, t=t_over, _default=0)
+            * unit_capacity(m; unit=u, node=ng, direction=d, stochastic_scenario=s, t=t_over)
             * _switch(d; from_node=nonspin_units_shut_down, to_node=nonspin_units_started_up)[u, n, s, t_over]
             * min(duration(t), duration(t_over))
             for (u, n, s, t_over) in _switch(
@@ -83,7 +78,6 @@ end
 
 function _build_constraint_non_spinning_reserves_upper_bound(m::Model, u, ng, d, s_path, t, limit::Parameter)
     @fetch unit_flow, nonspin_units_started_up, nonspin_units_shut_down = m.ext[:spineopt].variables
-    t0 = _analysis_time(m)
     @build_constraint(
         sum(
             unit_flow[u, n, d, s, t_short] * duration(t_short)
@@ -95,12 +89,8 @@ function _build_constraint_non_spinning_reserves_upper_bound(m::Model, u, ng, d,
         )
         <=
         sum(
-            + limit(
-                m; unit=u, node=ng, direction=d, stochastic_scenario=s, analysis_time=t0, t=t_over, _default=1
-            )
-            * unit_capacity(
-                m; unit=u, node=ng, direction=d, stochastic_scenario=s, analysis_time=t0, t=t_over
-            )
+            + limit(m; unit=u, node=ng, direction=d, stochastic_scenario=s, t=t_over, _default=1)
+            * unit_capacity(m; unit=u, node=ng, direction=d, stochastic_scenario=s, t=t_over)
             * _switch(d; from_node=nonspin_units_shut_down, to_node=nonspin_units_started_up)[u, n, s, t_over]
             * min(duration(t), duration(t_over))
             for (u, n, s, t_over) in _switch(

--- a/src/constraints/constraint_ramp_down.jl
+++ b/src/constraints/constraint_ramp_down.jl
@@ -67,7 +67,6 @@ end
 
 function _build_constraint_ramp_down(m::Model, u, ng, d, s_path, t_before, t_after)
     @fetch units_on, units_shut_down, unit_flow = m.ext[:spineopt].variables
-    t0 = _analysis_time(m)
     @build_constraint(
         + sum(
             + unit_flow[u, n, d, s, t] * overlap_duration(t_before, t)
@@ -99,19 +98,19 @@ function _build_constraint_ramp_down(m::Model, u, ng, d, s_path, t_before, t_aft
         + (
             + sum(
                 + (
-                    + _shut_down_limit(m, u, ng, d, s, t0, t_after)
-                    - _minimum_operating_point(m, u, ng, d, s, t0, t_after)
-                    - _ramp_down_limit(m, u, ng, d, s, t0, t_after)
+                    + _shut_down_limit(m, u, ng, d, s, t_after)
+                    - _minimum_operating_point(m, u, ng, d, s, t_after)
+                    - _ramp_down_limit(m, u, ng, d, s, t_after)
                 )
-                * _unit_flow_capacity(m, u, ng, d, s, t0, t_after)
+                * _unit_flow_capacity(m, u, ng, d, s, t_after)
                 * units_shut_down[u, s, t]
                 * duration(t)
                 for (u, s, t) in units_switched_indices(m; unit=u, stochastic_scenario=s_path, t=t_after);
                 init=0,
             )
             + sum(
-                - _minimum_operating_point(m, u, ng, d, s, t0, t_after)
-                * _unit_flow_capacity(m, u, ng, d, s, t0, t_after)
+                - _minimum_operating_point(m, u, ng, d, s, t_after)
+                * _unit_flow_capacity(m, u, ng, d, s, t_after)
                 * units_on[u, s, t]
                 * duration(t)
                 for (u, s, t) in units_on_indices(m; unit=u, stochastic_scenario=s_path, t=t_after);
@@ -119,10 +118,10 @@ function _build_constraint_ramp_down(m::Model, u, ng, d, s_path, t_before, t_aft
             )
             + sum(
                 + (
-                    + _minimum_operating_point(m, u, ng, d, s, t0, t_after)
-                    + _ramp_down_limit(m, u, ng, d, s, t0, t_after)
+                    + _minimum_operating_point(m, u, ng, d, s, t_after)
+                    + _ramp_down_limit(m, u, ng, d, s, t_after)
                 )
-                * _unit_flow_capacity(m, u, ng, d, s, t0, t_after)
+                * _unit_flow_capacity(m, u, ng, d, s, t_after)
                 * units_on[u, s, t]
                 * duration(t)
                 for (u, s, t) in units_on_indices(m; unit=u, stochastic_scenario=s_path, t=t_before);
@@ -133,8 +132,8 @@ function _build_constraint_ramp_down(m::Model, u, ng, d, s_path, t_before, t_aft
     )
 end
 
-function _ramp_down_limit(m, u, ng, d, s, t0, t)
-    ramp_down_limit(m; unit=u, node=ng, direction=d, stochastic_scenario=s, analysis_time=t0, t=t, _default=1)
+function _ramp_down_limit(m, u, ng, d, s, t)
+    ramp_down_limit(m; unit=u, node=ng, direction=d, stochastic_scenario=s, t=t, _default=1)
 end
 
 function constraint_ramp_down_indices(m::Model)

--- a/src/constraints/constraint_ramp_up.jl
+++ b/src/constraints/constraint_ramp_up.jl
@@ -69,7 +69,6 @@ end
 
 function _build_constraint_ramp_up(m::Model, u, ng, d, s_path, t_before, t_after)
     @fetch units_on, units_started_up, unit_flow = m.ext[:spineopt].variables
-    t0 = _analysis_time(m)
     @build_constraint(
         + sum(
             + unit_flow[u, n, d, s, t] * overlap_duration(t_after, t)
@@ -101,11 +100,11 @@ function _build_constraint_ramp_up(m::Model, u, ng, d, s_path, t_before, t_after
         + (
             + sum(
                 + (
-                    + _start_up_limit(m, u, ng, d, s, t0, t_after)
-                    - _minimum_operating_point(m, u, ng, d, s, t0, t_after)
-                    - _ramp_up_limit(m, u, ng, d, s, t0, t_after)
+                    + _start_up_limit(m, u, ng, d, s, t_after)
+                    - _minimum_operating_point(m, u, ng, d, s, t_after)
+                    - _ramp_up_limit(m, u, ng, d, s, t_after)
                 )
-                * _unit_flow_capacity(m, u, ng, d, s, t0, t_after)
+                * _unit_flow_capacity(m, u, ng, d, s, t_after)
                 * units_started_up[u, s, t]
                 * duration(t)
                 for (u, s, t) in units_switched_indices(m; unit=u, stochastic_scenario=s_path, t=t_after);
@@ -113,18 +112,18 @@ function _build_constraint_ramp_up(m::Model, u, ng, d, s_path, t_before, t_after
             )
             + sum(
                 + (
-                    + _minimum_operating_point(m, u, ng, d, s, t0, t_after)
-                    + _ramp_up_limit(m, u, ng, d, s, t0, t_after)
+                    + _minimum_operating_point(m, u, ng, d, s, t_after)
+                    + _ramp_up_limit(m, u, ng, d, s, t_after)
                 )
-                * _unit_flow_capacity(m, u, ng, d, s, t0, t_after)
+                * _unit_flow_capacity(m, u, ng, d, s, t_after)
                 * units_on[u, s, t]
                 * duration(t)
                 for (u, s, t) in units_on_indices(m; unit=u, stochastic_scenario=s_path, t=t_after);
                 init=0,
             )
             - sum(
-                + _minimum_operating_point(m, u, ng, d, s, t0, t_after)
-                * _unit_flow_capacity(m, u, ng, d, s, t0, t_after)
+                + _minimum_operating_point(m, u, ng, d, s, t_after)
+                * _unit_flow_capacity(m, u, ng, d, s, t_after)
                 * units_on[u, s, t]
                 * duration(t)
                 for (u, s, t) in units_on_indices(m; unit=u, stochastic_scenario=s_path, t=t_before);
@@ -135,8 +134,8 @@ function _build_constraint_ramp_up(m::Model, u, ng, d, s_path, t_before, t_after
     )
 end
 
-function _ramp_up_limit(m, u, ng, d, s, t0, t)
-    ramp_up_limit(m; unit=u, node=ng, direction=d, stochastic_scenario=s, analysis_time=t0, t=t, _default=1)
+function _ramp_up_limit(m, u, ng, d, s, t)
+    ramp_up_limit(m; unit=u, node=ng, direction=d, stochastic_scenario=s, t=t, _default=1)
 end
 
 function constraint_ramp_up_indices(m::Model)

--- a/src/constraints/constraint_ratio_out_in_connection_flow.jl
+++ b/src/constraints/constraint_ratio_out_in_connection_flow.jl
@@ -56,7 +56,6 @@ function _build_constraint_ratio_out_in_connection_flow(m::Model, conn, ng_out, 
     # NOTE: the `<sense>_ratio_<directions>_connection_flow` parameter uses the stochastic dimensions
     # of the second <direction>!
     @fetch connection_flow = m.ext[:spineopt].variables
-    t0 = _analysis_time(m)
     build_sense_constraint(
         + sum(
             + connection_flow[conn, n_out, d, s, t_short] * duration(t_short)
@@ -73,10 +72,8 @@ function _build_constraint_ratio_out_in_connection_flow(m::Model, conn, ng_out, 
         sense,
         + sum(
             + connection_flow[conn, n_in, d, s, t_short]
-            * ratio_out_in(
-                m; connection=conn, node1=ng_out, node2=ng_in, stochastic_scenario=s, analysis_time=t0, t=t_short
-            )
-            * overlap_duration(t_short, _delayed_t(conn, ng_out, ng_in, t0, s, t))
+            * ratio_out_in(m; connection=conn, node1=ng_out, node2=ng_in, stochastic_scenario=s, t=t_short)
+            * overlap_duration(t_short, _delayed_t(conn, ng_out, ng_in, s, t))
             for (conn, n_in, d, s, t_short) in connection_flow_indices(
                 m;
                 connection=conn,
@@ -148,12 +145,11 @@ function constraint_ratio_out_in_connection_flow_indices(m::Model, ratio_out_in)
 end
 
 function _to_delayed_time_slice(m, conn, ng_out, ng_in, s, t)
-    t0 = _analysis_time(m)
-    to_time_slice(m; t=_delayed_t(conn, ng_out, ng_in, t0, s, t))
+    to_time_slice(m; t=_delayed_t(conn, ng_out, ng_in, s, t))
 end
 
-function _delayed_t(conn, ng_out, ng_in, t0, s, t)
-    t - connection_flow_delay(connection=conn, node1=ng_out, node2=ng_in, analysis_time=t0, stochastic_scenario=s, t=t)
+function _delayed_t(conn, ng_out, ng_in, s, t)
+    t - connection_flow_delay(connection=conn, node1=ng_out, node2=ng_in, stochastic_scenario=s, t=t)
 end
 
 """

--- a/src/constraints/constraint_ratio_unit_flow.jl
+++ b/src/constraints/constraint_ratio_unit_flow.jl
@@ -75,7 +75,6 @@ function _build_constraint_ratio_unit_flow(m::Model, u, ng1, ng2, s_path, t, rat
     # NOTE: that the `<sense>_ratio_<directions>_unit_flow` parameter uses the stochastic dimensions of the second
     # <direction>!
     @fetch unit_flow = m.ext[:spineopt].variables
-    t0 = _analysis_time(m)
     build_sense_constraint(
         + sum(
             get(unit_flow, (u, n1, d1, s, t_short), 0)
@@ -87,14 +86,14 @@ function _build_constraint_ratio_unit_flow(m::Model, u, ng1, ng2, s_path, t, rat
         + sum(
             get(unit_flow, (u, n2, d2, s, t_short), 0)
             * duration(t_short)
-            * ratio(m; unit=u, node1=ng1, node2=ng2, stochastic_scenario=s, analysis_time=t0, t=t)
+            * ratio(m; unit=u, node1=ng1, node2=ng2, stochastic_scenario=s, t=t)
             for n2 in members(ng2), s in s_path, t_short in t_in_t(m; t_long=t);
             init=0,
         )
         + sum(
             _get_units_on(m, u, s, t1)
             * min(duration(t1), duration(t))
-            * units_on_coefficient(m; unit=u, node1=ng1, node2=ng2, stochastic_scenario=s, analysis_time=t0, t=t)
+            * units_on_coefficient(m; unit=u, node1=ng1, node2=ng2, stochastic_scenario=s, t=t)
             for (u, s, t1) in unit_stochastic_time_indices(
                 m; unit=u, stochastic_scenario=s_path, t=t_overlaps_t(m; t=t)
             );

--- a/src/constraints/constraint_storage_lifetime.jl
+++ b/src/constraints/constraint_storage_lifetime.jl
@@ -28,7 +28,6 @@ end
 
 function _build_constraint_storage_lifetime(m::Model, n, s_path, t)
     @fetch storages_invested_available, storages_invested = m.ext[:spineopt].variables
-    t0 = _analysis_time(m)
     @build_constraint(
         sum(
             storages_invested_available[n, s, t]
@@ -52,17 +51,12 @@ function constraint_storage_lifetime_indices(m::Model)
 end
 
 function _past_storages_invested_available_indices(m, n, s_path, t)
-    t0 = _analysis_time(m)
     storages_invested_available_indices(
         m;
         node=n,
         stochastic_scenario=s_path,
         t=to_time_slice(
-            m;
-            t=TimeSlice(
-                end_(t) - storage_investment_lifetime(node=n, analysis_time=t0, stochastic_scenario=s_path, t=t),
-                end_(t),
-            )
+            m; t=TimeSlice(end_(t) - storage_investment_lifetime(node=n, stochastic_scenario=s_path, t=t), end_(t))
         )
     )
 end

--- a/src/constraints/constraint_storage_line_pack.jl
+++ b/src/constraints/constraint_storage_line_pack.jl
@@ -45,7 +45,6 @@ end
 
 function _build_constraint_storage_line_pack(m::Model, conn, stor, ng, s_path, t)
     @fetch node_state, node_pressure = m.ext[:spineopt].variables
-    t0 = _analysis_time(m)
     @build_constraint(
         sum(
             node_state[stor, s, t] * duration(t)

--- a/src/constraints/constraint_storages_invested_available.jl
+++ b/src/constraints/constraint_storages_invested_available.jl
@@ -41,10 +41,9 @@ end
 
 function _build_constraint_storages_invested_available(m::Model, n, s, t)
     @fetch storages_invested_available = m.ext[:spineopt].variables
-    t0 = _analysis_time(m)
     @build_constraint(
         + storages_invested_available[n, s, t]
         <=
-        + candidate_storages(m; node=n, stochastic_scenario=s, analysis_time=t0, t=t)
+        + candidate_storages(m; node=n, stochastic_scenario=s, t=t)
     )
 end

--- a/src/constraints/constraint_unit_flow_capacity.jl
+++ b/src/constraints/constraint_unit_flow_capacity.jl
@@ -219,7 +219,7 @@ function constraint_unit_flow_capacity_tight_compact_indices(m::Model)
                 )
             )
         )
-        for (subpath, parts_by_case) in _unit_capacity_constraint_subpaths(path, u, _analysis_time(m), t)
+        for (subpath, parts_by_case) in _unit_capacity_constraint_subpaths(path, u, t)
         for (case, parts) in parts_by_case
         for part in parts
     )

--- a/src/constraints/constraint_unit_flow_op_bounds.jl
+++ b/src/constraints/constraint_unit_flow_op_bounds.jl
@@ -60,7 +60,6 @@ end
 
 function _build_constraint_unit_flow_op_bounds(m::Model, u, n, d, op, s, t)
     @fetch unit_flow_op, unit_flow_op_active = m.ext[:spineopt].variables
-    t0 = _analysis_time(m)
     @build_constraint(
         + unit_flow_op[u, n, d, op, s, t]
         <=
@@ -69,14 +68,10 @@ function _build_constraint_unit_flow_op_bounds(m::Model, u, n, d, op, s, t)
             unit_flow_op_active[u, n, d, op, s, t] : _get_units_on(m, u, s, t)
         )
         * (
-            + operating_points(m; unit=u, node=n, direction=d, stochastic_scenario=s, analysis_time=t0, i=op)
-            - (
-                (op > 1) ? operating_points(
-                    m; unit=u, node=n, direction=d, stochastic_scenario=s, analysis_time=t0, i=op - 1
-                ) : 0
-            )
+            + operating_points(m; unit=u, node=n, direction=d, stochastic_scenario=s, i=op)
+            - ((op > 1) ? operating_points(m; unit=u, node=n, direction=d, stochastic_scenario=s, i=(op - 1)) : 0)
         )
-        * unit_flow_capacity(m; unit=u, node=n, direction=d, stochastic_scenario=s, analysis_time=t0, t=t)
+        * unit_flow_capacity(m; unit=u, node=n, direction=d, stochastic_scenario=s, t=t)
     )
 end
 

--- a/src/constraints/constraint_unit_flow_op_rank.jl
+++ b/src/constraints/constraint_unit_flow_op_rank.jl
@@ -49,19 +49,14 @@ end
 
 function _build_constraint_unit_flow_op_rank(m::Model, u, n, d, op, s, t)
     @fetch unit_flow_op, unit_flow_op_active = m.ext[:spineopt].variables
-    t0 = _analysis_time(m)
     @build_constraint(
         + unit_flow_op[u, n, d, op, s, t]
         >=
         (
-            + operating_points(m; unit=u, node=n, direction=d, stochastic_scenario=s, analysis_time=t0, i=op)
-            - (
-                (op > 1) ? operating_points(
-                    m; unit=u, node=n, direction=d, stochastic_scenario=s, analysis_time=t0, i=op - 1
-                ) : 0
-            )
+            + operating_points(m; unit=u, node=n, direction=d, stochastic_scenario=s, i=op)
+            - ((op > 1) ? operating_points(m; unit=u, node=n, direction=d, stochastic_scenario=s, i=(op - 1)) : 0)
         )
-        * unit_flow_capacity(m; unit=u, node=n, direction=d, stochastic_scenario=s, analysis_time=t0, t=t)
+        * unit_flow_capacity(m; unit=u, node=n, direction=d, stochastic_scenario=s, t=t)
         * unit_flow_op_active[u, n, d, op + 1, s, t]
     )
 end

--- a/src/constraints/constraint_unit_lifetime.jl
+++ b/src/constraints/constraint_unit_lifetime.jl
@@ -28,7 +28,6 @@ end
 
 function _build_constraint_unit_lifetime(m::Model, u, s_path, t)
     @fetch units_invested_available, units_invested = m.ext[:spineopt].variables
-    t0 = _analysis_time(m)
     @build_constraint(
         sum(
             units_invested_available[u, s, t]
@@ -44,7 +43,6 @@ function _build_constraint_unit_lifetime(m::Model, u, s_path, t)
 end
 
 function constraint_unit_lifetime_indices(m::Model)
-    t0 = _analysis_time(m)
     (
         (unit=u, stochastic_path=path, t=t)
         for (u, t) in unit_investment_time_indices(m; unit=indices(unit_investment_lifetime))
@@ -53,16 +51,12 @@ function constraint_unit_lifetime_indices(m::Model)
 end
 
 function _past_units_invested_available_indices(m, u, s_path, t)
-    t0 = _analysis_time(m)
     units_invested_available_indices(
         m;
         unit=u,
         stochastic_scenario=s_path,
         t=to_time_slice(
-            m;
-            t=TimeSlice(
-                end_(t) - unit_investment_lifetime(unit=u, analysis_time=t0, stochastic_scenario=s_path, t=t), end_(t)
-            )
+            m; t=TimeSlice(end_(t) - unit_investment_lifetime(unit=u, stochastic_scenario=s_path, t=t), end_(t))
         )
     )
 end

--- a/src/constraints/constraint_unit_pw_heat_rate.jl
+++ b/src/constraints/constraint_unit_pw_heat_rate.jl
@@ -45,7 +45,6 @@ end
 
 function _build_constraint_unit_pw_heat_rate(m::Model, u, n_from, n_to, s_path, t)
     @fetch unit_flow, unit_flow_op, units_on, units_started_up = m.ext[:spineopt].variables
-    t0 = _analysis_time(m)
     @build_constraint(
         sum(
             + unit_flow[u, n, d, s, t_short] * duration(t_short)
@@ -62,9 +61,7 @@ function _build_constraint_unit_pw_heat_rate(m::Model, u, n_from, n_to, s_path, 
         ==
         + sum(
             + unit_flow_op[u, n, d, op, s, t_short]
-            * unit_incremental_heat_rate(
-                m; unit=u, node1=n_from, node2=n, i=op, stochastic_scenario=s, analysis_time=t0, t=t_short
-            )
+            * unit_incremental_heat_rate(m; unit=u, node1=n_from, node2=n, i=op, stochastic_scenario=s, t=t_short)
             * duration(t_short)
             for (u, n, d, op, s, t_short) in unit_flow_op_indices(
                 m;
@@ -78,9 +75,7 @@ function _build_constraint_unit_pw_heat_rate(m::Model, u, n_from, n_to, s_path, 
         )
         + sum(
             + unit_flow[u, n, d, s, t_short]
-            * unit_incremental_heat_rate(
-                m; unit=u, node1=n_from, node2=n, i=1, stochastic_scenario=s, analysis_time=t0, t=t_short
-            )
+            * unit_incremental_heat_rate(m; unit=u, node1=n_from, node2=n, i=1, stochastic_scenario=s, t=t_short)
             * duration(t_short)
             for (u, n, d, s, t_short) in unit_flow_indices(
                 m;
@@ -96,13 +91,9 @@ function _build_constraint_unit_pw_heat_rate(m::Model, u, n_from, n_to, s_path, 
         + sum(
             + units_on[u, s, t1]
             * min(duration(t1), duration(t))
-            * unit_idle_heat_rate(
-               m; unit=u, node1=n_from, node2=n_to, stochastic_scenario=s, analysis_time=t0, t=t
-            )
+            * unit_idle_heat_rate(m; unit=u, node1=n_from, node2=n_to, stochastic_scenario=s, t=t)
             + units_started_up[u, s, t1]
-            * unit_start_flow(
-                m; unit=u, node1=n_from, node2=n_to, stochastic_scenario=s, analysis_time=t0, t=t
-            )
+            * unit_start_flow(m; unit=u, node1=n_from, node2=n_to, stochastic_scenario=s, t=t)
             for (u, s, t1) in units_on_indices(m; unit=u, stochastic_scenario=s_path, t=t_overlaps_t(m; t=t));
             init=0,
         )

--- a/src/constraints/constraint_units_available.jl
+++ b/src/constraints/constraint_units_available.jl
@@ -37,7 +37,6 @@ end
 
 function _build_constraint_units_available(m, u, s, t)
     @fetch units_on, units_out_of_service, units_invested_available = m.ext[:spineopt].variables
-    t0 = _analysis_time(m)
     @build_constraint(
         + sum(
             + units_on[u, s, t] 
@@ -53,7 +52,7 @@ function _build_constraint_units_available(m, u, s, t)
             init=0,
         )
         <=
-        number_of_units(m; unit=u, stochastic_scenario=s, analysis_time=t0, t=t)
+        number_of_units(m; unit=u, stochastic_scenario=s, t=t)
     )
 end
 

--- a/src/constraints/constraint_units_invested_available.jl
+++ b/src/constraints/constraint_units_invested_available.jl
@@ -36,8 +36,5 @@ end
 
 function _build_constraint_units_invested_available(m::Model, u, s, t)
     @fetch units_invested_available = m.ext[:spineopt].variables
-    t0 = _analysis_time(m)
-    @build_constraint(
-        units_invested_available[u, s, t] <= candidate_units(m; unit=u, stochastic_scenario=s, analysis_time=t0, t=t)
-    )
+    @build_constraint(units_invested_available[u, s, t] <= candidate_units(m; unit=u, stochastic_scenario=s, t=t))
 end

--- a/src/constraints/constraint_units_out_of_service_contiguity.jl
+++ b/src/constraints/constraint_units_out_of_service_contiguity.jl
@@ -46,7 +46,6 @@ end
 
 function _build_constraint_units_out_of_service_contiguity(m::Model, u, s_path, t)
     @fetch units_out_of_service, units_taken_out_of_service, units_returned_to_service = m.ext[:spineopt].variables
-    t0 = _analysis_time(m)
     @build_constraint(
         + sum(
             + units_out_of_service[u, s, t]

--- a/src/constraints/constraint_user_constraint.jl
+++ b/src/constraints/constraint_user_constraint.jl
@@ -78,20 +78,11 @@ function _build_constraint_user_constraint(m::Model, uc, path, t)
         user_constraint_slack_pos,
         user_constraint_slack_neg
     ) = m.ext[:spineopt].variables
-    t0 = _analysis_time(m)
     build_sense_constraint(
         + sum(
             + unit_flow_op[u, n, d, op, s, t_short]
             * unit_flow_coefficient(
-                m;
-                unit=u,
-                node=n,
-                user_constraint=uc,
-                direction=d,
-                i=op,
-                stochastic_scenario=s,
-                analysis_time=t0,
-                t=t_short
+                m; unit=u, node=n, user_constraint=uc, direction=d, i=op, stochastic_scenario=s, t=t_short
             )
             * duration(t_short)
             for (u, n) in unit__from_node__user_constraint(user_constraint=uc, direction=direction(:from_node))
@@ -103,15 +94,7 @@ function _build_constraint_user_constraint(m::Model, uc, path, t)
         + sum(
             + unit_flow[u, n, d, s, t_short]
             * unit_flow_coefficient(
-                m;
-                unit=u,
-                node=n,
-                user_constraint=uc,
-                direction=d,
-                i=1,
-                stochastic_scenario=s,
-                analysis_time=t0,
-                t=t_short
+                m; unit=u, node=n, user_constraint=uc, direction=d, i=1, stochastic_scenario=s, t=t_short
             )
             * duration(t_short)
             for (u, n) in unit__from_node__user_constraint(user_constraint=uc, direction=direction(:from_node))
@@ -124,15 +107,7 @@ function _build_constraint_user_constraint(m::Model, uc, path, t)
         + sum(
             + unit_flow_op[u, n, d, op, s, t_short]
             * unit_flow_coefficient(
-                m;
-                unit=u,
-                node=n,
-                user_constraint=uc,
-                direction=d,
-                i=op,
-                stochastic_scenario=s,
-                analysis_time=t0,
-                t=t_short
+                m; unit=u, node=n, user_constraint=uc, direction=d, i=op, stochastic_scenario=s, t=t_short
             )
             * duration(t_short)
             for (u, n) in unit__to_node__user_constraint(user_constraint=uc, direction=direction(:to_node))
@@ -144,15 +119,7 @@ function _build_constraint_user_constraint(m::Model, uc, path, t)
         + sum(
             + unit_flow[u, n, d, s, t_short]
             * unit_flow_coefficient(
-                m;
-                unit=u,
-                node=n,
-                user_constraint=uc,
-                direction=d,
-                i=1,
-                stochastic_scenario=s,
-                analysis_time=t0,
-                t=t_short
+                m; unit=u, node=n, user_constraint=uc, direction=d, i=1, stochastic_scenario=s, t=t_short
             )
             * duration(t_short)
             for (u, n) in unit__to_node__user_constraint(user_constraint=uc, direction=direction(:to_node))
@@ -163,22 +130,16 @@ function _build_constraint_user_constraint(m::Model, uc, path, t)
             init=0,
         )
         + sum(
-            (   
-                + units_on[u, s, t1]
-                * units_on_coefficient(m; user_constraint=uc, unit=u, stochastic_scenario=s, analysis_time=t0, t=t1)
-            )
+            + units_on[u, s, t1]
+            * units_on_coefficient(m; user_constraint=uc, unit=u, stochastic_scenario=s, t=t1)
             * min(duration(t1), duration(t))
             for u in unit__user_constraint(user_constraint=uc)
             for (u, s, t1) in units_on_indices(m; unit=u, stochastic_scenario=path, t=t_overlaps_t(m; t=t));
             init=0,
         )
         + sum(
-            (   
-                + units_started_up[u, s, t1]
-                * units_started_up_coefficient(
-                    m; user_constraint=uc, unit=u, stochastic_scenario=s, analysis_time=t0, t=t1
-                )
-            )
+            + units_started_up[u, s, t1]
+            * units_started_up_coefficient(m; user_constraint=uc, unit=u, stochastic_scenario=s, t=t1)
             * min(duration(t1), duration(t))
             for u in unit__user_constraint(user_constraint=uc)
             for (u, s, t1) in units_switched_indices(m; unit=u, stochastic_scenario=path, t=t_overlaps_t(m; t=t));
@@ -187,13 +148,9 @@ function _build_constraint_user_constraint(m::Model, uc, path, t)
         + sum(
             (   
                 + units_invested_available[u, s, t1]
-                * units_invested_available_coefficient(
-                    m; user_constraint=uc, unit=u, stochastic_scenario=s, analysis_time=t0, t=t1
-                )
+                * units_invested_available_coefficient(m; user_constraint=uc, unit=u, stochastic_scenario=s, t=t1)
                 + units_invested[u, s, t1]
-                * units_invested_coefficient(
-                    m; user_constraint=uc, unit=u, stochastic_scenario=s, analysis_time=t0, t=t1
-                )
+                * units_invested_coefficient(m; user_constraint=uc, unit=u, stochastic_scenario=s, t=t1)
             )
             * min(duration(t1), duration(t))
             for u in unit__user_constraint(user_constraint=uc)
@@ -206,12 +163,10 @@ function _build_constraint_user_constraint(m::Model, uc, path, t)
             (   
                 + connections_invested_available[c, s, t1]
                 * connections_invested_available_coefficient(
-                    m; user_constraint=uc, connection=c, stochastic_scenario=s, analysis_time=t0, t=t1
+                    m; user_constraint=uc, connection=c, stochastic_scenario=s, t=t1
                 )
                 + connections_invested[c, s, t1]
-                * connections_invested_coefficient(
-                    m; user_constraint=uc, connection=c, stochastic_scenario=s, analysis_time=t0, t=t1
-                )
+                * connections_invested_coefficient(m; user_constraint=uc, connection=c, stochastic_scenario=s, t=t1)
             )
             * min(duration(t1), duration(t))
             for c in connection__user_constraint(user_constraint=uc)
@@ -223,13 +178,9 @@ function _build_constraint_user_constraint(m::Model, uc, path, t)
         + sum(
             (   
                 + storages_invested_available[n, s, t1]
-                * storages_invested_available_coefficient(
-                    m; user_constraint=uc, node=n, stochastic_scenario=s, analysis_time=t0, t=t1
-                )
+                * storages_invested_available_coefficient(m; user_constraint=uc, node=n, stochastic_scenario=s, t=t1)
                 + storages_invested[n, s, t1]
-                * storages_invested_coefficient(
-                    m; user_constraint=uc, node=n, stochastic_scenario=s, analysis_time=t0, t=t1
-                )
+                * storages_invested_coefficient(m; user_constraint=uc, node=n, stochastic_scenario=s, t=t1)
             )
             * min(duration(t1), duration(t))
             for n in node__user_constraint(user_constraint=uc)
@@ -241,14 +192,7 @@ function _build_constraint_user_constraint(m::Model, uc, path, t)
         + sum(
             + connection_flow[c, n, d, s, t_short]
             * connection_flow_coefficient(
-                m;
-                connection=c,
-                node=n,
-                user_constraint=uc,
-                direction=d,
-                stochastic_scenario=s,
-                analysis_time=t0,
-                t=t_short
+                m; connection=c, node=n, user_constraint=uc, direction=d, stochastic_scenario=s, t=t_short
             )
             * duration(t_short)
             for (c, n) in connection__from_node__user_constraint(
@@ -267,14 +211,7 @@ function _build_constraint_user_constraint(m::Model, uc, path, t)
         + sum(
             + connection_flow[c, n, d, s, t_short]
             * connection_flow_coefficient(
-                m;
-                connection=c,
-                node=n,
-                user_constraint=uc,
-                direction=d,
-                stochastic_scenario=s,
-                analysis_time=t0,
-                t=t_short
+                m; connection=c, node=n, user_constraint=uc, direction=d, stochastic_scenario=s, t=t_short
             )
             * duration(t_short)
             for (c, n) in connection__to_node__user_constraint(user_constraint=uc, direction=direction(:to_node))
@@ -290,17 +227,15 @@ function _build_constraint_user_constraint(m::Model, uc, path, t)
         )
         + sum(
             + node_state[n, s, t_short]
-            * node_state_coefficient(
-                m; node=n, user_constraint=uc, stochastic_scenario=s, analysis_time=t0, t=t_short
-            )
+            * node_state_coefficient(m; node=n, user_constraint=uc, stochastic_scenario=s, t=t_short)
             * duration(t_short)
             for n in indices(node_state_coefficient; user_constraint=uc)
             for (n, s, t_short) in node_state_indices(m; node=n, stochastic_scenario=path, t=t_in_t(m; t_long=t));
             init=0,
         )
         + sum(
-            + demand(m; node=n, stochastic_scenario=s, analysis_time=t0, t=t)
-            * demand_coefficient(m; node=n, user_constraint=uc, stochastic_scenario=s, analysis_time=t0, t=t)
+            + demand(m; node=n, stochastic_scenario=s, t=t)
+            * demand_coefficient(m; node=n, user_constraint=uc, stochastic_scenario=s, t=t)
             * duration(t_short)
             for n in node__user_constraint(user_constraint=uc)
             for (ns, s, t_short) in node_stochastic_time_indices(
@@ -315,10 +250,7 @@ function _build_constraint_user_constraint(m::Model, uc, path, t)
         )
         ,
         constraint_sense(user_constraint=uc),
-        + sum(
-            right_hand_side(m; user_constraint=uc, stochastic_scenario=s, analysis_time=t0, t=t) for s in path;
-            init=0,
-        )
+        + sum(right_hand_side(m; user_constraint=uc, stochastic_scenario=s, t=t) for s in path; init=0)
         * duration(t)
         / length(path),
     )

--- a/src/data_structure/temporal_structure.jl
+++ b/src/data_structure/temporal_structure.jl
@@ -830,5 +830,6 @@ function _t_extreme_resolution_sets!(m, t_dict, kw)
 end
 
 function (x::Parameter)(m::Model; kwargs...)
-    m.ext[:spineopt].temporal_structure[:call_update](x; kwargs...)
+    t0 = _analysis_time(m)
+    m.ext[:spineopt].temporal_structure[:call_update](x; analysis_time=t0, kwargs...)
 end

--- a/src/expressions/capacity_margin.jl
+++ b/src/expressions/capacity_margin.jl
@@ -50,20 +50,19 @@ See also
 
 function add_expression_capacity_margin!(m::Model)
     @fetch unit_flow, units_on = m.ext[:spineopt].variables
-    t0 = _analysis_time(m)
     m.ext[:spineopt].expressions[:capacity_margin] = Dict(
         (node=n, stochastic_path=s_path, t=t) => @expression(
             m,
             - sum(
-                + demand(m; node=n, stochastic_scenario=s, analysis_time=t0, t=_first_repr_t(m, t))
+                + demand(m; node=n, stochastic_scenario=s, t=_first_repr_t(m, t))
                 for (n, s, t) in node_injection_indices(
                     m; node=n, stochastic_scenario=s_path, t=t, temporal_block=anything
                 );
                 init=0,
             )
             - sum(
-                fractional_demand(m; node=n, stochastic_scenario=s, analysis_time=t0, t=_first_repr_t(m, t))
-                * demand(m; node=ng, stochastic_scenario=s, analysis_time=t0, t=_first_repr_t(m, t))
+                fractional_demand(m; node=n, stochastic_scenario=s, t=_first_repr_t(m, t))
+                * demand(m; node=ng, stochastic_scenario=s, t=_first_repr_t(m, t))
                 for (n, s, t) in node_injection_indices(
                     m; node=n, stochastic_scenario=s_path, t=t, temporal_block=anything
                 )
@@ -101,7 +100,7 @@ function add_expression_capacity_margin!(m::Model)
             # Conventional and Renewable Capacity
             + sum(
                 + sum(
-                    unit_flow_capacity(m; unit=u, node=n_, direction=d, stochastic_scenario=s, analysis_time=t0, t=t)
+                    unit_flow_capacity(m; unit=u, node=n_, direction=d, stochastic_scenario=s, t=t)
                     for (u, n_, d, s, t_short) in unit_flow_indices(m; unit=u, node=n_, stochastic_scenario=s_path, t=t)
                 )
                 * (

--- a/src/objective/connection_flow_costs.jl
+++ b/src/objective/connection_flow_costs.jl
@@ -24,16 +24,13 @@ Create an expression for `connection_flow` costs.
 """
 function connection_flow_costs(m::Model, t_range)
     @fetch connection_flow = m.ext[:spineopt].variables
-    t0 = _analysis_time(m)
     @expression(
         m,
         sum(
             connection_flow[conn, n, d, s, t]
             * duration(t)
             * prod(weight(temporal_block=blk) for blk in blocks(t))
-            * connection_flow_cost(
-                m; connection=conn, node=n, direction=d, stochastic_scenario=s, analysis_time=t0, t=t
-            )
+            * connection_flow_cost(m; connection=conn, node=n, direction=d, stochastic_scenario=s, t=t)
             * node_stochastic_scenario_weight(m; node=n, stochastic_scenario=s)
             for (conn, n, d) in indices(connection_flow_cost)
             for (conn, n, d, s, t) in connection_flow_indices(m; connection=conn, node=n, direction=d, t=t_range);

--- a/src/objective/connection_investment_costs.jl
+++ b/src/objective/connection_investment_costs.jl
@@ -24,14 +24,13 @@ Create and expression for connection investment costs.
 """
 function connection_investment_costs(m::Model, t_range)
     @fetch connections_invested = m.ext[:spineopt].variables
-    t0 = _analysis_time(m)
     connection = indices(connection_investment_cost)
     @expression(
         m,
         + sum(
             connections_invested[c, s, t]
             * prod(weight(temporal_block=blk) for blk in blocks(t))
-            * connection_investment_cost(m; connection=c, stochastic_scenario=s, analysis_time=t0, t=t)
+            * connection_investment_cost(m; connection=c, stochastic_scenario=s, t=t)
             * connection_stochastic_scenario_weight(m; connection=c, stochastic_scenario=s)
             for (c, s, t) in connections_invested_available_indices(m; connection=connection, t=t_range);
             init=0,

--- a/src/objective/fixed_om_costs.jl
+++ b/src/objective/fixed_om_costs.jl
@@ -24,14 +24,13 @@ Create an expression for fixed operation costs of units.
 """
 function fixed_om_costs(m, t_range)
     @fetch units_invested_available = m.ext[:spineopt].variables
-    t0 = _analysis_time(m)
     @expression(
         m,
         sum(
-            + unit_capacity(m; unit=u, node=ng, direction=d, stochastic_scenario=s, analysis_time=t0, t=t)
-            * fom_cost(m; unit=u, stochastic_scenario=s, analysis_time=t0, t=t)
+            + unit_capacity(m; unit=u, node=ng, direction=d, stochastic_scenario=s, t=t)
+            * fom_cost(m; unit=u, stochastic_scenario=s, t=t)
             * (
-                + number_of_units(m; unit=u, stochastic_scenario=s, analysis_time=t0, t=t)
+                + number_of_units(m; unit=u, stochastic_scenario=s, t=t)
                 + units_invested_available[u, s, t]
             )
             * prod(weight(temporal_block=blk) for blk in blocks(t))

--- a/src/objective/fuel_costs.jl
+++ b/src/objective/fuel_costs.jl
@@ -24,14 +24,13 @@ Create an expression for fuel costs of units.
 """
 function fuel_costs(m::Model, t_range)
     @fetch unit_flow = m.ext[:spineopt].variables
-    t0 = _analysis_time(m)
     @expression(
         m,
         sum(
             unit_flow[u, n, d, s, t]
             * duration(t)
             * prod(weight(temporal_block=blk) for blk in blocks(t))
-            * fuel_cost(m; unit=u, node=ng, direction=d, stochastic_scenario=s, analysis_time=t0, t=t)
+            * fuel_cost(m; unit=u, node=ng, direction=d, stochastic_scenario=s, t=t)
             * node_stochastic_scenario_weight(m; node=ng, stochastic_scenario=s)
             for (u, ng, d) in indices(fuel_cost)
             for (u, n, d, s, t) in unit_flow_indices(m; unit=u, node=ng, direction=d, t=t_range);

--- a/src/objective/min_capacity_margin_penalties.jl
+++ b/src/objective/min_capacity_margin_penalties.jl
@@ -25,14 +25,13 @@ Create an expression for min_capacity_margin_penalty.
 
 function min_capacity_margin_penalties(m::Model, t_range)
     @fetch min_capacity_margin_slack = m.ext[:spineopt].variables
-    t0 = _analysis_time(m)
     @expression(
         m,
         + sum(
             min_capacity_margin_slack[n, s, t]
             * duration(t)
             * prod(weight(temporal_block=blk) for blk in blocks(t))
-            * min_capacity_margin_penalty(m; node=n, stochastic_scenario=s, analysis_time=t0, t=t)
+            * min_capacity_margin_penalty(m; node=n, stochastic_scenario=s, t=t)
             * node_stochastic_scenario_weight(m; node=n, stochastic_scenario=s)
             for (n, s, t) in min_capacity_margin_slack_indices(m; t=t_range);
             init=0,

--- a/src/objective/objective_penalties.jl
+++ b/src/objective/objective_penalties.jl
@@ -27,14 +27,13 @@ function objective_penalties(m::Model, t_range)
     @fetch (
         node_slack_pos, node_slack_neg, user_constraint_slack_pos, user_constraint_slack_neg
     ) = m.ext[:spineopt].variables
-    t0 = _analysis_time(m)
     @expression(
         m,
         + sum(
             (node_slack_neg[n, s, t] + node_slack_pos[n, s, t])
             * duration(t)
             * prod(weight(temporal_block=blk) for blk in blocks(t))
-            * node_slack_penalty(m; node=n, stochastic_scenario=s, analysis_time=t0, t=t)
+            * node_slack_penalty(m; node=n, stochastic_scenario=s, t=t)
             * node_stochastic_scenario_weight(m; node=n, stochastic_scenario=s)
             for (n, s, t) in node_slack_indices(m; t=t_range);
             init=0,
@@ -43,7 +42,7 @@ function objective_penalties(m::Model, t_range)
             (user_constraint_slack_neg[uc, s, t] + user_constraint_slack_pos[uc, s, t])
             * duration(t)
             * prod(weight(temporal_block=blk) for blk in blocks(t))
-            * user_constraint_slack_penalty(m; user_constraint=uc, stochastic_scenario=s, analysis_time=t0, t=t)
+            * user_constraint_slack_penalty(m; user_constraint=uc, stochastic_scenario=s, t=t)
             * any_stochastic_scenario_weight(m; stochastic_scenario=s)
             for (uc, s, t) in user_constraint_slack_indices(m; t=t_range);
             init=0,

--- a/src/objective/renewable_curtailment_costs.jl
+++ b/src/objective/renewable_curtailment_costs.jl
@@ -24,15 +24,14 @@ Create an expression for curtailment costs of renewables.
 """
 function renewable_curtailment_costs(m::Model, t_range)
     @fetch unit_flow, units_on = m.ext[:spineopt].variables
-    t0 = _analysis_time(m)
     @expression(
         m,
         sum(
-            curtailment_cost[(unit=u, stochastic_scenario=s, analysis_time=t0, t=t_short)]
+            + curtailment_cost(m; unit=u, stochastic_scenario=s, t=t_short)
             * node_stochastic_scenario_weight(m; node=n, stochastic_scenario=s)
             * (
                 + units_on[u, s, t_long]
-                * unit_flow_capacity(m; unit=u, node=n, direction=d, stochastic_scenario=s, analysis_time=t0, t=t_short)
+                * unit_flow_capacity(m; unit=u, node=n, direction=d, stochastic_scenario=s, t=t_short)
                 - unit_flow[u, n, d, s, t_short]
             )
             * prod(weight(temporal_block=blk) for blk in blocks(t_short))

--- a/src/objective/res_proc_costs.jl
+++ b/src/objective/res_proc_costs.jl
@@ -24,14 +24,13 @@ Add expression for reserve procurement costs.
 """
 function res_proc_costs(m::Model, t_range)
     @fetch unit_flow = m.ext[:spineopt].variables
-    t0 = _analysis_time(m)
     @expression(
         m,
         sum(
             unit_flow[u, n, d, s, t]
             * duration(t)
             * prod(weight(temporal_block=blk) for blk in blocks(t))
-            * reserve_procurement_cost(m; unit=u, node=ng, direction=d, stochastic_scenario=s, analysis_time=t0, t=t)
+            * reserve_procurement_cost(m; unit=u, node=ng, direction=d, stochastic_scenario=s, t=t)
             * node_stochastic_scenario_weight(m; node=ng, stochastic_scenario=s)
             for (u, ng, d) in indices(reserve_procurement_cost)
             for (u, n, d, s, t) in unit_flow_indices(m; unit=u, node=ng, direction=d, t=t_range);

--- a/src/objective/shut_down_costs.jl
+++ b/src/objective/shut_down_costs.jl
@@ -24,12 +24,11 @@ Create an expression for unit shutdown costs.
 """
 function shut_down_costs(m::Model, t_range)
     @fetch units_shut_down = m.ext[:spineopt].variables
-    t0 = _analysis_time(m)
     @expression(
         m,
         sum(
             + units_shut_down[u, s, t]
-            * shut_down_cost(m; unit=u, stochastic_scenario=s, analysis_time=t0, t=t)
+            * shut_down_cost(m; unit=u, stochastic_scenario=s, t=t)
             * prod(weight(temporal_block=blk) for blk in blocks(t))
             * unit_stochastic_scenario_weight(m; unit=u, stochastic_scenario=s)
             for (u, s, t) in units_on_indices(m; unit=indices(shut_down_cost), t=t_range);

--- a/src/objective/start_up_costs.jl
+++ b/src/objective/start_up_costs.jl
@@ -24,12 +24,11 @@ Create an expression for unit startup costs.
 """
 function start_up_costs(m::Model, t_range)
     @fetch units_started_up = m.ext[:spineopt].variables
-    t0 = _analysis_time(m)
     @expression(
         m,
         sum(
             + units_started_up[u, s, t]
-            * start_up_cost(m; unit=u, stochastic_scenario=s, analysis_time=t0, t=t)
+            * start_up_cost(m; unit=u, stochastic_scenario=s, t=t)
             * prod(weight(temporal_block=blk) for blk in blocks(t))
             * unit_stochastic_scenario_weight(m; unit=u, stochastic_scenario=s)
             for (u, s, t) in units_on_indices(m; unit=indices(start_up_cost), t=t_range);

--- a/src/objective/storage_investment_costs.jl
+++ b/src/objective/storage_investment_costs.jl
@@ -24,13 +24,12 @@ Create and expression for storage investment costs.
 """
 function storage_investment_costs(m::Model, t_range)
     @fetch storages_invested = m.ext[:spineopt].variables
-    t0 = _analysis_time(m)
     node = indices(storage_investment_cost)
     @expression(
         m,
         + sum(
             + storages_invested[n, s, t]
-            * storage_investment_cost(m; node=n, stochastic_scenario=s, analysis_time=t0, t=t)
+            * storage_investment_cost(m; node=n, stochastic_scenario=s, t=t)
             * prod(weight(temporal_block=blk) for blk in blocks(t))
             * node_stochastic_scenario_weight(m; node=n, stochastic_scenario=s)
             for (n, s, t) in storages_invested_available_indices(m; node=node, t=t_range);

--- a/src/objective/taxes.jl
+++ b/src/objective/taxes.jl
@@ -24,13 +24,12 @@ Create an expression for unit taxes.
 """
 function taxes(m::Model, t_range)
     @fetch unit_flow = m.ext[:spineopt].variables
-    t0 = _analysis_time(m)
     @expression(
         m,
         + sum(
             + unit_flow[u, n, d, s, t]
             * duration(t)
-            * tax_net_unit_flow(m; node=n, stochastic_scenario=s, analysis_time=t0, t=t)
+            * tax_net_unit_flow(m; node=n, stochastic_scenario=s, t=t)
             * prod(weight(temporal_block=blk) for blk in blocks(t))
             * node_stochastic_scenario_weight(m; node=n, stochastic_scenario=s)
             for (n,) in indices(tax_net_unit_flow)
@@ -40,7 +39,7 @@ function taxes(m::Model, t_range)
         - sum(
             + unit_flow[u, n, d, s, t]
             * duration(t)
-            * tax_net_unit_flow(m; node=n, stochastic_scenario=s, analysis_time=t0, t=t)
+            * tax_net_unit_flow(m; node=n, stochastic_scenario=s, t=t)
             * prod(weight(temporal_block=blk) for blk in blocks(t))
             * node_stochastic_scenario_weight(m; node=n, stochastic_scenario=s)
             for (n,) in indices(tax_net_unit_flow)
@@ -50,7 +49,7 @@ function taxes(m::Model, t_range)
         + sum(
             + unit_flow[u, n, d, s, t]
             * duration(t)
-            * tax_out_unit_flow(m; node=n, stochastic_scenario=s, analysis_time=t0, t=t)
+            * tax_out_unit_flow(m; node=n, stochastic_scenario=s, t=t)
             * prod(weight(temporal_block=blk) for blk in blocks(t))
             * node_stochastic_scenario_weight(m; node=n, stochastic_scenario=s)
             for (n,) in indices(tax_out_unit_flow)
@@ -60,7 +59,7 @@ function taxes(m::Model, t_range)
         + sum(
             unit_flow[u, n, d, s, t]
             * duration(t)
-            * tax_in_unit_flow(m; node=n, stochastic_scenario=s, analysis_time=t0, t=t)
+            * tax_in_unit_flow(m; node=n, stochastic_scenario=s, t=t)
             * prod(weight(temporal_block=blk) for blk in blocks(t))
             * node_stochastic_scenario_weight(m; node=n, stochastic_scenario=s)
             for (n,) in indices(tax_in_unit_flow)

--- a/src/objective/unit_investment_costs.jl
+++ b/src/objective/unit_investment_costs.jl
@@ -24,13 +24,12 @@ Create and expression for unit investment costs.
 """
 function unit_investment_costs(m::Model, t_range)
     @fetch units_invested = m.ext[:spineopt].variables
-    t0 = _analysis_time(m)
     unit = indices(unit_investment_cost)
     @expression(
         m,
         + sum(
             + units_invested[u, s, t]
-            * unit_investment_cost(m; unit=u, stochastic_scenario=s, analysis_time=t0, t=t)
+            * unit_investment_cost(m; unit=u, stochastic_scenario=s, t=t)
             * prod(weight(temporal_block=blk) for blk in blocks(t))
             # This term is activated when there is a representative temporal block in those containing TimeSlice t.
             # We assume only one representative temporal structure available, of which the temporal blocks represent

--- a/src/objective/units_on_costs.jl
+++ b/src/objective/units_on_costs.jl
@@ -24,13 +24,12 @@ Create an expression for units_on cost.
 """
 function units_on_costs(m::Model, t_range)
     @fetch units_on = m.ext[:spineopt].variables
-    t0 = _analysis_time(m)
     @expression(
         m,
         sum(
             + units_on[u, s, t]
             * duration(t)
-            * units_on_cost(m; unit=u, stochastic_scenario=s, analysis_time=t0, t=t)
+            * units_on_cost(m; unit=u, stochastic_scenario=s, t=t)
             * prod(weight(temporal_block=blk) for blk in blocks(t))
             # This term is activated when there is a representative termporal block in those containing TimeSlice t.
             # We assume only one representative temporal structure available, of which the termporal blocks represent

--- a/src/objective/variable_om_costs.jl
+++ b/src/objective/variable_om_costs.jl
@@ -24,14 +24,13 @@ Create an expression for unit_flow variable operation costs.
 """
 function variable_om_costs(m::Model, t_range)
     @fetch unit_flow = m.ext[:spineopt].variables
-    t0 = _analysis_time(m)
     @expression(
         m,
         sum(
             + unit_flow[u, n, d, s, t]
             * duration(t)
             * prod(weight(temporal_block=blk) for blk in blocks(t))
-            * vom_cost(m; unit=ug, node=ng, direction=d, stochastic_scenario=s, analysis_time=t0, t=t)
+            * vom_cost(m; unit=ug, node=ng, direction=d, stochastic_scenario=s, t=t)
             * node_stochastic_scenario_weight(m; node=ng, stochastic_scenario=s)
             for (ug, ng, d) in indices(vom_cost)
             for (u, n, d, s, t) in unit_flow_indices(m; unit=ug, node=ng, direction=d, t=t_range);

--- a/src/run_spineopt_basic.jl
+++ b/src/run_spineopt_basic.jl
@@ -318,7 +318,7 @@ function _init_downstream_outputs!(st, stage_m, child_models)
                 for (ent, fix_indices) in fix_indices_by_ent
                     input = downstream_outputs[ent]
                     for ind in fix_indices
-                        call_kwargs = (analysis_time=startref(current_window(child_m)), t=ind.t)
+                        call_kwargs = (analysis_time=_analysis_time(child_m), t=ind.t)
                         call = Call(input, call_kwargs, (Symbol(st.name, :_, out_name), call_kwargs))
                         fix(child_m.ext[:spineopt].variables[out_name][ind], call)
                     end

--- a/src/variables/variable_common.jl
+++ b/src/variables/variable_common.jl
@@ -129,11 +129,10 @@ _check_unique(x, y) = x == y ? x : error("$x != $y")
 
 _resolve(::Nothing, args...; default=nothing, kwargs...) = default
 _resolve(f, ind; kwargs...) = f(ind)
-_resolve(f, m, ind; kwargs...) = f(m; ind..., analysis_time=_analysis_time(m))
+_resolve(f, m, ind; kwargs...) = f(m; ind...)
 _resolve(f, ind, other_ind, _factor; reducer, kwargs...) = _apply(reducer, f(ind), f(other_ind))
 function _resolve(f, m, ind, other_ind, factor; reducer, kwargs...)
-    t0 = _analysis_time(m)
-    _apply(reducer, f(m; ind..., analysis_time=t0), _mul(factor, f(m; other_ind..., analysis_time=t0)))
+    _apply(reducer, f(m; ind...), _mul(factor, f(m; other_ind...)))
 end
 
 _mul(_factor, ::Nothing) = nothing

--- a/src/variables/variable_node_pressure.jl
+++ b/src/variables/variable_node_pressure.jl
@@ -47,7 +47,6 @@ end
 Add `node_pressure` variables to model `m`.
 """
 function add_variable_node_pressure!(m::Model)
-    t0 = start(current_window(m))
     add_variable!(
         m,
         :node_pressure,

--- a/src/variables/variable_node_voltage_angle.jl
+++ b/src/variables/variable_node_voltage_angle.jl
@@ -44,7 +44,6 @@ end
 Add `node_voltage_angle` variables to model `m`.
 """
 function add_variable_node_voltage_angle!(m::Model)
-    t0 = start(current_window(m))
     add_variable!(
         m,
         :node_voltage_angle,

--- a/src/variables/variable_nonspin_units_shut_down.jl
+++ b/src/variables/variable_nonspin_units_shut_down.jl
@@ -46,7 +46,6 @@ end
 Add `nonspin_units_shut_down` variables to model `m`.
 """
 function add_variable_nonspin_units_shut_down!(m::Model)
-    t0 = start(current_window(m))
     add_variable!(
         m,
         :nonspin_units_shut_down,

--- a/src/variables/variable_units_on.jl
+++ b/src/variables/variable_units_on.jl
@@ -125,6 +125,6 @@ end
 
 function _get_units_on(m, u, s, t)
     get(m.ext[:spineopt].variables[:units_on], (u, s, t)) do
-        number_of_units(m; unit=u, stochastic_scenario=s, analysis_time=_analysis_time(m), t=t)
+        number_of_units(m; unit=u, stochastic_scenario=s, t=t)
     end
 end

--- a/src/variables/variable_units_out_of_service.jl
+++ b/src/variables/variable_units_out_of_service.jl
@@ -90,6 +90,6 @@ end
 
 function _get_units_out_of_service(m, u, s, t)
     get(m.ext[:spineopt].variables[:units_out_of_service], (u, s, t)) do
-        units_unavailable(m; unit=u, stochastic_scenario=s, analysis_time=_analysis_time(m), t=t)
+        units_unavailable(m; unit=u, stochastic_scenario=s, t=t)
     end
 end


### PR DESCRIPTION
We were passing the analysis time explicitely to every single parameter call, but since recently we don't call the parameter function directly but we call an intermediate function that redirects the call to the parameter -> so we can pass the analysis time there, only once.

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted according to SpineOpt's style
- [x] Unit tests pass
