### PR TITLE
Add a missing line that activates the temporal resolution tutorial in the docs

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -40,6 +40,7 @@ pages = [
     "Tutorials" => Any[
         "Webinars" => joinpath("tutorial", "webinars.md"),
         "Simple system" => joinpath("tutorial", "simple_system.md"),
+        "Temporal resolution" => joinpath("tutorial", "temporal_resolution.md"),
         "Reserve requirements" => joinpath("tutorial", "reserves.md"),
         "Ramping constraints" => joinpath("tutorial", "ramping.md"),
         "Unit Commitment" => joinpath("tutorial", "unit_commitment.md"),


### PR DESCRIPTION
For some reason, temporal resolution was created but not used in the docs.

Fixes # (issue)

## Checklist before merging
- [ ] Documentation is up-to-date
- [ ] Unit tests have been added/updated accordingly
- [ ] Code has been formatted according to SpineOpt's style
- [ ] Unit tests pass
