### PR TITLE
Improve variable replacement expressions

### DIFF
--- a/src/benders.jl
+++ b/src/benders.jl
@@ -51,6 +51,7 @@ function _add_mp_variables!(m; log_level=3)
         name = name_from_fn(add_variable!)
         @timelog log_level 3 "- [$name]" add_variable!(m)
     end
+    _expand_replacement_expressions!(m)
 end
 
 """

--- a/src/util/misc.jl
+++ b/src/util/misc.jl
@@ -307,6 +307,15 @@ function _get_max_duration(m::Model, lookback_params::Vector{Parameter})
     reduce(max, (val for val in max_vals if val !== nothing); init=dur_unit(1))
 end
 
+function _get_var_with_replacement(m, var_name, ind)
+    get(m.ext[:spineopt].variables[var_name], ind) do
+        replacement_fn_by_var = Dict(:units_on => number_of_units, :units_out_of_service => (m; kwargs...) -> 0)
+        replacement_fn = get(replacement_fn_by_var, var_name, nothing)
+        isnothing(replacement_fn) && throw(KeyError, ind)  # FIXME
+        replacement_fn(m; ind...)
+    end
+end
+
 # Base
 _ObjectArrayLike = Union{ObjectLike,Array{T,1} where T<:ObjectLike}
 _RelationshipArrayLike{K} = NamedTuple{K,V} where {K,V<:Tuple{Vararg{_ObjectArrayLike}}}

--- a/src/variables/variable_common.jl
+++ b/src/variables/variable_common.jl
@@ -28,9 +28,16 @@ Add a variable to `m`, with given `name` and indices given by interating over `i
   - `bin::Union{Function,Nothing}=nothing`: given an index, return whether or not the variable should be binary
   - `int::Union{Function,Nothing}=nothing`: given an index, return whether or not the variable should be integer
   - `fix_value::Union{Function,Nothing}=nothing`: given an index, return a fix value for the variable or nothing
-  - `non_anticipativity_time::Union{Function,Nothing}=nothing`: given an index, return the non-anticipatity time or nothing
-  - `non_anticipativity_margin::Union{Function,Nothing}=nothing`: given an index, return the non-anticipatity margin or nothing
-  - `required_history_period::Union{Period,Nothing}=nothing`: given an index, return the required history period or nothing
+  - `non_anticipativity_time::Union{Function,Nothing}=nothing`: given an index, return the non-anticipatity time
+    or nothing
+  - `non_anticipativity_margin::Union{Function,Nothing}=nothing`: given an index, return the non-anticipatity margin
+    or nothing
+  - `required_history_period::Union{Period,Nothing}=nothing`: given an index, return the required history period
+    or nothing
+  - `replacement_expressions::Dict=Dict()`: mapping some of the indices returned by the given `indices` function,
+    to another Dict with a recipe to build an expression to use instead of the variable.
+    The recipe Dict maps variable names to a tuple of index and coefficient.
+    The expression is built as the sum of the coefficient and the variable for that index over the entire Dict.
 """
 function add_variable!(
     m::Model,
@@ -46,7 +53,7 @@ function add_variable!(
     non_anticipativity_time::Union{Parameter,Nothing}=nothing,
     non_anticipativity_margin::Union{Parameter,Nothing}=nothing,
     required_history_period::Union{Period,Nothing}=nothing,
-    ind_map=Dict(),
+    replacement_expressions=Dict(),
 )
     if required_history_period === nothing
         required_history_period = _model_duration_unit(m.ext[:spineopt].instance)(1)
@@ -54,13 +61,14 @@ function add_variable!(
     t_start = start(first(time_slice(m)))
     t_history = TimeSlice(t_start - required_history_period, t_start)
     history_time_slices = [t for t in history_time_slice(m) if overlaps(t_history, t)]
-    m.ext[:spineopt].variables_definition[name] = Dict{Symbol,Union{Function,Parameter,Vector{TimeSlice},Nothing}}(
+    m.ext[:spineopt].variables_definition[name] = Dict(
         :indices => indices,
         :bin => bin,
         :int => int,
         :non_anticipativity_time => non_anticipativity_time,
         :non_anticipativity_margin => non_anticipativity_margin,
         :history_time_slices => history_time_slices,
+        :replacement_expressions => replacement_expressions,
     )
     lb = _nothing_if_empty(lb)
     ub = _nothing_if_empty(ub)
@@ -70,25 +78,28 @@ function add_variable!(
     t = vcat(history_time_slices, time_slice(m))
     first_ind = iterate(indices(m; t=t))
     K = first_ind === nothing ? Any : typeof(first_ind[1])
-    vars = m.ext[:spineopt].variables[name] = Dict{K,Union{VariableRef,AffExpr,Call}}(
-        ind => _add_variable!(m, name, ind) for ind in indices(m; t=t) if !haskey(ind_map, ind)
+    V = Union{VariableRef,GenericAffExpr{T,VariableRef} where T<:Union{Number,Call}}
+    vars = m.ext[:spineopt].variables[name] = Dict{K,V}(
+        ind => _add_variable!(m, name, ind) for ind in indices(m; t=t) if !haskey(replacement_expressions, ind)
     )
-    inverse_ind_map = Dict(ref_ind => (ind, 1 / coeff) for (ind, (ref_ind, coeff)) in ind_map)
+    inverse_replacement_expressions = Dict(
+        ref_ind => (ind, 1 / coeff)
+        for (ind, (ref_ind, coeff)) in ((ind, ref[name]) for (ind, ref) in replacement_expressions)
+    )
     Threads.@threads for ind in collect(keys(vars))
         # Resolve bin, int, lb, ub, fix_value and internal_fix_value for ind.
-        # If we have an ind_map, then we need to combine any values given for the ind and its referrer.
+        # If we have an replacement_expressions, then we need to combine any values given for the ind and its referrer.
         # For example, for the lower bound we need to take the maximum between the lower bound for ind,
         # and the lower bound for the referrer scaled by the appropriate factor.
-        other_ind_and_factor = get(inverse_ind_map, ind, ())
-        res_bin = _resolve(bin, ind, other_ind_and_factor...; default=false, reducer=any)
-        res_int = _resolve(int, ind, other_ind_and_factor...; default=false, reducer=any)
-        res_lb = _resolve(lb, m, ind, other_ind_and_factor...; reducer=max)
-        res_ub = _resolve(ub, m, ind, other_ind_and_factor...; reducer=min)
-        res_fix_value = _resolve(fix_value, m, ind, other_ind_and_factor...; reducer=_check_unique)
-        res_internal_fix_value = _resolve(internal_fix_value, m, ind, other_ind_and_factor...; reducer=_check_unique)
+        expression = get(inverse_replacement_expressions, ind, ())
+        res_bin = _resolve(bin, ind, expression...; default=false, reducer=any)
+        res_int = _resolve(int, ind, expression...; default=false, reducer=any)
+        res_lb = _resolve(lb, m, ind, expression...; reducer=max)
+        res_ub = _resolve(ub, m, ind, expression...; reducer=min)
+        res_fix_value = _resolve(fix_value, m, ind, expression...; reducer=_check_unique)
+        res_internal_fix_value = _resolve(internal_fix_value, m, ind, expression...; reducer=_check_unique)
         _finalize_variable!(vars[ind], res_bin, res_int, res_lb, res_ub, res_fix_value, res_internal_fix_value)
     end
-    merge!(vars, Dict(ind => coeff * vars[ref_ind] for (ind, (ref_ind, coeff)) in ind_map))
     # Apply initial value, but make sure it updates itself by using a TimeSeries Call
     if initial_value !== nothing
         last_history_t = last(history_time_slice(m))

--- a/src/variables/variable_unit_flow.jl
+++ b/src/variables/variable_unit_flow.jl
@@ -61,9 +61,8 @@ end
 
 function _fix_ratio_out_in_unit_flow_simple(u, n1, n2, fix_ratio)
     fix_ratio in (fix_ratio_out_in_unit_flow, fix_ratio_in_out_unit_flow) || return nothing
-    (_similar(n1, n2) && iszero(units_on_coefficient(unit=u, node1=n1, node2=n2, _default=0))) || return nothing
-    ratio = fix_ratio(unit=u, node1=n1, node2=n2, _strict=false)
-    ratio isa Number && return ratio
+    _similar(n1, n2) || return nothing
+    fix_ratio(unit=u, node1=n1, node2=n2, _strict=false)
 end
 
 """
@@ -73,9 +72,12 @@ Add `unit_flow` variables to model `m`.
 """
 function add_variable_unit_flow!(m::Model)
     d_to, d_from = direction(:to_node), direction(:from_node)
-    ind_map = Dict(
-        (unit=u, node=n1, direction=d1, stochastic_scenario=s, t=t) => (
-            (unit=u, node=n2, direction=d2, stochastic_scenario=s, t=t), ratio
+    replacement_expressions = Dict(
+        (unit=u, node=n1, direction=d1, stochastic_scenario=s, t=t) => Dict(
+            :unit_flow => ((unit=u, node=n2, direction=d2, stochastic_scenario=s, t=t), ratio),
+            :units_on => (
+                (unit=u, stochastic_scenario=s, t=t), units_on_coefficient(unit=u, node1=n1, node2=n2, _default=0)
+            ),
         )
         for (u, n1, d1, n2, d2, ratio) in Iterators.flatten(
             (
@@ -102,6 +104,6 @@ function add_variable_unit_flow!(m::Model)
         initial_value=initial_unit_flow,
         non_anticipativity_time=unit_flow_non_anticipativity_time,
         non_anticipativity_margin=unit_flow_non_anticipativity_margin,
-        ind_map=ind_map,
+        replacement_expressions=replacement_expressions,
     )
 end

--- a/test/constraints/constraint_connection.jl
+++ b/test/constraints/constraint_connection.jl
@@ -1684,48 +1684,6 @@ function test_constraint_candidate_connection_ub()
     end
 end
 
-function test_connection_history_parameters()
-    @testset "constraint_connection_lifetime" begin
-        flow_ratio = 0.8
-        conn_flow_minutes_delay = 180
-        lifetime_minutes = 240
-        candidate_connections = 3
-        model_end = Dict("type" => "date_time", "data" => "2000-01-01T05:00:00")
-
-        url_in = _test_constraint_connection_setup()
-        connection_investment_lifetime = Dict("type" => "duration", "data" => string(lifetime_minutes, "m"))
-        connection_flow_delay = Dict("type" => "duration", "data" => string(conn_flow_minutes_delay, "m"))
-        object_parameter_values = [
-            ["connection", "connection_ab", "candidate_connections", candidate_connections],
-            ["connection", "connection_ab", "connection_investment_lifetime", connection_investment_lifetime],
-            ["model", "instance", "model_end", model_end],
-        ]
-        relationships = [
-            ["connection__investment_temporal_block", ["connection_ab", "hourly"]],
-            ["connection__investment_stochastic_structure", ["connection_ab", "stochastic"]],
-            ["connection__node__node", ["connection_ab", "node_b", "node_a"]],
-        ]
-        relationship_parameter_values = [
-            ["connection__node__node", ["connection_ab", "node_b", "node_a"], "connection_flow_delay", connection_flow_delay],
-            ["connection__node__node", ["connection_ab", "node_b", "node_a"], "fix_ratio_out_in_connection_flow", flow_ratio],
-        ]
-        SpineInterface.import_data(
-            url_in;
-            relationships=relationships,
-            object_parameter_values=object_parameter_values,
-            relationship_parameter_values=relationship_parameter_values,
-        )
-        m = run_spineopt(url_in; log_level=0, optimize=false)
-        var_connection_flow = m.ext[:spineopt].variables[:connection_flow]
-        var_connections_invested_available = m.ext[:spineopt].variables[:connections_invested_available]
-        var_connections_invested = m.ext[:spineopt].variables[:connections_invested]
-        
-        @test length(var_connection_flow) == 42
-        @test length(var_connections_invested_available) == 9
-        @test length(var_connections_invested) == 9
-    end
-end
-
 @testset "connection-based constraints" begin
     test_constraint_connection_flow_capacity()
     test_constraint_connection_flow_capacity_bidirectional()
@@ -1748,5 +1706,4 @@ end
     test_constraint_candidate_connection_lb()
     test_constraint_ratio_out_in_connection_intact_flow()
     test_constraint_candidate_connection_ub()
-    test_connection_history_parameters()
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -143,6 +143,7 @@ end
     include("constraints/constraint_user_constraint.jl")
     include("constraints/constraint_investment_group.jl")
     include("objective/objective.jl")
+    include("variables/variables.jl")
     include("util/misc.jl")
     include("run_spineopt.jl")
     include("run_spineopt_benders.jl")

--- a/test/variables/variables.jl
+++ b/test/variables/variables.jl
@@ -1,0 +1,303 @@
+#############################################################################
+# Copyright (C) 2017 - 2018  Spine Project
+#
+# This file is part of SpineOpt.
+#
+# SpineOpt is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# SpineOpt is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#############################################################################
+
+function _test_variable_unit_setup()
+    url_in = "sqlite://"
+    test_data = Dict(
+        :objects => [
+            ["model", "instance"],
+            ["temporal_block", "hourly"],
+            ["temporal_block", "investments_hourly"],
+            ["temporal_block", "two_hourly"],
+            ["stochastic_structure", "deterministic"],
+            ["stochastic_structure", "investments_deterministic"],
+            ["stochastic_structure", "stochastic"],
+            ["unit", "unit_ab"],
+            ["node", "node_a"],
+            ["node", "node_b"],
+            ["node", "node_c"],
+            ["node", "node_group_bc"],
+            ["stochastic_scenario", "parent"],
+            ["stochastic_scenario", "child"],
+        ],
+        :relationships => [
+            ["model__temporal_block", ["instance", "hourly"]],
+            ["model__temporal_block", ["instance", "investments_hourly"]],
+            ["model__temporal_block", ["instance", "two_hourly"]],
+            ["model__stochastic_structure", ["instance", "deterministic"]],
+            ["model__stochastic_structure", ["instance", "investments_deterministic"]],
+            ["model__stochastic_structure", ["instance", "stochastic"]],
+            ["units_on__temporal_block", ["unit_ab", "hourly"]],
+            ["units_on__stochastic_structure", ["unit_ab", "stochastic"]],
+            ["unit__from_node", ["unit_ab", "node_a"]],
+            ["unit__to_node", ["unit_ab", "node_b"]],
+            ["unit__to_node", ["unit_ab", "node_c"]],
+            ["node__temporal_block", ["node_a", "hourly"]],
+            ["node__temporal_block", ["node_b", "two_hourly"]],
+            ["node__temporal_block", ["node_c", "hourly"]],
+            ["node__stochastic_structure", ["node_a", "stochastic"]],
+            ["node__stochastic_structure", ["node_b", "deterministic"]],
+            ["node__stochastic_structure", ["node_c", "stochastic"]],
+            ["stochastic_structure__stochastic_scenario", ["deterministic", "parent"]],
+            ["stochastic_structure__stochastic_scenario", ["investments_deterministic", "parent"]],
+            ["stochastic_structure__stochastic_scenario", ["stochastic", "parent"]],
+            ["stochastic_structure__stochastic_scenario", ["stochastic", "child"]],
+            ["parent_stochastic_scenario__child_stochastic_scenario", ["parent", "child"]],
+        ],
+        :object_groups => [["node", "node_group_bc", "node_b"], ["node", "node_group_bc", "node_c"]],
+        :object_parameter_values => [
+            ["model", "instance", "model_start", Dict("type" => "date_time", "data" => "2000-01-01T00:00:00")],
+            ["model", "instance", "model_end", Dict("type" => "date_time", "data" => "2000-01-01T02:00:00")],
+            ["model", "instance", "duration_unit", "hour"],
+            ["model", "instance", "model_type", "spineopt_standard"],
+            ["model", "instance", "max_gap", "0.05"],
+            ["model", "instance", "max_iterations", "2"],
+            ["temporal_block", "hourly", "resolution", Dict("type" => "duration", "data" => "1h")],
+            ["temporal_block", "investments_hourly", "resolution", Dict("type" => "duration", "data" => "1h")],
+            ["temporal_block", "two_hourly", "resolution", Dict("type" => "duration", "data" => "2h")],
+            ["model", "instance", "db_mip_solver", "HiGHS.jl"],
+            ["model", "instance", "db_lp_solver", "HiGHS.jl"],
+            ["unit", "unit_ab", "units_on_cost", 1],  # Just to have units_on variables
+        ],
+        :relationship_parameter_values => [
+            [
+                "stochastic_structure__stochastic_scenario",
+                ["stochastic", "parent"],
+                "stochastic_scenario_end",
+                Dict("type" => "duration", "data" => "1h"),
+            ]
+        ],
+    )
+    _load_test_data(url_in, test_data)
+    url_in
+end
+
+function _test_variable_connection_setup()
+    url_in = "sqlite://"
+    test_data = Dict(
+        :objects => [
+            ["model", "instance"],
+            ["temporal_block", "hourly"],
+            ["temporal_block", "investments_hourly"],
+            ["temporal_block", "two_hourly"],
+            ["stochastic_structure", "deterministic"],
+            ["stochastic_structure", "investments_deterministic"],
+            ["stochastic_structure", "stochastic"],
+            ["connection", "connection_ab"],
+            ["connection", "connection_bc"],
+            ["connection", "connection_ca"],
+            ["node", "node_a"],
+            ["node", "node_b"],
+            ["node", "node_c"],
+            ["stochastic_scenario", "parent"],
+            ["stochastic_scenario", "child"],
+        ],
+        :relationships => [
+            ["model__temporal_block", ["instance", "hourly"]],
+            ["model__temporal_block", ["instance", "two_hourly"]],
+            ["model__temporal_block", ["instance", "investments_hourly"]],
+            ["model__stochastic_structure", ["instance", "deterministic"]],
+            ["model__stochastic_structure", ["instance", "stochastic"]],
+            ["model__stochastic_structure", ["instance", "investments_deterministic"]],
+            ["connection__from_node", ["connection_ab", "node_a"]],
+            ["connection__to_node", ["connection_ab", "node_b"]],
+            ["connection__from_node", ["connection_bc", "node_b"]],
+            ["connection__to_node", ["connection_bc", "node_c"]],
+            ["connection__from_node", ["connection_ca", "node_c"]],
+            ["connection__to_node", ["connection_ca", "node_a"]],
+            ["node__temporal_block", ["node_a", "hourly"]],
+            ["node__temporal_block", ["node_b", "two_hourly"]],
+            ["node__temporal_block", ["node_c", "hourly"]],
+            ["node__stochastic_structure", ["node_a", "stochastic"]],
+            ["node__stochastic_structure", ["node_b", "deterministic"]],
+            ["node__stochastic_structure", ["node_c", "stochastic"]],
+            ["stochastic_structure__stochastic_scenario", ["deterministic", "parent"]],
+            ["stochastic_structure__stochastic_scenario", ["stochastic", "parent"]],
+            ["stochastic_structure__stochastic_scenario", ["stochastic", "child"]],
+            ["stochastic_structure__stochastic_scenario", ["investments_deterministic", "parent"]],
+            ["parent_stochastic_scenario__child_stochastic_scenario", ["parent", "child"]],
+        ],
+        :object_parameter_values => [
+            ["model", "instance", "model_start", Dict("type" => "date_time", "data" => "2000-01-01T00:00:00")],
+            ["model", "instance", "model_end", Dict("type" => "date_time", "data" => "2000-01-01T02:00:00")],
+            ["model", "instance", "duration_unit", "hour"],
+            ["model", "instance", "model_type", "spineopt_standard"],
+            ["model", "instance", "max_gap", "0.05"],
+            ["model", "instance", "max_iterations", "2"],
+            ["temporal_block", "hourly", "resolution", Dict("type" => "duration", "data" => "1h")],
+            ["temporal_block", "two_hourly", "resolution", Dict("type" => "duration", "data" => "2h")],
+            ["model", "instance", "db_mip_solver", "HiGHS.jl"],
+            ["model", "instance", "db_lp_solver", "HiGHS.jl"],
+        ],
+        :relationship_parameter_values => [
+            [
+                "stochastic_structure__stochastic_scenario",
+                ["stochastic", "parent"],
+                "stochastic_scenario_end",
+                Dict("type" => "duration", "data" => "1h")
+            ]
+        ],
+    )
+    _load_test_data(url_in, test_data)
+    url_in
+end
+
+function test_initial_units_on()
+    @testset "initial_units_on" begin
+        url_in = _test_variable_unit_setup()
+        init_units_on = 123
+        object_parameter_values = [
+            ["unit", "unit_ab", "initial_units_on", init_units_on],
+            ["model", "instance", "roll_forward", unparse_db_value(Hour(1))],
+        ]
+        SpineInterface.import_data(url_in; object_parameter_values=object_parameter_values)
+        m = run_spineopt(url_in; log_level=0, optimize=false)
+        var_units_on = m.ext[:spineopt].variables[:units_on]
+        for key in keys(var_units_on)
+            is_history_t = start(key.t) < model_start(model=m.ext[:spineopt].instance)
+            @test is_fixed(var_units_on[key]) == is_history_t
+            if is_history_t
+                @test fix_value(var_units_on[key]) == init_units_on
+            end
+        end
+    end
+end
+
+function test_unit_online_variable_type_none()
+    @testset "unit_online_variable_type_none" begin
+        url_in = _test_variable_unit_setup()
+        unit_availability_factor = 0.5
+        object_parameter_values = [
+            ["unit", "unit_ab", "unit_availability_factor", unit_availability_factor],
+            ["unit", "unit_ab", "online_variable_type", "unit_online_variable_type_none"],
+            ["model", "instance", "roll_forward", unparse_db_value(Hour(1))],
+        ]
+        SpineInterface.import_data(url_in; object_parameter_values=object_parameter_values)
+        m = run_spineopt(url_in; log_level=0, optimize=true)
+        var_units_on = m.ext[:spineopt].variables[:units_on]
+        constraint_u_avail = m.ext[:spineopt].constraints[:units_available]
+        scenarios = (stochastic_scenario(:parent), stochastic_scenario(:child))
+        time_slices = time_slice(m; temporal_block=temporal_block(:hourly))
+        @testset for (s, t) in zip(scenarios, time_slices)
+            key = (unit(:unit_ab), s, t)
+            @test_throws KeyError var_units_on[key...]
+            @test_throws KeyError constraint_u_avail[key...]
+        end
+    end
+end
+
+function test_unit_history_parameters()
+    @testset "unit_history_parameters" begin
+        min_up_minutes = 120
+        min_down_minutes = 180
+        scheduled_outage_duration_minutes = 60
+        lifetime_minutes = 240
+        candidate_units = 3
+        
+        url_in = _test_variable_unit_setup()
+        model_end = Dict("type" => "date_time", "data" => "2000-01-01T05:00:00")
+        min_up_time = Dict("type" => "duration", "data" => string(min_up_minutes, "m"))
+        min_down_time = Dict("type" => "duration", "data" => string(min_down_minutes, "m"))
+        scheduled_outage_duration = Dict("type" => "duration", "data" => string(scheduled_outage_duration_minutes, "m"))
+        unit_investment_lifetime = Dict("type" => "duration", "data" => string(lifetime_minutes, "m"))
+        object_parameter_values = [
+            ["unit", "unit_ab", "min_up_time", min_up_time],
+            ["unit", "unit_ab", "min_down_time", min_down_time],
+            ["unit", "unit_ab", "candidate_units", candidate_units],
+            ["unit", "unit_ab", "scheduled_outage_duration", scheduled_outage_duration],
+            ["unit", "unit_ab", "outage_variable_type", "unit_online_variable_type_integer"],
+            ["unit", "unit_ab", "unit_investment_lifetime", unit_investment_lifetime],
+            ["model", "instance", "model_end", model_end],
+        ]
+        relationships = [
+            ["unit__investment_temporal_block", ["unit_ab", "hourly"]],
+            ["unit__investment_stochastic_structure", ["unit_ab", "stochastic"]],
+        ]
+        SpineInterface.import_data(
+            url_in; relationships=relationships, object_parameter_values=object_parameter_values
+        )
+        m = run_spineopt(url_in; log_level=0, optimize=false)
+
+        var_units_on = m.ext[:spineopt].variables[:units_on]
+        var_units_started_up = m.ext[:spineopt].variables[:units_started_up]
+        var_units_shut_down = m.ext[:spineopt].variables[:units_shut_down]
+        var_units_out_of_service = m.ext[:spineopt].variables[:units_out_of_service]
+        var_units_taken_out_of_service = m.ext[:spineopt].variables[:units_taken_out_of_service]
+        var_units_invested_available = m.ext[:spineopt].variables[:units_invested_available]
+        var_units_invested = m.ext[:spineopt].variables[:units_invested]
+        
+        @test length(var_units_on) == 8
+        @test length(var_units_started_up) == 7
+        @test length(var_units_shut_down) == 8
+        @test length(var_units_out_of_service) == 6
+        @test length(var_units_taken_out_of_service) == 6
+        @test length(var_units_invested_available) == 9
+        @test length(var_units_invested) == 9
+
+    end
+end
+
+function test_connection_history_parameters()
+    @testset "constraint_connection_lifetime" begin
+        flow_ratio = 0.8
+        conn_flow_minutes_delay = 180
+        lifetime_minutes = 240
+        candidate_connections = 3
+        model_end = Dict("type" => "date_time", "data" => "2000-01-01T05:00:00")
+
+        url_in = _test_variable_connection_setup()
+        connection_investment_lifetime = Dict("type" => "duration", "data" => string(lifetime_minutes, "m"))
+        connection_flow_delay = Dict("type" => "duration", "data" => string(conn_flow_minutes_delay, "m"))
+        object_parameter_values = [
+            ["connection", "connection_ab", "candidate_connections", candidate_connections],
+            ["connection", "connection_ab", "connection_investment_lifetime", connection_investment_lifetime],
+            ["model", "instance", "model_end", model_end],
+        ]
+        relationships = [
+            ["connection__investment_temporal_block", ["connection_ab", "hourly"]],
+            ["connection__investment_stochastic_structure", ["connection_ab", "stochastic"]],
+            ["connection__node__node", ["connection_ab", "node_b", "node_a"]],
+        ]
+        relationship_parameter_values = [
+            ["connection__node__node", ["connection_ab", "node_b", "node_a"], "connection_flow_delay", connection_flow_delay],
+            ["connection__node__node", ["connection_ab", "node_b", "node_a"], "fix_ratio_out_in_connection_flow", flow_ratio],
+        ]
+        SpineInterface.import_data(
+            url_in;
+            relationships=relationships,
+            object_parameter_values=object_parameter_values,
+            relationship_parameter_values=relationship_parameter_values,
+        )
+        m = run_spineopt(url_in; log_level=0, optimize=false)
+        var_connection_flow = m.ext[:spineopt].variables[:connection_flow]
+        var_connections_invested_available = m.ext[:spineopt].variables[:connections_invested_available]
+        var_connections_invested = m.ext[:spineopt].variables[:connections_invested]
+        
+        @test length(var_connection_flow) == 42
+        @test length(var_connections_invested_available) == 9
+        @test length(var_connections_invested) == 9
+    end
+end
+
+@testset "unit-based constraints" begin
+    test_initial_units_on()
+    test_unit_online_variable_type_none()
+    test_unit_history_parameters()
+    test_connection_history_parameters()
+end


### PR DESCRIPTION
This PR refactors the variable replacement expressions functionality so expressions can combine different variables.

The idea is to have have `unit_flow[from node] = fix_ratio * unit_flow[to node] + units_on_coefficient * units_on`

## Checklist before merging
- [ ] Documentation is up-to-date
- [ ] Unit tests have been added/updated accordingly
- [ ] Code has been formatted according to SpineOpt's style
- [ ] Unit tests pass
