### PR TITLE
Start flow

### DIFF
--- a/src/constraints/constraint_ratio_unit_flow.jl
+++ b/src/constraints/constraint_ratio_unit_flow.jl
@@ -62,18 +62,22 @@ exist for the other 11 cases described above.
 
 See also [fix\_ratio\_out\_in\_unit\_flow](@ref), [fix\_units\_on\_coefficient\_out\_in](@ref).
 """
-function add_constraint_ratio_unit_flow!(m::Model, ratio, units_on_coeff, sense, d1, d2)
+function add_constraint_ratio_unit_flow!(m::Model, ratio)
     _add_constraint!(
         m,
         ratio.name,
-        m -> constraint_ratio_unit_flow_indices(m, ratio, d1, d2),
-        (m, ind...) -> _build_constraint_ratio_unit_flow(m, ind..., ratio, units_on_coeff, sense, d1, d2),
+        m -> constraint_ratio_unit_flow_indices(m, ratio),
+        (m, ind...) -> _build_constraint_ratio_unit_flow(m, ind..., ratio),
     )
 end
 
-function _build_constraint_ratio_unit_flow(m::Model, u, ng1, ng2, s_path, t, ratio, units_on_coeff, sense, d1, d2)
+function _build_constraint_ratio_unit_flow(m::Model, u, ng1, ng2, s_path, t, ratio)
     # NOTE: that the `<sense>_ratio_<directions>_unit_flow` parameter uses the stochastic dimensions of the second
     # <direction>!
+    d1, d2 = _ratio_to_d1_d2(ratio)
+    sense = _ratio_to_sense(ratio)
+    units_on_coeff = _ratio_to_units_on_coeff(ratio)
+    start_flow_sign = _ratio_to_start_flow_sign(ratio)
     @fetch unit_flow = m.ext[:spineopt].variables
     build_sense_constraint(
         + sum(
@@ -94,6 +98,10 @@ function _build_constraint_ratio_unit_flow(m::Model, u, ng1, ng2, s_path, t, rat
             _get_units_on(m, u, s, t1)
             * min(duration(t1), duration(t))
             * units_on_coeff(m; unit=u, node1=ng1, node2=ng2, stochastic_scenario=s, t=t)
+            + start_flow_sign
+            * _get_units_started_up(m, u, s, t1)
+            * min(duration(t1), duration(t))
+            * unit_start_flow(m; unit=u, node1=ng1, node2=ng2, stochastic_scenario=s, t=t)
             for (u, s, t1) in unit_stochastic_time_indices(
                 m; unit=u, stochastic_scenario=s_path, t=t_overlaps_t(m; t=t)
             );
@@ -108,9 +116,7 @@ end
 Call `add_constraint_ratio_unit_flow!` with the appropriate parameter and `directions`.
 """
 function add_constraint_fix_ratio_out_in_unit_flow!(m::Model)
-    add_constraint_ratio_unit_flow!(
-        m, fix_ratio_out_in_unit_flow, fix_units_on_coefficient_out_in, ==, direction(:to_node), direction(:from_node)
-    )
+    add_constraint_ratio_unit_flow!(m, fix_ratio_out_in_unit_flow)
 end
 
 """
@@ -119,9 +125,7 @@ end
 Call `add_constraint_ratio_unit_flow!` with the appropriate parameter and `directions`.
 """
 function add_constraint_max_ratio_out_in_unit_flow!(m::Model)
-    add_constraint_ratio_unit_flow!(
-        m, max_ratio_out_in_unit_flow, max_units_on_coefficient_out_in, <=, direction(:to_node), direction(:from_node)
-    )
+    add_constraint_ratio_unit_flow!(m, max_ratio_out_in_unit_flow)
 end
 
 """
@@ -130,9 +134,7 @@ end
 Call `add_constraint_ratio_unit_flow!` with the appropriate parameter and `directions`.
 """
 function add_constraint_min_ratio_out_in_unit_flow!(m::Model)
-    add_constraint_ratio_unit_flow!(
-        m, min_ratio_out_in_unit_flow, min_units_on_coefficient_out_in, >=, direction(:to_node), direction(:from_node)
-    )
+    add_constraint_ratio_unit_flow!(m, min_ratio_out_in_unit_flow)
 end
 
 """
@@ -141,9 +143,7 @@ end
 Call `add_constraint_ratio_unit_flow!` with the appropriate parameter and `directions`.
 """
 function add_constraint_fix_ratio_in_in_unit_flow!(m::Model)
-    add_constraint_ratio_unit_flow!(
-        m, fix_ratio_in_in_unit_flow, fix_units_on_coefficient_in_in, ==, direction(:from_node), direction(:from_node)
-    )
+    add_constraint_ratio_unit_flow!(m, fix_ratio_in_in_unit_flow)
 end
 
 """
@@ -152,9 +152,7 @@ end
 Call `add_constraint_ratio_unit_flow!` with the appropriate parameter and `directions`.
 """
 function add_constraint_max_ratio_in_in_unit_flow!(m::Model)
