### PR TITLE
Convert duration to days for past indices calculation

### DIFF
--- a/src/constraints/constraint_common.jl
+++ b/src/constraints/constraint_common.jl
@@ -70,11 +70,22 @@ past_units_on_indices(m, param, u, s_path, t) = _past_indices(m, units_on_indice
 
 function _past_indices(m, indices, param, s_path, t; kwargs...)
     look_behind = maximum(maximum_parameter_value(param(; kwargs..., stochastic_scenario=s, t=t)) for s in s_path)
+    
+    function convert_to_days(duration)
+        if isa(duration, Year)
+            return Day(Dates.value(duration) * 365)  # approximate conversion
+        elseif isa(duration, Month)
+            return Day(Dates.value(duration) * 30)   # approximate conversion
+        else
+            return duration                          # do nothing
+        end
+    end
+
     (
         (;
             ind...,
             weight=ifelse(
-                end_(t) - end_(ind.t) < param(m; kwargs..., stochastic_scenario=ind.stochastic_scenario, t=t), 1, 0
+                end_(t) - end_(ind.t) < convert_to_days(param(m; kwargs..., stochastic_scenario=ind.stochastic_scenario, t=t)), 1, 0
             ),
         )
         for ind in indices(

--- a/src/constraints/constraint_common.jl
+++ b/src/constraints/constraint_common.jl
@@ -71,15 +71,9 @@ past_units_on_indices(m, param, u, s_path, t) = _past_indices(m, units_on_indice
 function _past_indices(m, indices, param, s_path, t; kwargs...)
     look_behind = maximum(maximum_parameter_value(param(; kwargs..., stochastic_scenario=s, t=t)) for s in s_path)
     
-    function convert_to_days(duration)
-        if isa(duration, Year)
-            return Day(Dates.value(duration) * 365)  # approximate conversion
-        elseif isa(duration, Month)
-            return Day(Dates.value(duration) * 30)   # approximate conversion
-        else
-            return duration                          # do nothing
-        end
-    end
+    convert_to_days(duration::Year) = Day(Dates.value(duration) * 366)
+    convert_to_days(duration::Month) = Day(Dates.value(duration) * 31)
+    convert_to_days(duration) = duration
 
     (
         (;


### PR DESCRIPTION
## Motivation

Months and Years are challenging for detailed comparisons in the package Dates, since they don't have an exact length as the number of days varies in both. E.g. every leap year is longer than 365 days, so Dates doesn't allow direct comparisons with ill-defined durations as a precaution.

## Description of changes

These changes take the parameter and convert it into days if it is defined as a duration in years or months. It will use a standard value of 365 and 30 days for each one.

Fixes #1038 

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted according to SpineOpt's style
- [x] Unit tests pass
