### PR TITLE
Auto update constraints that need to look behind

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - "1.6"  # Minimum compatible Release
+          - "1.8"  # Minimum compatible Release
           - "1"    # Latest Release of Julia v1.x
         os:
           - ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -21,4 +21,4 @@ TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 [compat]
 JuMP = "^1.20"
 SpineInterface = "0.13"
-julia = "^1.6"
+julia = "^1.8"

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Please cite [this article](https://doi.org/10.1016/j.esr.2022.100902) when refer
 
 ### Compatibility
 
-This package requires [Julia](https://julialang.org/) 1.6 or higher.
+This package requires [Julia](https://julialang.org/) 1.8 or higher.
 
 ### Installation
 

--- a/src/constraints/constraint_connection_lifetime.jl
+++ b/src/constraints/constraint_connection_lifetime.jl
@@ -40,8 +40,8 @@ function _build_constraint_connection_lifetime(m::Model, conn, s_path, t)
         )
         >=
         sum(
-            connections_invested[conn, s_past, t_past]
-            for (conn, s_past, t_past) in _past_connections_invested_available_indices(m, conn, s_path, t)
+            connections_invested[conn, s_past, t_past] * weight
+            for (conn, s_past, t_past, weight) in _past_connections_invested_available_indices(m, conn, s_path, t)
         )
     )
 end
@@ -55,17 +55,7 @@ function constraint_connection_lifetime_indices(m::Model)
 end
 
 function _past_connections_invested_available_indices(m, conn, s_path, t)
-    connections_invested_available_indices(
-        m;
-        connection=conn,
-        stochastic_scenario=s_path,
-        t=to_time_slice(
-            m;
-            t=TimeSlice(
-                end_(t) - connection_investment_lifetime(connection=conn, stochastic_scenario=s_path, t=t), end_(t)
-            )
-        )
-    )
+    _past_indices(m, connections_invested_available_indices, connection_investment_lifetime, s_path, t; connection=conn)
 end
 
 """

--- a/src/constraints/constraint_min_down_time.jl
+++ b/src/constraints/constraint_min_down_time.jl
@@ -58,8 +58,8 @@ function _build_constraint_min_down_time(m::Model, u, s_path, t)
         )
         >=
         + sum(
-            units_shut_down[u, s_past, t_past]
-            for (u, s_past, t_past) in past_units_on_indices(m, u, s_path, t, min_down_time);
+            units_shut_down[u, s_past, t_past] * weight
+            for (u, s_past, t_past, weight) in past_units_on_indices(m, min_down_time, u, s_path, t);
             init=0,
         )
         + sum(
@@ -81,7 +81,7 @@ function constraint_min_down_time_indices(m::Model)
             m, 
             Iterators.flatten(
                 (
-                    past_units_on_indices(m, u, anything, t, min_down_time),
+                    past_units_on_indices(m, min_down_time, u, anything, t),
                     nonspin_units_started_up_indices(m; unit=u, t=t_before_t(m; t_after=t), temporal_block=anything),
                 )
             )

--- a/src/constraints/constraint_min_scheduled_outage_duration.jl
+++ b/src/constraints/constraint_min_scheduled_outage_duration.jl
@@ -43,7 +43,7 @@ function _build_constraint_min_scheduled_outage_duration(m::Model, u, s_path, t)
             for (u, s, t) in units_out_of_service_indices(m; unit=u, stochastic_scenario=s_path);
             init=0,
         )
-        >=
+        ==
         + maximum(
             (
                 + scheduled_outage_duration(m; unit=u, stochastic_scenario=s, t=t)

--- a/src/constraints/constraint_min_up_time.jl
+++ b/src/constraints/constraint_min_up_time.jl
@@ -57,8 +57,8 @@ function _build_constraint_min_up_time(m::Model, u, s_path, t)
         )
         >=
         + sum(
-            units_started_up[u, s_past, t_past]
-            for (u, s_past, t_past) in past_units_on_indices(m, u, s_path, t, min_up_time)
+            units_started_up[u, s_past, t_past] * weight
+            for (u, s_past, t_past, weight) in past_units_on_indices(m, min_up_time, u, s_path, t)
         )
     )
 end
@@ -68,7 +68,7 @@ function constraint_min_up_time_indices(m::Model; unit=anything, stochastic_path
         (unit=u, stochastic_path=path, t=t)
         for u in indices(min_up_time)
         for (u, t) in unit_time_indices(m; unit=u)
-        for path in active_stochastic_paths(m, past_units_on_indices(m, u, anything, t, min_up_time))
+        for path in active_stochastic_paths(m, past_units_on_indices(m, min_up_time, u, anything, t))
     )
 end
 

--- a/src/constraints/constraint_storage_lifetime.jl
+++ b/src/constraints/constraint_storage_lifetime.jl
@@ -36,8 +36,8 @@ function _build_constraint_storage_lifetime(m::Model, n, s_path, t)
         )
         >=
         sum(
-            storages_invested[n, s_past, t_past]
-            for (n, s_past, t_past) in _past_storages_invested_available_indices(m, n, s_path, t)
+            storages_invested[n, s_past, t_past] * weight
+            for (n, s_past, t_past, weight) in _past_storages_invested_available_indices(m, n, s_path, t)
         )
     )
 end
@@ -51,14 +51,7 @@ function constraint_storage_lifetime_indices(m::Model)
 end
 
 function _past_storages_invested_available_indices(m, n, s_path, t)
-    storages_invested_available_indices(
-        m;
-        node=n,
-        stochastic_scenario=s_path,
-        t=to_time_slice(
-            m; t=TimeSlice(end_(t) - storage_investment_lifetime(node=n, stochastic_scenario=s_path, t=t), end_(t))
-        )
-    )
+    _past_indices(m, storages_invested_available_indices, storage_investment_lifetime, s_path, t; node=n)
 end
 
 """

--- a/src/constraints/constraint_unit_lifetime.jl
+++ b/src/constraints/constraint_unit_lifetime.jl
@@ -36,8 +36,8 @@ function _build_constraint_unit_lifetime(m::Model, u, s_path, t)
         )
         >=
         sum(
-            units_invested[u, s_past, t_past]
-            for (u, s_past, t_past) in _past_units_invested_available_indices(m, u, s_path, t)
+            units_invested[u, s_past, t_past] * weight
+            for (u, s_past, t_past, weight) in _past_units_invested_available_indices(m, u, s_path, t)
         )
     )
 end