-    add_constraint_ratio_unit_flow!(
-        m, max_ratio_in_in_unit_flow, max_units_on_coefficient_in_in, <=, direction(:from_node), direction(:from_node)
-    )
+    add_constraint_ratio_unit_flow!(m, max_ratio_in_in_unit_flow)
 end
 
 """
@@ -163,9 +161,7 @@ end
 Call `add_constraint_ratio_unit_flow!` with the appropriate parameter and `directions`.
 """
 function add_constraint_min_ratio_in_in_unit_flow!(m::Model)
-    add_constraint_ratio_unit_flow!(
-        m, min_ratio_in_in_unit_flow, min_units_on_coefficient_in_in, >=, direction(:from_node), direction(:from_node)
-    )
+    add_constraint_ratio_unit_flow!(m, min_ratio_in_in_unit_flow)
 end
 
 """
@@ -174,9 +170,7 @@ end
 Call `add_constraint_ratio_unit_flow!` with the appropriate parameter and `directions`.
 """
 function add_constraint_fix_ratio_out_out_unit_flow!(m::Model)
-    add_constraint_ratio_unit_flow!(
-        m, fix_ratio_out_out_unit_flow, fix_units_on_coefficient_out_out, ==, direction(:to_node), direction(:to_node)
-    )
+    add_constraint_ratio_unit_flow!(m, fix_ratio_out_out_unit_flow)
 end
 
 """
@@ -185,9 +179,7 @@ end
 Call `add_constraint_ratio_unit_flow!` with the appropriate parameter and `directions`.
 """
 function add_constraint_max_ratio_out_out_unit_flow!(m::Model)
-    add_constraint_ratio_unit_flow!(
-        m, max_ratio_out_out_unit_flow, max_units_on_coefficient_out_out, <=, direction(:to_node), direction(:to_node)
-    )
+    add_constraint_ratio_unit_flow!(m, max_ratio_out_out_unit_flow)
 end
 
 """
@@ -196,9 +188,7 @@ end
 Call `add_constraint_ratio_unit_flow!` with the appropriate parameter and `directions`.
 """
 function add_constraint_min_ratio_out_out_unit_flow!(m::Model)
-    add_constraint_ratio_unit_flow!(
-        m, min_ratio_out_out_unit_flow, min_units_on_coefficient_out_out, >=, direction(:to_node), direction(:to_node)
-    )
+    add_constraint_ratio_unit_flow!(m, min_ratio_out_out_unit_flow)
 end
 
 """
@@ -207,9 +197,7 @@ end
 Call `add_constraint_ratio_unit_flow!` with the appropriate parameter and `directions`.
 """
 function add_constraint_fix_ratio_in_out_unit_flow!(m::Model)
-    add_constraint_ratio_unit_flow!(
-        m, fix_ratio_in_out_unit_flow, fix_units_on_coefficient_in_out, ==, direction(:from_node), direction(:to_node)
-    )
+    add_constraint_ratio_unit_flow!(m, fix_ratio_in_out_unit_flow)
 end
 
 """
@@ -218,9 +206,7 @@ end
 Call `add_constraint_ratio_unit_flow!` with the appropriate parameter and `directions`.
 """
 function add_constraint_max_ratio_in_out_unit_flow!(m::Model)
-    add_constraint_ratio_unit_flow!(
-        m, max_ratio_in_out_unit_flow, max_units_on_coefficient_in_out, <=, direction(:from_node), direction(:to_node)
-    )
+    add_constraint_ratio_unit_flow!(m, max_ratio_in_out_unit_flow)
 end
 
 """
@@ -229,12 +215,11 @@ end
 Call `add_constraint_ratio_unit_flow!` with the appropriate parameter and `directions`.
 """
 function add_constraint_min_ratio_in_out_unit_flow!(m::Model)
-    add_constraint_ratio_unit_flow!(
-        m, min_ratio_in_out_unit_flow, min_units_on_coefficient_in_out, >=, direction(:from_node), direction(:to_node)
-    )
+    add_constraint_ratio_unit_flow!(m, min_ratio_in_out_unit_flow)
 end
 
-function constraint_ratio_unit_flow_indices(m::Model, ratio, d1, d2)
+function constraint_ratio_unit_flow_indices(m::Model, ratio)
+    d1, d2 = _ratio_to_d1_d2(ratio)
     (
         (unit=u, node1=n1, node2=n2, stochastic_path=path, t=t)
         for (u, n1, n2) in indices(ratio)
@@ -247,6 +232,61 @@ function constraint_ratio_unit_flow_indices(m::Model, ratio, d1, d2)
             units_on_indices(m; unit=u),
         )
     )
