### PR TITLE
Tighten up min_scheduled_outage_duration constraint

### DIFF
--- a/src/constraints/constraint_min_scheduled_outage_duration.jl
+++ b/src/constraints/constraint_min_scheduled_outage_duration.jl
@@ -37,26 +37,34 @@ end
 
 function _build_constraint_min_scheduled_outage_duration(m::Model, u, s_path, t)
     @fetch units_out_of_service = m.ext[:spineopt].variables
+    max_sch_out_dur = maximum(
+        (
+            + scheduled_outage_duration(m; unit=u, stochastic_scenario=s, t=t)
+            * (
+                + number_of_units(m; unit=u, stochastic_scenario=s, t=t)
+                + candidate_units(m; unit=u, stochastic_scenario=s, t=t, _default=0)
+            )
+        )
+        for s in s_path
+    )
+    lowest_res = maximum(_maximum(resolution(temporal_block=tb)) for tb in units_on__temporal_block(unit=u))
+    max_err = rem(max_sch_out_dur, lowest_res)
     @build_constraint(
+        + 0
+        <=
         + sum(
             + units_out_of_service[u, s, t] * duration(t)
             for (u, s, t) in units_out_of_service_indices(m; unit=u, stochastic_scenario=s_path);
             init=0,
         )
-        >=
-        + maximum(
-            (
-                + scheduled_outage_duration(m; unit=u, stochastic_scenario=s, t=t)
-                * (
-                    + number_of_units(m; unit=u, stochastic_scenario=s, t=t)
-                    + candidate_units(m; unit=u, stochastic_scenario=s, t=t, _default=0)
-                )
-            ) / _model_duration_unit(m.ext[:spineopt].instance)(1)
-            for s in s_path;
-            init=0,
-        )
+        - (max_sch_out_dur / _model_duration_unit(m.ext[:spineopt].instance)(1))
+        <=
+        + max_err / _model_duration_unit(m.ext[:spineopt].instance)(1)
     )
 end
+
+_maximum(x::T) where T<:Vector = maximum(x)
+_maximum(x) = x
 
 """
     constraint_scheduled_outage_duration_indices(m::Model, unit, t)

--- a/src/constraints/constraint_units_out_of_service_contiguity.jl
+++ b/src/constraints/constraint_units_out_of_service_contiguity.jl
@@ -54,7 +54,7 @@ function _build_constraint_units_out_of_service_contiguity(m::Model, u, s_path, 
             );
             init=0,
         )
-        ==
+        >=
         + sum(
             units_taken_out_of_service[u, s_past, t_past] * weight
             for (u, s_past, t_past, weight) in past_units_out_of_service_indices(m, u, s_path, t)

--- a/test/constraints/constraint_unit.jl
+++ b/test/constraints/constraint_unit.jl
@@ -1044,7 +1044,6 @@ function test_constraint_units_out_of_service_contiguity()
     end
 end
 
-
 function test_constraint_min_scheduled_outage_duration()
     @testset "constraint_min_scheduled_outage_duration" begin
         model_end = Dict("type" => "date_time", "data" => "2000-01-01T05:00:00")
@@ -1068,7 +1067,11 @@ function test_constraint_min_scheduled_outage_duration()
             scenarios = [[stochastic_scenario(:parent)]; repeat([stochastic_scenario(:child)], 4)]
             time_slices = time_slice(m; temporal_block=temporal_block(:hourly))
             vars_u_oos = [var_units_out_of_service[unit(:unit_ab), s, t] for (s, t) in zip(scenarios, time_slices)]
-            expected_con = @build_constraint(sum(vars_u_oos) >= scheduled_outage_duration_minutes / 60)
+            expected_con = @build_constraint(
+                scheduled_outage_duration_minutes / 60
+                <= sum(vars_u_oos)
+                <= ceil(scheduled_outage_duration_minutes / 60)
+            )
             con_key = (unit(:unit_ab), s_path, constraint_t)
             observed_con = constraint_object(constraint[con_key...])
             @test _is_constraint_equal(observed_con, expected_con)           

--- a/test/constraints/constraint_unit.jl
+++ b/test/constraints/constraint_unit.jl
@@ -1035,7 +1035,7 @@ function test_constraint_units_out_of_service_contiguity()
                 var_u_oos_key = (unit(:unit_ab), s, t)
                 var_u_oos = var_units_out_of_service[var_u_oos_key...]
                 vars_u_toos = [var_units_taken_out_of_service[unit(:unit_ab), s, t] for (s, t) in zip(s_set, t_set)]
-                expected_con = @build_constraint(var_u_oos == sum(vars_u_toos))
+                expected_con = @build_constraint(var_u_oos >= sum(vars_u_toos))
                 con_key = (unit(:unit_ab), path, t)
                 observed_con = constraint_object(constraint[con_key...])
                 @test _is_constraint_equal(observed_con, expected_con)


### PR DESCRIPTION
We make it a range constraint so the sum of units_out_of_service over the window is greater than the scheduled outage duration but also lower than the scheduled outage duration plus the maximum error due to the temporal resolution of the unit not being able to fit exactly the scheduled outage duration.

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted according to SpineOpt's style
- [x] Unit tests pass