@@ -51,14 +51,7 @@ function constraint_unit_lifetime_indices(m::Model)
 end
 
 function _past_units_invested_available_indices(m, u, s_path, t)
-    units_invested_available_indices(
-        m;
-        unit=u,
-        stochastic_scenario=s_path,
-        t=to_time_slice(
-            m; t=TimeSlice(end_(t) - unit_investment_lifetime(unit=u, stochastic_scenario=s_path, t=t), end_(t))
-        )
-    )
+    _past_indices(m, units_invested_available_indices, unit_investment_lifetime, s_path, t; unit=u)
 end
 
 """

--- a/src/constraints/constraint_units_out_of_service_contiguity.jl
+++ b/src/constraints/constraint_units_out_of_service_contiguity.jl
@@ -54,12 +54,16 @@ function _build_constraint_units_out_of_service_contiguity(m::Model, u, s_path, 
             );
             init=0,
         )           
-        >=
+        ==
         + sum(
-            units_taken_out_of_service[u, s_past, t_past]
-            for (u, s_past, t_past) in past_units_out_of_service_indices(m, u, s_path, t, scheduled_outage_duration)
+            units_taken_out_of_service[u, s_past, t_past] * weight
+            for (u, s_past, t_past, weight) in past_units_out_of_service_indices(m, u, s_path, t)
         )
     )
+end
+
+function past_units_out_of_service_indices(m, u, s_path, t)
+    _past_indices(m, units_out_of_service_indices, scheduled_outage_duration, s_path, t; unit=u)
 end
 
 function constraint_units_out_of_service_contiguity_indices(m::Model)
@@ -67,8 +71,6 @@ function constraint_units_out_of_service_contiguity_indices(m::Model)
         (unit=u, stochastic_path=path, t=t)
         for u in indices(scheduled_outage_duration)
         for (u, t) in unit_time_indices(m; unit=u)
-        for path in active_stochastic_paths(
-            m, past_units_out_of_service_indices(m, u, anything, t, scheduled_outage_duration)
-        )
+        for path in active_stochastic_paths(m, past_units_out_of_service_indices(m, u, anything, t))
     )
 end

--- a/test/constraints/constraint_unit.jl
+++ b/test/constraints/constraint_unit.jl
@@ -1035,7 +1035,7 @@ function test_constraint_units_out_of_service_contiguity()
                 var_u_oos_key = (unit(:unit_ab), s, t)
                 var_u_oos = var_units_out_of_service[var_u_oos_key...]
                 vars_u_toos = [var_units_taken_out_of_service[unit(:unit_ab), s, t] for (s, t) in zip(s_set, t_set)]
-                expected_con = @build_constraint(var_u_oos >= sum(vars_u_toos))
+                expected_con = @build_constraint(var_u_oos == sum(vars_u_toos))
                 con_key = (unit(:unit_ab), path, t)
                 observed_con = constraint_object(constraint[con_key...])
                 @test _is_constraint_equal(observed_con, expected_con)
@@ -1068,7 +1068,7 @@ function test_constraint_min_scheduled_outage_duration()
             scenarios = [[stochastic_scenario(:parent)]; repeat([stochastic_scenario(:child)], 4)]
             time_slices = time_slice(m; temporal_block=temporal_block(:hourly))
             vars_u_oos = [var_units_out_of_service[unit(:unit_ab), s, t] for (s, t) in zip(scenarios, time_slices)]
-            expected_con = @build_constraint(sum(vars_u_oos) >= scheduled_outage_duration_minutes / 60)
+            expected_con = @build_constraint(sum(vars_u_oos) == scheduled_outage_duration_minutes / 60)
             con_key = (unit(:unit_ab), s_path, constraint_t)
             observed_con = constraint_object(constraint[con_key...])
             @test _is_constraint_equal(observed_con, expected_con)           

--- a/test/run_spineopt_mga.jl
+++ b/test/run_spineopt_mga.jl
@@ -17,7 +17,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #############################################################################
 
-function _test_algorithm_structure_setup()
+function _test_run_spineopt_mga_setup()
     url_in = "sqlite://"
     test_data = Dict(
         :objects => [
@@ -129,9 +129,9 @@ function _test_algorithm_structure_setup()
     url_in
 end
 
-function _test_test_mga_algorithm()
-    @testset "test mga algorithm" begin
-        url_in = _test_algorithm_structure_setup()
+function _test_run_spineopt_mga()
+    @testset "run_spineopt_mga" begin
+        url_in = _test_run_spineopt_mga_setup()
         candidate_units = 1
         candidate_connections = 1
         candidate_storages = 1
@@ -486,9 +486,9 @@ function _test_test_mga_algorithm()
     end
 end
 
-function _test_test_mga_algorithm_2()
-    @testset "test mga algorithm 2" begin
-        url_in = _test_algorithm_structure_setup()
+function _test_run_spineopt_mga_2()
+    @testset "run_spineopt_mga_2" begin
+        url_in = _test_run_spineopt_mga_setup()
         candidate_units = 1
         candidate_connections = 1
         candidate_storages = 1
@@ -601,7 +601,7 @@ function _test_test_mga_algorithm_2()
     end
 end
 
-@testset "algorithm structure" begin
-    _test_test_mga_algorithm()
-    _test_test_mga_algorithm_2()
+@testset "run_spineopt_mga" begin
+    _test_run_spineopt_mga()
+    _test_run_spineopt_mga_2()
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -80,12 +80,12 @@ function _is_constraint_equal_kernel(left, right)
     left_terms, right_terms = left.func.terms, right.func.terms
     missing_in_right = setdiff(keys(left_terms), keys(right_terms))
     if !isempty(missing_in_right)
-        @error string("missing in right constraint", missing_in_right)
+        @error string("missing in right constraint: ", missing_in_right)
         return false
     end
     missing_in_left = setdiff(keys(right_terms), keys(left_terms))
     if !isempty(missing_in_left)
-        @error string("missing in left constraint", missing_in_left)
+        @error string("missing in left constraint: ", missing_in_left)
         return false
     end
     for k in keys(left_terms)


### PR DESCRIPTION
This PR improves the auto-update system so it also can update constraints that include terms depending on the value of a parameter value, for example min_up_time. Now if the value of min_up_time changes across different model solves, the constraint includes just the right terms.

IMPORTANT: SpineOpt now requires Julia >= 1.8 to be able to use ifelse with 'calls'.

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted according to SpineOpt's style
- [x] Unit tests pass