+end
+
+function _ratio_to_units_on_coeff(ratio)
+    Dict(
+        fix_ratio_out_in_unit_flow => fix_units_on_coefficient_out_in,
+        max_ratio_out_in_unit_flow => max_units_on_coefficient_out_in,
+        min_ratio_out_in_unit_flow => min_units_on_coefficient_out_in,
+        fix_ratio_in_in_unit_flow => fix_units_on_coefficient_in_in,
+        max_ratio_in_in_unit_flow => max_units_on_coefficient_in_in,
+        min_ratio_in_in_unit_flow => min_units_on_coefficient_in_in,
+        fix_ratio_out_out_unit_flow => fix_units_on_coefficient_out_out,
+        max_ratio_out_out_unit_flow => max_units_on_coefficient_out_out,
+        min_ratio_out_out_unit_flow => min_units_on_coefficient_out_out,
+        fix_ratio_in_out_unit_flow => fix_units_on_coefficient_in_out,
+        max_ratio_in_out_unit_flow => max_units_on_coefficient_in_out,
+        min_ratio_in_out_unit_flow => min_units_on_coefficient_in_out,
+    )[ratio]
+end
+
+function _ratio_to_d1_d2(ratio)
+    Dict(
+        fix_ratio_out_in_unit_flow => (direction(:to_node), direction(:from_node), ==),
+        max_ratio_out_in_unit_flow => (direction(:to_node), direction(:from_node), <=),
+        min_ratio_out_in_unit_flow => (direction(:to_node), direction(:from_node), >=),
+        fix_ratio_in_in_unit_flow => (direction(:from_node), direction(:from_node), ==),
+        max_ratio_in_in_unit_flow => (direction(:from_node), direction(:from_node), <=),
+        min_ratio_in_in_unit_flow => (direction(:from_node), direction(:from_node), >=),
+        fix_ratio_out_out_unit_flow => (direction(:to_node), direction(:to_node), ==),
+        max_ratio_out_out_unit_flow => (direction(:to_node), direction(:to_node), <=),
+        min_ratio_out_out_unit_flow => (direction(:to_node), direction(:to_node), >=),
+        fix_ratio_in_out_unit_flow => (direction(:from_node), direction(:to_node), ==),
+        max_ratio_in_out_unit_flow => (direction(:from_node), direction(:to_node), <=),
+        min_ratio_in_out_unit_flow => (direction(:from_node), direction(:to_node), >=),
+    )[ratio]
+end
+
+function _ratio_to_sense(ratio)
+    Dict(
+        fix_ratio_out_in_unit_flow => ==,
+        max_ratio_out_in_unit_flow => <=,
+        min_ratio_out_in_unit_flow => >=,
+        fix_ratio_in_in_unit_flow => ==,
+        max_ratio_in_in_unit_flow => <=,
+        min_ratio_in_in_unit_flow => >=,
+        fix_ratio_out_out_unit_flow => ==,
+        max_ratio_out_out_unit_flow => <=,
+        min_ratio_out_out_unit_flow => >=,
+        fix_ratio_in_out_unit_flow => ==,
+        max_ratio_in_out_unit_flow => <=,
+        min_ratio_in_out_unit_flow => >=,
+    )[ratio]
+end
+
+function _ratio_to_start_flow_sign(ratio)
+    get(Dict(fix_ratio_out_in_unit_flow => -1, fix_ratio_in_out_unit_flow => 1), ratio, 0)
 end
 
 """

--- a/src/util/misc.jl
+++ b/src/util/misc.jl
@@ -309,10 +309,14 @@ end
 
 function _get_var_with_replacement(m, var_name, ind)
     get(m.ext[:spineopt].variables[var_name], ind) do
-        replacement_fn_by_var = Dict(:units_on => number_of_units, :units_out_of_service => (m; kwargs...) -> 0)
-        replacement_fn = get(replacement_fn_by_var, var_name, nothing)
-        isnothing(replacement_fn) && throw(KeyError(ind))
-        replacement_fn(m; ind...)
+        get_var_by_name = Dict(
+            :units_on => _get_units_on,
+            :units_out_of_service => _get_units_out_of_service,
+            :units_started_up => _get_units_started_up,
+        )
+        get_var = get(get_var_by_name, var_name, nothing)
+        isnothing(get_var) && throw(KeyError(ind))
+        get_var(m, ind...)
     end
 end
 

--- a/src/variables/variable_units_on.jl
+++ b/src/variables/variable_units_on.jl
@@ -111,3 +111,7 @@ function _get_units_on(m, u, s, t)
         number_of_units(m; unit=u, stochastic_scenario=s, t=t)
     end
 end
+
+function _get_units_started_up(m, u, s, t)
+    get(m.ext[:spineopt].variables[:units_started_up], (u, s, t), 0)
+end


### PR DESCRIPTION
Support start_flow in fix_ratio_unit_flow constraints.

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted according to SpineOpt's style
- [x] Unit tests pass
