### PR TITLE
create units_started_up and units_shut_down variables for ramping cases

### DIFF
--- a/src/data_structure/preprocess_data_structure.jl
+++ b/src/data_structure/preprocess_data_structure.jl
@@ -945,6 +945,10 @@ function generate_unit_commitment_parameters()
             indices(shut_down_cost), 
             (x.unit for x in indices(start_up_limit)),
             (x.unit for x in indices(shut_down_limit)),
+            # ramp_up constraint needs units_started_up variable to avoid being infeasible 
+            (x.unit for x in indices(ramp_up_limit)),
+            # ramp_down constraint needs units_shut_down variable to avoid being infeasible 
+            (x.unit for x in indices(ramp_down_limit)),
             (x.unit for x in indices(unit_start_flow) if unit_start_flow(; x...) != 0),
             (x.unit for x in indices(units_started_up_coefficient) if units_started_up_coefficient(; x...) != 0),
         )
@@ -956,8 +960,6 @@ function generate_unit_commitment_parameters()
             indices(units_on_non_anticipativity_time),
             # In investment mode, the model needs units_on to formulate available units (constraint_units_available).
             (u for u in indices(candidate_units) if candidate_units(unit=u) > 0),
-            (x.unit for x in indices(ramp_up_limit)),
-            (x.unit for x in indices(ramp_down_limit)),
             (x.unit for x in indices(units_on_coefficient) if units_on_coefficient(; x...) != 0),
             (x.unit for x in indices(minimum_operating_point) if minimum_operating_point(; x...) != 0),
             # The variable units_on is by default linear.


### PR DESCRIPTION
In cases where the user uses the "ramp_up/down_limit" (e.g., issue #1029 ), the `ramp_up` or `ramp_down` constraint needs, respectively, the `units_started_up` or `units_shut_down` variables. Otherwise, the model may become infeasible. However, the variables are not always activated in such cases unless the user specifies the dedicated parameters.

## Checklist before merging
- [ ] Documentation is up-to-date
- [ ] Unit tests have been added/updated accordingly
- [ ] Code has been formatted according to SpineOpt's style
- [ ] Unit tests pass
