### PR TITLE
Get rid of replacement_value

### DIFF
--- a/src/data_structure/preprocess_data_structure.jl
+++ b/src/data_structure/preprocess_data_structure.jl
@@ -925,38 +925,56 @@ end
 _prod_or_nothing(args...) = any(isnothing.(args)) ? nothing : *(args...)
 
 function generate_unit_commitment_parameters()
-    _switchable_unit_iter = Iterators.flatten(
-        (
-            indices(min_up_time),
-            indices(min_down_time),
-            indices(start_up_cost),
-            indices(shut_down_cost), 
-            (x.unit for x in indices(start_up_limit)),
-            (x.unit for x in indices(shut_down_limit)),
-            (x.unit for x in indices(unit_start_flow) if unit_start_flow(; x...) != 0),
-            (x.unit for x in indices(units_started_up_coefficient) if units_started_up_coefficient(; x...) != 0),
+    unit_with_switched_variable_set = unique(
+        Iterators.flatten(
+            (
+                indices(min_up_time),
+                indices(min_down_time),
+                indices(start_up_cost),
+                indices(shut_down_cost), 
+                (x.unit for x in indices(start_up_limit)),
+                (x.unit for x in indices(shut_down_limit)),
+                (x.unit for x in indices(unit_start_flow) if unit_start_flow(; x...) != 0),
+                (x.unit for x in indices(units_started_up_coefficient) if units_started_up_coefficient(; x...) != 0),
+            )
         )
     )
-    _deactivatable_unit_iter = Iterators.flatten(
-        (indices(scheduled_outage_duration), (u for u in indices(units_unavailable) if units_unavailable(unit=u) != 0))
-    )
-    _activatable_unit_iter = Iterators.flatten(
-        (
-            _switchable_unit_iter,
-            _deactivatable_unit_iter,
-            indices(units_on_cost),
-            indices(units_on_non_anticipativity_time),
-            (u for u in indices(candidate_units) if candidate_units(unit=u) > 0),
-            (x.unit for x in indices(units_on_coefficient) if units_on_coefficient(; x...) != 0),
-            (x.unit for x in indices(minimum_operating_point) if minimum_operating_point(; x...) != 0),
+    unit_with_out_of_service_variable_set = unique(
+        Iterators.flatten(
+            (
+                indices(scheduled_outage_duration),
+                (u for u in indices(units_unavailable) if units_unavailable(unit=u) != 0),
+            )
         )
     )
-    for (pname, iter) in (
-        (:has_switched_variable, _switchable_unit_iter),
-        (:has_online_variable, _activatable_unit_iter),
-        (:has_out_of_service_variable, _deactivatable_unit_iter),
+    unit_with_online_variable_set = unique(
+        Iterators.flatten(
+            (
+                unit_with_switched_variable_set,
+                unit_with_out_of_service_variable_set,
+                indices(units_on_cost),
+                indices(units_on_non_anticipativity_time),
+                (u for u in indices(candidate_units) if candidate_units(unit=u) > 0),
+                (x.unit for x in indices(units_on_coefficient) if units_on_coefficient(; x...) != 0),
+                (x.unit for x in indices(minimum_operating_point) if minimum_operating_point(; x...) != 0),
+            )
+        )
     )
-        add_object_parameter_values!(unit, Dict(u => Dict(pname => parameter_value(true)) for u in unique(iter)))
+    unit_without_online_variable_iter = (
+        u for u in unit() if online_variable_type(unit=u) == :unit_online_variable_type_none
+    )
+    unit_without_out_of_service_variable_iter = (
+        u for u in unit() if outage_variable_type(unit=u) == :unit_online_variable_type_none
+    )
+    setdiff!(unit_with_switched_variable_set, unit_without_online_variable_iter)
+    setdiff!(unit_with_out_of_service_variable_set, unit_without_out_of_service_variable_iter)
+    setdiff!(unit_with_online_variable_set, unit_without_online_variable_iter)
+    for (pname, unit_set) in (
+        (:has_switched_variable, unit_with_switched_variable_set),
+        (:has_out_of_service_variable, unit_with_out_of_service_variable_set),
+        (:has_online_variable, unit_with_online_variable_set),
+    )
+        add_object_parameter_values!(unit, Dict(u => Dict(pname => parameter_value(true)) for u in unit_set))
         add_object_parameter_defaults!(unit, Dict(pname => parameter_value(false)))
     end
     @eval begin

--- a/src/variables/variable_common.jl
+++ b/src/variables/variable_common.jl
@@ -43,7 +43,6 @@ function add_variable!(
     initial_value::Union{Parameter,Nothing}=nothing,
     fix_value::Union{Parameter,Nothing}=nothing,
     internal_fix_value::Union{Parameter,Nothing}=nothing,
-    replacement_value::Union{Function,Nothing}=nothing,
     non_anticipativity_time::Union{Parameter,Nothing}=nothing,
     non_anticipativity_margin::Union{Parameter,Nothing}=nothing,
     required_history_period::Union{Period,Nothing}=nothing,
@@ -72,7 +71,7 @@ function add_variable!(
     first_ind = iterate(indices(m; t=t))
     K = first_ind === nothing ? Any : typeof(first_ind[1])
     vars = m.ext[:spineopt].variables[name] = Dict{K,Union{VariableRef,AffExpr,Call}}(
-        ind => _add_variable!(m, name, ind, replacement_value) for ind in indices(m; t=t) if !haskey(ind_map, ind)
+        ind => _add_variable!(m, name, ind) for ind in indices(m; t=t) if !haskey(ind_map, ind)
     )
     inverse_ind_map = Dict(ref_ind => (ind, 1 / coeff) for (ind, (ref_ind, coeff)) in ind_map)
     Threads.@threads for ind in collect(keys(vars))
@@ -114,14 +113,7 @@ _nothing_if_empty(x) = x
 
 _base_name(name, ind) = string(name, "[", join(ind, ", "), "]")
 
-function _add_variable!(m, name, ind, replacement_value)
-    if replacement_value !== nothing
-        ind_ = (analysis_time=_analysis_time(m), ind...)
-        value = replacement_value(ind_)
-        if value !== nothing
-            return value
-        end
-    end
+function _add_variable!(m, name, ind)
     @variable(m, base_name=_base_name(name, ind))
 end
 

--- a/src/variables/variable_units_on.jl
+++ b/src/variables/variable_units_on.jl
@@ -85,22 +85,6 @@ Check if unit online variable type is defined as an integer.
 """
 units_on_int(x) = online_variable_type(unit=x.unit) == :unit_online_variable_type_integer
 
-function units_on_replacement_value(ind)
-    if online_variable_type(unit=ind.unit) == :unit_online_variable_type_none
-        number_of_units[(; ind...)]
-    else
-        nothing
-    end
-end
-
-function units_switched_replacement_value(ind)
-    if online_variable_type(unit=ind.unit) == :unit_online_variable_type_none
-        Call(0)
-    else
-        nothing
-    end
-end
-
 """
     add_variable_units_on!(m::Model)
 
@@ -116,7 +100,6 @@ function add_variable_units_on!(m::Model)
         int=units_on_int,
         fix_value=fix_units_on,
         initial_value=initial_units_on,
-        replacement_value=units_on_replacement_value,
         non_anticipativity_time=units_on_non_anticipativity_time,
         non_anticipativity_margin=units_on_non_anticipativity_margin,
         required_history_period=_get_max_duration(m, [min_up_time, min_down_time]),

--- a/src/variables/variable_units_out_of_service.jl
+++ b/src/variables/variable_units_out_of_service.jl
@@ -51,23 +51,6 @@ Check if unit online variable type is defined as an integer.
 """
 units_out_of_service_int(x) = outage_variable_type(unit=x.unit) == :unit_online_variable_type_integer
 
-function units_out_of_service_replacement_value(ind)
-    if outage_variable_type(unit=ind.unit, _default=:unit_online_variable_type_none) == :unit_online_variable_type_none
-        units_unavailable[(; ind...)]
-    else
-        nothing
-    end
-end
-
-function units_out_of_service_switched_replacement_value(ind)
-    if outage_variable_type(unit=ind.unit, _default=:unit_online_variable_type_none) == :unit_online_variable_type_none
-        Call(0)
-    else
-        nothing
-    end
-end
-
-
 """
     add_variable_units_out_of_service!(m::Model)
 
@@ -83,7 +66,6 @@ function add_variable_units_out_of_service!(m::Model)
         int=units_out_of_service_int,
         fix_value=fix_units_out_of_service,
         initial_value=initial_units_out_of_service,
-        replacement_value=units_out_of_service_replacement_value,
         required_history_period=maximum_parameter_value(scheduled_outage_duration),        
     )
 end

--- a/src/variables/variable_units_returned_to_service.jl
+++ b/src/variables/variable_units_returned_to_service.jl
@@ -24,12 +24,6 @@ Add `units_returned_to_service` variables to model `m`.
 """
 function add_variable_units_returned_to_service!(m::Model)
     add_variable!(
-        m,
-        :units_returned_to_service,
-        units_out_of_service_indices;
-        lb=constant(0),
-        bin=units_on_bin,
-        int=units_on_int,
-        replacement_value=units_out_of_service_switched_replacement_value,
+        m, :units_returned_to_service, units_out_of_service_indices; lb=constant(0), bin=units_on_bin, int=units_on_int
     )
 end

--- a/src/variables/variable_units_shut_down.jl
+++ b/src/variables/variable_units_shut_down.jl
@@ -30,7 +30,6 @@ function add_variable_units_shut_down!(m::Model)
         lb=constant(0),
         bin=units_on_bin,
         int=units_on_int,
-        replacement_value=units_switched_replacement_value,
         required_history_period=maximum_parameter_value(min_down_time),
     )
 end

--- a/src/variables/variable_units_started_up.jl
+++ b/src/variables/variable_units_started_up.jl
@@ -30,7 +30,6 @@ function add_variable_units_started_up!(m::Model)
         lb=constant(0),
         bin=units_on_bin,
         int=units_on_int,
-        replacement_value=units_switched_replacement_value,
         required_history_period=maximum_parameter_value(min_up_time),
     )
 end

--- a/src/variables/variable_units_taken_out_of_service.jl
+++ b/src/variables/variable_units_taken_out_of_service.jl
@@ -30,7 +30,6 @@ function add_variable_units_taken_out_of_service!(m::Model)
         lb=constant(0),
         bin=units_on_bin,
         int=units_on_int,
-        replacement_value=units_out_of_service_switched_replacement_value,
         required_history_period=maximum_parameter_value(scheduled_outage_duration),
     )
 end

--- a/test/constraints/constraint_unit.jl
+++ b/test/constraints/constraint_unit.jl
@@ -2023,11 +2023,8 @@ function test_unit_online_variable_type_none()
         time_slices = time_slice(m; temporal_block=temporal_block(:hourly))
         @testset for (s, t) in zip(scenarios, time_slices)
             key = (unit(:unit_ab), s, t)
-            var_u_on = var_units_on[key...]
-            con_u_avail = constraint_u_avail[key...]
-            @test var_u_on isa Call
-            @test realize(var_u_on) == 1
-            @test con_u_avail === nothing
+            @test_throws KeyError var_units_on[key...]
+            @test_throws KeyError constraint_u_avail[key...]
         end
     end
 end


### PR DESCRIPTION
Recently we implemented a mechanism to skip online and outage variables based on the values of some parameters - so we don't generate variables that are not needed. This PR uses that same mechanism to implement the online_variable_type_none thing.

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted according to SpineOpt's style
- [x] Unit tests pass
