### PR TITLE
bugfix database stochastic tutorial

### DIFF
--- a/examples/stochastic.json
+++ b/examples/stochastic.json
@@ -1,0 +1,4474 @@
+{
+    "entity_classes": [
+        [
+            "commodity",
+            [],
+            "A good or product that can be consumed, produced, traded. E.g., electricity, oil, gas, water...",
+            281473533932880,
+            true
+        ],
+        [
+            "connection",
+            [],
+            "A transfer of commodities between nodes. E.g. electricity line, gas pipeline...",
+            280378317271233,
+            true
+        ],
+        [
+            "investment_group",
+            [],
+            "A group of investments that need to be done together.",
+            281105609585860,
+            false
+        ],
+        [
+            "model",
+            [],
+            "An instance of SpineOpt, that specifies general parameters such as the temporal horizon.",
+            281107035648412,
+            true
+        ],
+        [
+            "node",
+            [],
+            "A universal aggregator of commodify flows over units and connections, with storage capabilities.",
+            280740554077951,
+            true
+        ],
+        [
+            "output",
+            [],
+            "A variable name from SpineOpt whose value can be included in a report.",
+            280743406202948,
+            true
+        ],
+        [
+            "report",
+            [],
+            "A results report from a particular SpineOpt run, including the value of specific variables.",
+            281108461711708,
+            true
+        ],
+        [
+            "settings",
+            [],
+            "Internal SpineOpt settings. We kindly advise not to mess with this one.",
+            280375465144798,
+            false
+        ],
+        [
+            "stage",
+            [],
+            "An additional stage in the optimisation problem (EXPERIMENTAL)",
+            281107035649533,
+            true
+        ],
+        [
+            "stochastic_scenario",
+            [],
+            "A scenario for stochastic optimisation in SpineOpt.",
+            280743389491710,
+            true
+        ],
+        [
+            "stochastic_structure",
+            [],
+            "A group of stochastic scenarios that represent a structure.",
+            281470681806146,
+            true
+        ],
+        [
+            "temporal_block",
+            [],
+            "A length of time with a particular resolution.",
+            280376891207703,
+            true
+        ],
+        [
+            "unit",
+            [],
+            "A conversion of one/many comodities between nodes.",
+            281470681805429,
+            true
+        ],
+        [
+            "user_constraint",
+            [],
+            "A generic data-driven custom constraint.",
+            281473533931636,
+            true
+        ],
+        [
+            "connection__from_node",
+            [
+                "connection",
+                "node"
+            ],
+            "A flow on a `connection` from a `node`.",
+            280378317271897,
+            true
+        ],
+        [
+            "connection__investment_group",
+            [
+                "connection",
+                "investment_group"
+            ],
+            "A `connection` that belongs in an `investment_group`.",
+            null,
+            true
+        ],
+        [
+            "connection__investment_stochastic_structure",
+            [
+                "connection",
+                "stochastic_structure"
+            ],
+            "The `stochastic_structure` of a `connection` investment.",
+            null,
+            true
+        ],
+        [
+            "connection__investment_temporal_block",
+            [
+                "connection",
+                "temporal_block"
+            ],
+            "The `temporal_block` of a `connection` investment.",
+            null,
+            true
+        ],
+        [
+            "connection__to_node",
+            [
+                "connection",
+                "node"
+            ],
+            "A flow on a `connection` to a `node` .",
+            280378317271898,
+            true
+        ],
+        [
+            "connection__user_constraint",
+            [
+                "connection",
+                "user_constraint"
+            ],
+            "A `connection` investment constrained by a `user_constraint`.",
+            null,
+            true
+        ],
+        [
+            "model__default_investment_stochastic_structure",
+            [
+                "model",
+                "stochastic_structure"
+            ],
+            "The default `stochastic_structure` of all investments in the `model`.",
+            null,
+            true
+        ],
+        [
+            "model__default_investment_temporal_block",
+            [
+                "model",
+                "temporal_block"
+            ],
+            "The default `temporal_block` of all investments in the `model`.",
+            null,
+            true
+        ],
+        [
+            "model__default_stochastic_structure",
+            [
+                "model",
+                "stochastic_structure"
+            ],
+            "The default `stochastic_structure` of the `model.",
+            null,
+            true
+        ],
+        [
+            "model__default_temporal_block",
+            [
+                "model",
+                "temporal_block"
+            ],
+            "The default `temporal_block` of the `model`.",
+            null,
+            true
+        ],
+        [
+            "model__report",
+            [
+                "model",
+                "report"
+            ],
+            "A `report` that should be written for the `model`.",
+            null,
+            true
+        ],
+        [
+            "model__stochastic_structure",
+            [
+                "model",
+                "stochastic_structure"
+            ],
+            "Defines which `stochastic_structure`s are included in which `model`s.",
+            null,
+            true
+        ],
+        [
+            "model__temporal_block",
+            [
+                "model",
+                "temporal_block"
+            ],
+            "Defines which `temporal_block`s are included in which `model`s.",
+            null,
+            true
+        ],
+        [
+            "node__commodity",
+            [
+                "node",
+                "commodity"
+            ],
+            "A `commodity` for a `node`. Only a single `commodity` is permitted per `node`.",
+            null,
+            true
+        ],
+        [
+            "node__investment_group",
+            [
+                "node",
+                "investment_group"
+            ],
+            "A `node` that belongs in an `investment_group`.",
+            null,
+            true
+        ],
+        [
+            "node__investment_stochastic_structure",
+            [
+                "node",
+                "stochastic_structure"
+            ],
+            "The `stochastic_structure` of a `node` storage investment.",
+            null,
+            true
+        ],
+        [
+            "node__investment_temporal_block",
+            [
+                "node",
+                "temporal_block"
+            ],
+            "The `temporal_block` of a `node` storage investment.",
+            null,
+            true
+        ],
+        [
+            "node__node",
+            [
+                "node",
+                "node"
+            ],
+            "An interaction between two `node`s.",
+            null,
+            true
+        ],
+        [
+            "node__stochastic_structure",
+            [
+                "node",
+                "stochastic_structure"
+            ],
+            "The `stochastic_structure` of a `node`. Only one `stochastic_structure` is permitted per `node`.",
+            null,
+            true
+        ],
+        [
+            "node__temporal_block",
+            [
+                "node",
+                "temporal_block"
+            ],
+            "The `temporal_block` of a `node` and the corresponding `flow` variables.",
+            null,
+            true
+        ],
+        [
+            "node__user_constraint",
+            [
+                "node",
+                "user_constraint"
+            ],
+            "A `node` state constrained by a `user_constraint`, or a `node` demand included in a `user_constraint`.",
+            null,
+            true
+        ],
+        [
+            "parent_stochastic_scenario__child_stochastic_scenario",
+            [
+                "stochastic_scenario",
+                "stochastic_scenario"
+            ],
+            "A parent-child relationship between two `stochastic_scenario`s defining the master stochastic direct acyclic graph.",
+            null,
+            true
+        ],
+        [
+            "report__output",
+            [
+                "report",
+                "output"
+            ],
+            "An `output` that should be included in a `report`.",
+            null,
+            true
+        ],
+        [
+            "stage__child_stage",
+            [
+                "stage",
+                "stage"
+            ],
+            "A parent-child relationship between two `stage`s (EXPERIMENTAL).",
+            null,
+            true
+        ],
+        [
+            "stochastic_structure__stochastic_scenario",
+            [
+                "stochastic_structure",
+                "stochastic_scenario"
+            ],
+            "A `stochastic_scenarios` that belongs in a `stochastic_structure`.",
+            null,
+            true
+        ],
+        [
+            "unit__commodity",
+            [
+                "unit",
+                "commodity"
+            ],
+            "Holds parameters for `commodities` used by the `unit`.",
+            null,
+            true
+        ],
+        [
+            "unit__from_node",
+            [
+                "unit",
+                "node"
+            ],
+            "A flow on a `unit` from a `node`.",
+            281470681805657,
+            true
+        ],
+        [
+            "unit__investment_group",
+            [
+                "unit",
+                "investment_group"
+            ],
+            "A `unit` that belongs in an `investment_group`.",
+            null,
+            true
+        ],
+        [
+            "unit__investment_stochastic_structure",
+            [
+                "unit",
+                "stochastic_structure"
+            ],
+            "The `stochastic_structure` of a `unit` investment.",
+            null,
+            true
+        ],
+        [
+            "unit__investment_temporal_block",
+            [
+                "unit",
+                "temporal_block"
+            ],
+            "The `temporal_block` of a `unit` investment.",
+            null,
+            true
+        ],
+        [
+            "unit__to_node",
+            [
+                "unit",
+                "node"
+            ],
+            "A flow on a `unit` to a `node`.",
+            281470681805658,
+            true
+        ],
+        [
+            "unit__user_constraint",
+            [
+                "unit",
+                "user_constraint"
+            ],
+            "A `unit` commitment constrained by a `user_constraint`.",
+            null,
+            true
+        ],
+        [
+            "units_on__stochastic_structure",
+            [
+                "unit",
+                "stochastic_structure"
+            ],
+            "The `stochastic_structure` of a `unit` commitment. Only one `stochastic_structure` is permitted per `unit`.",
+            null,
+            true
+        ],
+        [
+            "units_on__temporal_block",
+            [
+                "unit",
+                "temporal_block"
+            ],
+            "The `temporal_block` of a `unit` commitment.",
+            null,
+            true
+        ],
+        [
+            "connection__from_node__investment_group",
+            [
+                "connection",
+                "node",
+                "investment_group"
+            ],
+            "A flow on a `connection` from a `node` whose capacity should be counted in the capacity invested available of an `investment_group`.",
+            null,
+            true
+        ],
+        [
+            "connection__from_node__user_constraint",
+            [
+                "connection",
+                "node",
+                "user_constraint"
+            ],
+            "A flow on a `connection` from a `node` constrained by a `user_constraint`.",
+            null,
+            true
+        ],
+        [
+            "connection__node__node",
+            [
+                "connection",
+                "node",
+                "node"
+            ],
+            "A `connection` acting over two `node`s.",
+            null,
+            true
+        ],
+        [
+            "connection__to_node__investment_group",
+            [
+                "connection",
+                "node",
+                "investment_group"
+            ],
+            "A flow on a `connection` to a `node` whose capacity should be counted in the capacity invested available of an `investment_group`.",
+            null,
+            true
+        ],
+        [
+            "connection__to_node__user_constraint",
+            [
+                "connection",
+                "node",
+                "user_constraint"
+            ],
+            "A flow on a `connection` to a `node` constrained by a `user_constraint",
+            null,
+            true
+        ],
+        [
+            "stage__output__connection",
+            [
+                "stage",
+                "output",
+                "connection"
+            ],
+            "An `output` that should be fixed by a `stage` for a `connection` in all its children (EXPERIMENTAL).",
+            null,
+            true
+        ],
+        [
+            "stage__output__node",
+            [
+                "stage",
+                "output",
+                "node"
+            ],
+            "An `output` that should be fixed by a `stage` for a `node` in all its children (EXPERIMENTAL).",
+            null,
+            true
+        ],
+        [
+            "stage__output__unit",
+            [
+                "stage",
+                "output",
+                "unit"
+            ],
+            "An `output` that should be fixed by a `stage` for a `unit` in all its children (EXPERIMENTAL).",
+            null,
+            true
+        ],
+        [
+            "unit__from_node__investment_group",
+            [
+                "unit",
+                "node",
+                "investment_group"
+            ],
+            "A flow on a `unit` from a `node` whose capacity should be counted in the capacity invested available of an `investment_group`.",
+            null,
+            true
+        ],
+        [
+            "unit__from_node__user_constraint",
+            [
+                "unit",
+                "node",
+                "user_constraint"
+            ],
+            "A flow on a `unit` from a `node` constrained by a `user_constraint`.",
+            null,
+            true
+        ],
+        [
+            "unit__node__node",
+            [
+                "unit",
+                "node",
+                "node"
+            ],
+            "A `unit` acting over two `node`s.",
+            null,
+            true
+        ],
+        [
+            "unit__to_node__investment_group",
+            [
+                "unit",
+                "node",
+                "investment_group"
+            ],
+            "A flow on a `unit` from a `node` whose capacity should be counted in the capacity invested available of an `investment_group`.",
+            null,
+            true
+        ],
+        [
+            "unit__to_node__user_constraint",
+            [
+                "unit",
+                "node",
+                "user_constraint"
+            ],
+            "A flow on a `unit` to a `node` constrained by a `user_constraint`.",
+            null,
+            true
+        ]
+    ],
+    "entities": [
+        [
+            "model",
+            "simple",
+            null
+        ],
+        [
+            "node",
+            "electricity_node",
+            null
+        ],
+        [
+            "node",
+            "fuel_node",
+            null
+        ],
+        [
+            "output",
+            "binary_gas_connection_flow",
+            null
+        ],
+        [
+            "output",
+            "connection_avg_intact_throughflow",
+            null
+        ],
+        [
+            "output",
+            "connection_avg_throughflow",
+            null
+        ],
+        [
+            "output",
+            "connection_flow",
+            null
+        ],
+        [
+            "output",
+            "connection_flow_costs",
+            null
+        ],
+        [
+            "output",
+            "connection_intact_flow",
+            null
+        ],
+        [
+            "output",
+            "connection_investment_costs",
+            null
+        ],
+        [
+            "output",
+            "connections_decommissioned",
+            null
+        ],
+        [
+            "output",
+            "connections_invested",
+            null
+        ],
+        [
+            "output",
+            "connections_invested_available",
+            null
+        ],
+        [
+            "output",
+            "contingency_is_binding",
+            null
+        ],
+        [
+            "output",
+            "fixed_om_costs",
+            null
+        ],
+        [
+            "output",
+            "fuel_costs",
+            null
+        ],
+        [
+            "output",
+            "mga_objective",
+            null
+        ],
+        [
+            "output",
+            "mp_objective_lowerbound",
+            null
+        ],
+        [
+            "output",
+            "node_injection",
+            null
+        ],
+        [
+            "output",
+            "node_pressure",
+            null
+        ],
+        [
+            "output",
+            "node_slack_neg",
+            null
+        ],
+        [
+            "output",
+            "node_slack_pos",
+            null
+        ],
+        [
+            "output",
+            "node_state",
+            null
+        ],
+        [
+            "output",
+            "node_voltage_angle",
+            null
+        ],
+        [
+            "output",
+            "nonspin_ramp_down_unit_flow",
+            null
+        ],
+        [
+            "output",
+            "nonspin_ramp_up_unit_flow",
+            null
+        ],
+        [
+            "output",
+            "nonspin_units_shut_down",
+            null
+        ],
+        [
+            "output",
+            "nonspin_units_started_up",
+            null
+        ],
+        [
+            "output",
+            "objective_penalties",
+            null
+        ],
+        [
+            "output",
+            "ramp_costs",
+            null
+        ],
+        [
+            "output",
+            "ramp_down_unit_flow",
+            null
+        ],
+        [
+            "output",
+            "ramp_up_unit_flow",
+            null
+        ],
+        [
+            "output",
+            "relative_optimality_gap",
+            null
+        ],
+        [
+            "output",
+            "renewable_curtailment_costs",
+            null
+        ],
+        [
+            "output",
+            "res_proc_costs",
+            null
+        ],
+        [
+            "output",
+            "shut_down_costs",
+            null
+        ],
+        [
+            "output",
+            "shut_down_unit_flow",
+            null
+        ],
+        [
+            "output",
+            "start_up_costs",
+            null
+        ],
+        [
+            "output",
+            "start_up_unit_flow",
+            null
+        ],
+        [
+            "output",
+            "storage_investment_costs",
+            null
+        ],
+        [
+            "output",
+            "storages_decommissioned",
+            null
+        ],
+        [
+            "output",
+            "storages_invested",
+            null
+        ],
+        [
+            "output",
+            "storages_invested_available",
+            null
+        ],
+        [
+            "output",
+            "taxes",
+            null
+        ],
+        [
+            "output",
+            "total_costs",
+            null
+        ],
+        [
+            "output",
+            "unit_flow",
+            null
+        ],
+        [
+            "output",
+            "unit_flow_op",
+            null
+        ],
+        [
+            "output",
+            "unit_flow_op_active",
+            null
+        ],
+        [
+            "output",
+            "unit_investment_costs",
+            null
+        ],
+        [
+            "output",
+            "units_available",
+            null
+        ],
+        [
+            "output",
+            "units_invested",
+            null
+        ],
+        [
+            "output",
+            "units_invested_available",
+            null
+        ],
+        [
+            "output",
+            "units_mothballed",
+            null
+        ],
+        [
+            "output",
+            "units_on",
+            null
+        ],
+        [
+            "output",
+            "units_on_costs",
+            null
+        ],
+        [
+            "output",
+            "units_shut_down",
+            null
+        ],
+        [
+            "output",
+            "units_started_up",
+            null
+        ],
+        [
+            "output",
+            "variable_om_costs",
+            null
+        ],
+        [
+            "report",
+            "report1",
+            null
+        ],
+        [
+            "stochastic_scenario",
+            "base",
+            null
+        ],
+        [
+            "stochastic_scenario",
+            "forecast1",
+            null
+        ],
+        [
+            "stochastic_scenario",
+            "forecast2",
+            null
+        ],
+        [
+            "stochastic_scenario",
+            "forecast3",
+            null
+        ],
+        [
+            "stochastic_structure",
+            "DAG",
+            null
+        ],
+        [
+            "temporal_block",
+            "flat",
+            null
+        ],
+        [
+            "unit",
+            "power_plant_a",
+            null
+        ],
+        [
+            "unit",
+            "power_plant_b",
+            null
+        ],
+        [
+            "model__default_stochastic_structure",
+            [
+                "simple",
+                "DAG"
+            ],
+            null
+        ],
+        [
+            "model__default_temporal_block",
+            [
+                "simple",
+                "flat"
+            ],
+            null
+        ],
+        [
+            "model__report",
+            [
+                "simple",
+                "report1"
+            ],
+            null
+        ],
+        [
+            "model__stochastic_structure",
+            [
+                "simple",
+                "DAG"
+            ],
+            null
+        ],
+        [
+            "model__temporal_block",
+            [
+                "simple",
+                "flat"
+            ],
+            null
+        ],
+        [
+            "parent_stochastic_scenario__child_stochastic_scenario",
+            [
+                "base",
+                "forecast1"
+            ],
+            null
+        ],
+        [
+            "parent_stochastic_scenario__child_stochastic_scenario",
+            [
+                "base",
+                "forecast2"
+            ],
+            null
+        ],
+        [
+            "parent_stochastic_scenario__child_stochastic_scenario",
+            [
+                "base",
+                "forecast3"
+            ],
+            null
+        ],
+        [
+            "report__output",
+            [
+                "report1",
+                "unit_flow"
+            ],
+            null
+        ],
+        [
+            "stochastic_structure__stochastic_scenario",
+            [
+                "DAG",
+                "base"
+            ],
+            null
+        ],
+        [
+            "stochastic_structure__stochastic_scenario",
+            [
+                "DAG",
+                "forecast1"
+            ],
+            null
+        ],
+        [
+            "stochastic_structure__stochastic_scenario",
+            [
+                "DAG",
+                "forecast2"
+            ],
+            null
+        ],
+        [
+            "stochastic_structure__stochastic_scenario",
+            [
+                "DAG",
+                "forecast3"
+            ],
+            null
+        ],
+        [
+            "unit__from_node",
+            [
+                "power_plant_a",
+                "fuel_node"
+            ],
+            null
+        ],
+        [
+            "unit__from_node",
+            [
+                "power_plant_b",
+                "fuel_node"
+            ],
+            null
+        ],
+        [
+            "unit__to_node",
+            [
+                "power_plant_a",
+                "electricity_node"
+            ],
+            null
+        ],
+        [
+            "unit__to_node",
+            [
+                "power_plant_b",
+                "electricity_node"
+            ],
+            null
+        ],
+        [
+            "unit__node__node",
+            [
+                "power_plant_a",
+                "electricity_node",
+                "fuel_node"
+            ],
+            null
+        ],
+        [
+            "unit__node__node",
+            [
+                "power_plant_b",
+                "electricity_node",
+                "fuel_node"
+            ],
+            null
+        ]
+    ],
+    "entity_alternatives": [
+        [
+            "stochastic_scenario",
+            [
+                "forecast1"
+            ],
+            "Base",
+            true
+        ],
+        [
+            "stochastic_scenario",
+            [
+                "forecast2"
+            ],
+            "Base",
+            true
+        ],
+        [
+            "stochastic_scenario",
+            [
+                "forecast3"
+            ],
+            "Base",
+            true
+        ]
+    ],
+    "parameter_value_lists": [
+        [
+            "balance_type_list",
+            "balance_type_group"
+        ],
+        [
+            "balance_type_list",
+            "balance_type_node"
+        ],
+        [
+            "balance_type_list",
+            "balance_type_none"
+        ],
+        [
+            "balance_type_list",
+            "balance_type_group"
+        ],
+        [
+            "balance_type_list",
+            "balance_type_node"
+        ],
+        [
+            "balance_type_list",
+            "balance_type_none"
+        ],
+        [
+            "boolean_value_list",
+            false
+        ],
+        [
+            "boolean_value_list",
+            true
+        ],
+        [
+            "boolean_value_list",
+            false
+        ],
+        [
+            "boolean_value_list",
+            true
+        ],
+        [
+            "commodity_physics_list",
+            "commodity_physics_lodf"
+        ],
+        [
+            "commodity_physics_list",
+            "commodity_physics_none"
+        ],
+        [
+            "commodity_physics_list",
+            "commodity_physics_ptdf"
+        ],
+        [
+            "commodity_physics_list",
+            "commodity_physics_lodf"
+        ],
+        [
+            "commodity_physics_list",
+            "commodity_physics_none"
+        ],
+        [
+            "commodity_physics_list",
+            "commodity_physics_ptdf"
+        ],
+        [
+            "connection_investment_variable_type_list",
+            "connection_investment_variable_type_continuous"
+        ],
+        [
+            "connection_investment_variable_type_list",
+            "connection_investment_variable_type_integer"
+        ],
+        [
+            "connection_investment_variable_type_list",
+            "connection_investment_variable_type_continuous"
+        ],
+        [
+            "connection_investment_variable_type_list",
+            "connection_investment_variable_type_integer"
+        ],
+        [
+            "connection_type_list",
+            "connection_type_lossless_bidirectional"
+        ],
+        [
+            "connection_type_list",
+            "connection_type_normal"
+        ],
+        [
+            "connection_type_list",
+            "connection_type_lossless_bidirectional"
+        ],
+        [
+            "connection_type_list",
+            "connection_type_normal"
+        ],
+        [
+            "constraint_sense_list",
+            "<="
+        ],
+        [
+            "constraint_sense_list",
+            "=="
+        ],
+        [
+            "constraint_sense_list",
+            ">="
+        ],
+        [
+            "constraint_sense_list",
+            "<="
+        ],
+        [
+            "constraint_sense_list",
+            "=="
+        ],
+        [
+            "constraint_sense_list",
+            ">="
+        ],
+        [
+            "db_lp_solver_list",
+            "KNITRO.jl"
+        ],
+        [
+            "db_lp_solver_list",
+            "CDCS.jl"
+        ],
+        [
+            "db_lp_solver_list",
+            "CDDLib.jl"
+        ],
+        [
+            "db_lp_solver_list",
+            "Clp.jl"
+        ],
+        [
+            "db_lp_solver_list",
+            "COSMO.jl"
+        ],
+        [
+            "db_lp_solver_list",
+            "CPLEX.jl"
+        ],
+        [
+            "db_lp_solver_list",
+            "CSDP.jl"
+        ],
+        [
+            "db_lp_solver_list",
+            "ECOS.jl"
+        ],
+        [
+            "db_lp_solver_list",
+            "Xpress.jl"
+        ],
+        [
+            "db_lp_solver_list",
+            "GLPK.jl"
+        ],
+        [
+            "db_lp_solver_list",
+            "Gurobi.jl"
+        ],
+        [
+            "db_lp_solver_list",
+            "HiGHS.jl"
+        ],
+        [
+            "db_lp_solver_list",
+            "Hypatia.jl"
+        ],
+        [
+            "db_lp_solver_list",
+            "Ipopt.jl"
+        ],
+        [
+            "db_lp_solver_list",
+            "MadNLP.jl"
+        ],
+        [
+            "db_lp_solver_list",
+            "MosekTools.jl"
+        ],
+        [
+            "db_lp_solver_list",
+            "NLopt.jl"
+        ],
+        [
+            "db_lp_solver_list",
+            "OSQP.jl"
+        ],
+        [
+            "db_lp_solver_list",
+            "ProxSDP.jl"
+        ],
+        [
+            "db_lp_solver_list",
+            "SCIP.jl"
+        ],
+        [
+            "db_lp_solver_list",
+            "SCS.jl"
+        ],
+        [
+            "db_lp_solver_list",
+            "SDPA.jl"
+        ],
+        [
+            "db_lp_solver_list",
+            "SDPNAL.jl"
+        ],
+        [
+            "db_lp_solver_list",
+            "SDPT3.jl"
+        ],
+        [
+            "db_lp_solver_list",
+            "SeDuMi.jl"
+        ],
+        [
+            "db_lp_solver_list",
+            "CDCS.jl"
+        ],
+        [
+            "db_lp_solver_list",
+            "CDDLib.jl"
+        ],
+        [
+            "db_lp_solver_list",
+            "Clp.jl"
+        ],
+        [
+            "db_lp_solver_list",
+            "COSMO.jl"
+        ],
+        [
+            "db_lp_solver_list",
+            "CPLEX.jl"
+        ],
+        [
+            "db_lp_solver_list",
+            "CSDP.jl"
+        ],
+        [
+            "db_lp_solver_list",
+            "ECOS.jl"
+        ],
+        [
+            "db_lp_solver_list",
+            "GLPK.jl"
+        ],
+        [
+            "db_lp_solver_list",
+            "Gurobi.jl"
+        ],
+        [
+            "db_lp_solver_list",
+            "HiGHS.jl"
+        ],
+        [
+            "db_lp_solver_list",
+            "Hypatia.jl"
+        ],
+        [
+            "db_lp_solver_list",
+            "Ipopt.jl"
+        ],
+        [
+            "db_lp_solver_list",
+            "KNITRO.jl"
+        ],
+        [
+            "db_lp_solver_list",
+            "MadNLP.jl"
+        ],
+        [
+            "db_lp_solver_list",
+            "MosekTools.jl"
+        ],
+        [
+            "db_lp_solver_list",
+            "NLopt.jl"
+        ],
+        [
+            "db_lp_solver_list",
+            "OSQP.jl"
+        ],
+        [
+            "db_lp_solver_list",
+            "ProxSDP.jl"
+        ],
+        [
+            "db_lp_solver_list",
+            "SCIP.jl"
+        ],
+        [
+            "db_lp_solver_list",
+            "SCS.jl"
+        ],
+        [
+            "db_lp_solver_list",
+            "SDPA.jl"
+        ],
+        [
+            "db_lp_solver_list",
+            "SDPNAL.jl"
+        ],
+        [
+            "db_lp_solver_list",
+            "SDPT3.jl"
+        ],
+        [
+            "db_lp_solver_list",
+            "SeDuMi.jl"
+        ],
+        [
+            "db_lp_solver_list",
+            "Xpress.jl"
+        ],
+        [
+            "db_mip_solver_list",
+            "KNITRO.jl"
+        ],
+        [
+            "db_mip_solver_list",
+            "Cbc.jl"
+        ],
+        [
+            "db_mip_solver_list",
+            "CPLEX.jl"
+        ],
+        [
+            "db_mip_solver_list",
+            "HiGHS.jl"
+        ],
+        [
+            "db_mip_solver_list",
+            "Xpress.jl"
+        ],
+        [
+            "db_mip_solver_list",
+            "GLPK.jl"
+        ],
+        [
+            "db_mip_solver_list",
+            "Gurobi.jl"
+        ],
+        [
+            "db_mip_solver_list",
+            "Juniper.jl"
+        ],
+        [
+            "db_mip_solver_list",
+            "MosekTools.jl"
+        ],
+        [
+            "db_mip_solver_list",
+            "SCIP.jl"
+        ],
+        [
+            "db_mip_solver_list",
+            "Cbc.jl"
+        ],
+        [
+            "db_mip_solver_list",
+            "CPLEX.jl"
+        ],
+        [
+            "db_mip_solver_list",
+            "GLPK.jl"
+        ],
+        [
+            "db_mip_solver_list",
+            "Gurobi.jl"
+        ],
+        [
+            "db_mip_solver_list",
+            "HiGHS.jl"
+        ],
+        [
+            "db_mip_solver_list",
+            "Juniper.jl"
+        ],
+        [
+            "db_mip_solver_list",
+            "KNITRO.jl"
+        ],
+        [
+            "db_mip_solver_list",
+            "MosekTools.jl"
+        ],
+        [
+            "db_mip_solver_list",
+            "SCIP.jl"
+        ],
+        [
+            "db_mip_solver_list",
+            "Xpress.jl"
+        ],
+        [
+            "duration_unit_list",
+            "hour"
+        ],
+        [
+            "duration_unit_list",
+            "minute"
+        ],
+        [
+            "duration_unit_list",
+            "hour"
+        ],
+        [
+            "duration_unit_list",
+            "minute"
+        ],
+        [
+            "model_algorithm_list",
+            "basic_algorithm"
+        ],
+        [
+            "model_algorithm_list",
+            "mga_algorithm"
+        ],
+        [
+            "model_type_list",
+            "spineopt_benders"
+        ],
+        [
+            "model_type_list",
+            "spineopt_standard"
+        ],
+        [
+            "model_type_list",
+            "spineopt_other"
+        ],
+        [
+            "model_type_list",
+            "spineopt_mga"
+        ],
+        [
+            "model_type_list",
+            "spineopt_other"
+        ],
+        [
+            "model_type_list",
+            "spineopt_standard"
+        ],
+        [
+            "node_opf_type_list",
+            "node_opf_type_normal"
+        ],
+        [
+            "node_opf_type_list",
+            "node_opf_type_reference"
+        ],
+        [
+            "node_opf_type_list",
+            "node_opf_type_normal"
+        ],
+        [
+            "node_opf_type_list",
+            "node_opf_type_reference"
+        ],
+        [
+            "storage_investment_variable_type_list",
+            "storage_investment_variable_type_continuous"
+        ],
+        [
+            "storage_investment_variable_type_list",
+            "storage_investment_variable_type_integer"
+        ],
+        [
+            "storage_investment_variable_type_list",
+            "storage_investment_variable_type_continuous"
+        ],
+        [
+            "storage_investment_variable_type_list",
+            "storage_investment_variable_type_integer"
+        ],
+        [
+            "unit_investment_variable_type_list",
+            "unit_investment_variable_type_continuous"
+        ],
+        [
+            "unit_investment_variable_type_list",
+            "unit_investment_variable_type_integer"
+        ],
+        [
+            "unit_investment_variable_type_list",
+            "unit_investment_variable_type_continuous"
+        ],
+        [
+            "unit_investment_variable_type_list",
+            "unit_investment_variable_type_integer"
+        ],
+        [
+            "unit_online_variable_type_list",
+            "unit_online_variable_type_binary"
+        ],
+        [
+            "unit_online_variable_type_list",
+            "unit_online_variable_type_integer"
+        ],
+        [
+            "unit_online_variable_type_list",
+            "unit_online_variable_type_linear"
+        ],
+        [
+            "unit_online_variable_type_list",
+            "unit_online_variable_type_none"
+        ],
+        [
+            "unit_online_variable_type_list",
+            "unit_online_variable_type_binary"
+        ],
+        [
+            "unit_online_variable_type_list",
+            "unit_online_variable_type_integer"
+        ],
+        [
+            "unit_online_variable_type_list",
+            "unit_online_variable_type_linear"
+        ],
+        [
+            "unit_online_variable_type_list",
+            "unit_online_variable_type_none"
+        ],
+        [
+            "variable_type_list",
+            "variable_type_binary"
+        ],
+        [
+            "variable_type_list",
+            "variable_type_continuous"
+        ],
+        [
+            "variable_type_list",
+            "variable_type_integer"
+        ],
+        [
+            "write_mps_file_list",
+            "write_mps_always"
+        ],
+        [
+            "write_mps_file_list",
+            "write_mps_never"
+        ],
+        [
+            "write_mps_file_list",
+            "write_mps_on_no_solve"
+        ],
+        [
+            "write_mps_file_list",
+            "write_mps_always"
+        ],
+        [
+            "write_mps_file_list",
+            "write_mps_never"
+        ],
+        [
+            "write_mps_file_list",
+            "write_mps_on_no_solve"
+        ]
+    ],
+    "parameter_definitions": [
+        [
+            "commodity",
+            "commodity_lodf_tolerance",
+            0.1,
+            null,
+            "The minimum absolute value of the line outage distribution factor (LODF) that is considered meaningful."
+        ],
+        [
+            "commodity",
+            "commodity_physics",
+            "commodity_physics_none",
+            "commodity_physics_list",
+            "Defines if the `commodity` follows lodf or ptdf physics."
+        ],
+        [
+            "commodity",
+            "commodity_physics_duration",
+            null,
+            null,
+            "For how long the `commodity_physics` should apply relative to the start of the window."
+        ],
+        [
+            "commodity",
+            "commodity_ptdf_threshold",
+            0.001,
+            null,
+            "The minimum absolute value of the power transfer distribution factor (PTDF) that is considered meaningful."
+        ],
+        [
+            "commodity",
+            "is_active",
+            true,
+            "boolean_value_list",
+            "If false, the object is excluded from the model if the tool filter object activity control is specified"
+        ],
+        [
+            "commodity",
+            "mp_min_res_gen_to_demand_ratio",
+            null,
+            null,
+            "Minimum ratio of renewable generation to demand for this commodity - used in the minimum renewable generation constraint within the Benders master problem"
+        ],
+        [
+            "commodity",
+            "mp_min_res_gen_to_demand_ratio_slack_penalty",
+            null,
+            null,
+            "Penalty for violating the minimum renewable generation to demand ratio."
+        ],
+        [
+            "connection",
+            "benders_starting_connections_invested",
+            null,
+            null,
+            "Fixes the number of connections invested during the first Benders iteration"
+        ],
+        [
+            "connection",
+            "candidate_connections",
+            null,
+            null,
+            "The number of connections that may be invested in"
+        ],
+        [
+            "connection",
+            "connection_availability_factor",
+            1.0,
+            null,
+            "Availability of the `connection`, acting as a multiplier on its `connection_capacity`. Typically between 0-1."
+        ],
+        [
+            "connection",
+            "connection_contingency",
+            null,
+            "boolean_value_list",
+            "A boolean flag for defining a contingency `connection`."
+        ],
+        [
+            "connection",
+            "connection_decommissioning_cost",
+            null,
+            null,
+            "Costs associated with decommissioning a power plant. The costs will b discounted to the `discount_year``at distribted equally over the decommissioning time."
+        ],
+        [
+            "connection",
+            "connection_decommissioning_time",
+            {
+                "type": "duration",
+                "data": "0h"
+            },
+            null,
+            "A connection's decommissioning time, i.e., the time between the moment at which a connection decommissioning decision is takien, and the moment at which decommissioning is complete."
+        ],
+        [
+            "connection",
+            "connection_discount_rate_technology_specific",
+            0.0,
+            null,
+            "connection-specific discount rate used to calculate the connection's investment costs. If not specified, the model discount rate is used."
+        ],
+        [
+            "connection",
+            "connection_investment_cost",
+            null,
+            null,
+            "The per unit investment cost for the connection over the `connection_investment_tech_lifetime`"
+        ],
+        [
+            "connection",
+            "connection_investment_econ_lifetime",
+            null,
+            null,
+            "Determines the minimum economical investment lifetime of a connection."
+        ],
+        [
+            "connection",
+            "connection_investment_tech_lifetime",
+            null,
+            null,
+            "Determines the maximum technical lifetime of a connection. Once invested, it remains in service for this long"
+        ],
+        [
+            "connection",
+            "connection_investment_variable_type",
+            "connection_investment_variable_type_integer",
+            "connection_investment_variable_type_list",
+            "Determines whether the investment variable is integer `variable_type_integer` or continuous `variable_type_continuous`"
+        ],
+        [
+            "connection",
+            "connection_lead_time",
+            {
+                "type": "duration",
+                "data": "0h"
+            },
+            null,
+            "A connection's lead time, i.e., the time between the moment at which a connection investment decision is takien, and the moment at which the connection investment becomes operational."
+        ],
+        [
+            "connection",
+            "connection_monitored",
+            false,
+            "boolean_value_list",
+            "A boolean flag for defining a contingency `connection`."
+        ],
+        [
+            "connection",
+            "connection_reactance",
+            null,
+            null,
+            "The per unit reactance of a `connection`."
+        ],
+        [
+            "connection",
+            "connection_reactance_base",
+            1,
+            null,
+            "If the reactance is given for a p.u.  (e.g. p.u. = 100MW), the `connection_reactance_base` can be set to perform this conversion (e.g. *100)."
+        ],
+        [
+            "connection",
+            "connection_resistance",
+            null,
+            null,
+            "The per unit resistance of a `connection`."
+        ],
+        [
+            "connection",
+            "connection_type",
+            "connection_type_normal",
+            "connection_type_list",
+            "A selector between a normal and a lossless bidirectional `connection`."
+        ],
+        [
+            "connection",
+            "connections_invested_big_m_mga",
+            null,
+            null,
+            "big_m_mga should be chosen as small as possible but sufficiently large. For units_invested_mga an appropriate big_m_mga would be twice the candidate connections."
+        ],
+        [
+            "connection",
+            "connections_invested_mga",
+            false,
+            "boolean_value_list",
+            "Defines whether a certain variable (here: connections_invested) will be considered in the maximal-differences of the mga objective"
+        ],
+        [
+            "connection",
+            "connections_invested_mga_weight",
+            1,
+            null,
+            "Used to scale mga variables. For weightd sum mga method, the length of this weight given as an Array will determine the number of iterations."
+        ],
+        [
+            "connection",
+            "fix_connections_invested",
+            null,
+            null,
+            "Setting a value fixes the connections_invested variable accordingly"
+        ],
+        [
+            "connection",
+            "fix_connections_invested_available",
+            null,
+            null,
+            "Setting a value fixes the connections_invested_available variable accordingly"
+        ],
+        [
+            "connection",
+            "forced_availability_factor",
+            null,
+            null,
+            "Availability factor due to outages/deratings."
+        ],
+        [
+            "connection",
+            "graph_view_position",
+            null,
+            null,
+            "An optional setting for tweaking the position of the different elements when drawing them via Spine Toolbox Graph View."
+        ],
+        [
+            "connection",
+            "has_binary_gas_flow",
+            false,
+            "boolean_value_list",
+            "This parameter needs to be set to `true` in order to represent bidirectional pressure drive gas transfer."
+        ],
+        [
+            "connection",
+            "initial_connections_invested",
+            null,
+            null,
+            "Setting a value fixes the connections_invested variable at the beginning"
+        ],
+        [
+            "connection",
+            "initial_connections_invested_available",
+            null,
+            null,
+            "Setting a value fixes the connections_invested_available variable at the beginning"
+        ],
+        [
+            "connection",
+            "is_active",
+            true,
+            "boolean_value_list",
+            "If false, the object is excluded from the model if the tool filter object activity control is specified"
+        ],
+        [
+            "connection",
+            "number_of_connections",
+            1.0,
+            null,
+            "Denotes the number of 'sub connections' aggregated to form the modelled `connection`."
+        ],
+        [
+            "connection__from_node",
+            "connection_capacity",
+            null,
+            null,
+            "Limits the `connection_flow` variable from the `from_node`. `from_node` can be a group of `nodes`, in which case the sum of the `connection_flow` is constrained."
+        ],
+        [
+            "connection__from_node",
+            "connection_conv_cap_to_flow",
+            1.0,
+            null,
+            "Optional coefficient for `connection_capacity` unit conversions in the case that the `connection_capacity` value is incompatible with the desired `connection_flow` units."
+        ],
+        [
+            "connection__from_node",
+            "connection_emergency_capacity",
+            null,
+            null,
+            "Post contingency flow capacity of a `connection`. Sometimes referred to as emergency rating"
+        ],
+        [
+            "connection__from_node",
+            "connection_flow_cost",
+            null,
+            null,
+            "Variable costs of a flow through a `connection`. E.g. EUR/MWh of energy throughput."
+        ],
+        [
+            "connection__from_node",
+            "connection_flow_non_anticipativity_margin",
+            null,
+            null,
+            "Margin by which `connection_flow` variable can differ from the value in the previous window during `non_anticipativity_time`."
+        ],
+        [
+            "connection__from_node",
+            "connection_flow_non_anticipativity_time",
+            null,
+            null,
+            "Period of time where the value of the `connection_flow` variable has to be fixed to the result from the previous window."
+        ],
+        [
+            "connection__from_node",
+            "connection_intact_flow_non_anticipativity_margin",
+            null,
+            null,
+            "Margin by which `connection_intact_flow` variable can differ from the value in the previous window during `non_anticipativity_time`."
+        ],
+        [
+            "connection__from_node",
+            "connection_intact_flow_non_anticipativity_time",
+            null,
+            null,
+            "Period of time where the value of the `connection_intact_flow` variable has to be fixed to the result from the previous window."
+        ],
+        [
+            "connection__from_node",
+            "fix_binary_gas_connection_flow",
+            null,
+            null,
+            "Fix the value of the `connection_flow_binary` variable, and hence pre-determine the direction of flow in the connection."
+        ],
+        [
+            "connection__from_node",
+            "fix_connection_flow",
+            null,
+            null,
+            "Fix the value of the `connection_flow` variable."
+        ],
+        [
+            "connection__from_node",
+            "fix_connection_intact_flow",
+            null,
+            null,
+            "Fix the value of the `connection_intact_flow` variable."
+        ],
+        [
+            "connection__from_node",
+            "graph_view_position",
+            null,
+            null,
+            "An optional setting for tweaking the position of the different elements when drawing them via Spine Toolbox Graph View."
+        ],
+        [
+            "connection__from_node",
+            "initial_binary_gas_connection_flow",
+            null,
+            null,
+            "Initialize the value of the `connection_flow_binary` variable, and hence pre-determine the direction of flow in the connection."
+        ],
+        [
+            "connection__from_node",
+            "initial_connection_flow",
+            null,
+            null,
+            "Initialize the value of the `connection_flow` variable."
+        ],
+        [
+            "connection__from_node",
+            "initial_connection_intact_flow",
+            null,
+            null,
+            "Initialize the value of the `connection_intact_flow` variable."
+        ],
+        [
+            "connection__from_node__user_constraint",
+            "connection_flow_coefficient",
+            0.0,
+            null,
+            "defines the user constraint coefficient on the connection flow variable in the from direction"
+        ],
+        [
+            "connection__node__node",
+            "compression_factor",
+            null,
+            null,
+            "The compression factor establishes a compression from an origin node to a receiving node, which are connected through a connection. The first node corresponds to the origin node, the second to the (compressed) destination node. Typically the value is >=1."
+        ],
+        [
+            "connection__node__node",
+            "connection_flow_delay",
+            {
+                "type": "duration",
+                "data": "0h"
+            },
+            null,
+            "Delays the `connection_flows` associated with the latter `node` in respect to the `connection_flows` associated with the first `node`."
+        ],
+        [
+            "connection__node__node",
+            "connection_linepack_constant",
+            null,
+            null,
+            "The linepack constant is a property of gas pipelines and relates the linepack to the pressure of the adjacent nodes."
+        ],
+        [
+            "connection__node__node",
+            "fix_ratio_out_in_connection_flow",
+            null,
+            null,
+            "Fix the ratio between an outgoing `connection_flow` to the first `node` and an incoming `connection_flow` from the second `node`."
+        ],
+        [
+            "connection__node__node",
+            "fixed_pressure_constant_0",
+            null,
+            null,
+            "Fixed pressure points for pipelines for the outer approximation of the Weymouth approximation. The direction of flow is the first node in the relationship to the second node in the relationship."
+        ],
+        [
+            "connection__node__node",
+            "fixed_pressure_constant_1",
+            null,
+            null,
+            "Fixed pressure points for pipelines for the outer approximation of the Weymouth approximation. The direction of flow is the first node in the relationship to the second node in the relationship."
+        ],
+        [
+            "connection__node__node",
+            "max_ratio_out_in_connection_flow",
+            null,
+            null,
+            "Maximum ratio between an outgoing `connection_flow` to the first `node` and an incoming `connection_flow` from the second `node`."
+        ],
+        [
+            "connection__node__node",
+            "min_ratio_out_in_connection_flow",
+            null,
+            null,
+            "Minimum ratio between an outgoing `connection_flow` to the first `node` and an incoming `connection_flow` from the second `node`."
+        ],
+        [
+            "connection__to_node",
+            "connection_capacity",
+            null,
+            null,
+            "Limits the `connection_flow` variable to the `to_node`. `to_node` can be a group of `nodes`, in which case the sum of the `connection_flow` is constrained."
+        ],
+        [
+            "connection__to_node",
+            "connection_conv_cap_to_flow",
+            1.0,
+            null,
+            "Optional coefficient for `connection_capacity` unit conversions in the case the `connection_capacity` value is incompatible with the desired `connection_flow` units."
+        ],
+        [
+            "connection__to_node",
+            "connection_emergency_capacity",
+            null,
+            null,
+            "The maximum post-contingency flow on a monitored `connection`."
+        ],
+        [
+            "connection__to_node",
+            "connection_flow_cost",
+            null,
+            null,
+            "Variable costs of a flow through a `connection`. E.g. EUR/MWh of energy throughput."
+        ],
+        [
+            "connection__to_node",
+            "connection_flow_non_anticipativity_margin",
+            null,
+            null,
+            "Margin by which `connection_flow` variable can differ from the value in the previous window during `non_anticipativity_time`."
+        ],
+        [
+            "connection__to_node",
+            "connection_flow_non_anticipativity_time",
+            null,
+            null,
+            "Period of time where the value of the `connection_flow` variable has to be fixed to the result from the previous window."
+        ],
+        [
+            "connection__to_node",
+            "connection_intact_flow_non_anticipativity_margin",
+            null,
+            null,
+            "Margin by which `connection_intact_flow` variable can differ from the value in the previous window during `non_anticipativity_time`."
+        ],
+        [
+            "connection__to_node",
+            "connection_intact_flow_non_anticipativity_time",
+            null,
+            null,
+            "Period of time where the value of the `connection_intact_flow` variable has to be fixed to the result from the previous window."
+        ],
+        [
+            "connection__to_node",
+            "fix_binary_gas_connection_flow",
+            null,
+            null,
+            "Fix the value of the `connection_flow_binary` variable, and hence pre-determine the direction of flow in the connection."
+        ],
+        [
+            "connection__to_node",
+            "fix_connection_flow",
+            null,
+            null,
+            "Fix the value of the `connection_flow` variable."
+        ],
+        [
+            "connection__to_node",
+            "fix_connection_intact_flow",
+            null,
+            null,
+            "Fix the value of the `connection_intact_flow` variable."
+        ],
+        [
+            "connection__to_node",
+            "graph_view_position",
+            null,
+            null,
+            "An optional setting for tweaking the position of the different elements when drawing them via Spine Toolbox Graph View."
+        ],
+        [
+            "connection__to_node",
+            "initial_binary_gas_connection_flow",
+            null,
+            null,
+            "Initialize the value of the `connection_flow_binary` variable, and hence pre-determine the direction of flow in the connection."
+        ],
+        [
+            "connection__to_node",
+            "initial_connection_flow",
+            null,
+            null,
+            "Initialize the value of the `connection_flow` variable."
+        ],
+        [
+            "connection__to_node",
+            "initial_connection_intact_flow",
+            null,
+            null,
+            "Initialize the value of the `connection_intact_flow` variable."
+        ],
+        [
+            "connection__to_node__user_constraint",
+            "connection_flow_coefficient",
+            0.0,
+            null,
+            "defines the user constraint coefficient on the connection flow variable in the to direction"
+        ],
+        [
+            "connection__user_constraint",
+            "connections_invested_available_coefficient",
+            0.0,
+            null,
+            "coefficient of `connections_invested_available` in the specific `user_constraint`"
+        ],
+        [
+            "connection__user_constraint",
+            "connections_invested_coefficient",
+            0.0,
+            null,
+            "coefficient of `connections_invested` in the specific `user_constraint`"
+        ],
+        [
+            "investment_group",
+            "equal_investments",
+            false,
+            "boolean_value_list",
+            "Whether all entities in the group must have the same investment decision."
+        ],
+        [
+            "investment_group",
+            "maximum_capacity_invested_available",
+            null,
+            null,
+            "Upper bound on the capacity invested available in the group at any point in time."
+        ],
+        [
+            "investment_group",
+            "maximum_entities_invested_available",
+            null,
+            null,
+            "Upper bound on the number of entities invested available in the group at any point in time."
+        ],
+        [
+            "investment_group",
+            "minimum_capacity_invested_available",
+            null,
+            null,
+            "Lower bound on the capacity invested available in the group at any point in time."
+        ],
+        [
+            "investment_group",
+            "minimum_entities_invested_available",
+            null,
+            null,
+            "Lower bound on the number of entities invested available in the group at any point in time."
+        ],
+        [
+            "model",
+            "big_m",
+            1000000,
+            null,
+            "Sufficiently large number used for linearization bilinear terms, e.g. to enforce bidirectional flow for gas pipielines"
+        ],
+        [
+            "model",
+            "db_lp_solver",
+            "HiGHS.jl",
+            "db_lp_solver_list",
+            "Solver for MIP problems. Solver package must be added and pre-configured in Julia. Overrides lp_solver RunSpineOpt kwarg"
+        ],
+        [
+            "model",
+            "db_lp_solver_options",
+            {
+                "type": "map",
+                "data": [
+                    [
+                        "HiGHS.jl",
+                        {
+                            "data": [
+                                [
+                                    "presolve",
+                                    "on"
+                                ],
+                                [
+                                    "time_limit",
+                                    300.01
+                                ]
+                            ],
+                            "type": "map",
+                            "index_type": "str"
+                        }
+                    ],
+                    [
+                        "Clp.jl",
+                        {
+                            "data": [
+                                [
+                                    "LogLevel",
+                                    0.0
+                                ]
+                            ],
+                            "type": "map",
+                            "index_type": "str"
+                        }
+                    ]
+                ],
+                "index_type": "str"
+            },
+            null,
+            "Map parameter containing LP solver option name option value pairs. See solver documentation for supported solver options"
+        ],
+        [
+            "model",
+            "db_mip_solver",
+            "HiGHS.jl",
+            "db_mip_solver_list",
+            "Solver for MIP problems. Solver package must be added and pre-configured in Julia. Overrides mip_solver RunSpineOpt kwarg"
+        ],
+        [
+            "model",
+            "db_mip_solver_options",
+            {
+                "type": "map",
+                "data": [
+                    [
+                        "HiGHS.jl",
+                        {
+                            "data": [
+                                [
+                                    "presolve",
+                                    "on"
+                                ],
+                                [
+                                    "mip_rel_gap",
+                                    0.01
+                                ],
+                                [
+                                    "threads",
+                                    0.0
+                                ],
+                                [
+                                    "time_limit",
+                                    300.01
+                                ]
+                            ],
+                            "type": "map",
+                            "index_type": "str"
+                        }
+                    ],
+                    [
+                        "Cbc.jl",
+                        {
+                            "data": [
+                                [
+                                    "ratioGap",
+                                    0.01
+                                ],
+                                [
+                                    "logLevel",
+                                    0.0
+                                ]
+                            ],
+                            "type": "map",
+                            "index_type": "str"
+                        }
+                    ],
+                    [
+                        "CPLEX.jl",
+                        {
+                            "data": [
+                                [
+                                    "CPX_PARAM_EPGAP",
+                                    0.01
+                                ]
+                            ],
+                            "type": "map",
+                            "index_type": "str"
+                        }
+                    ]
+                ],
+                "index_type": "str"
+            },
+            null,
+            "Map parameter containing MIP solver option name option value pairs for MIP. See solver documentation for supported solver options"
+        ],
+        [
+            "model",
+            "discount_rate",
+            0,
+            null,
+            "The discount rate used for the discounting of future cashflows"
+        ],
+        [
+            "model",
+            "discount_year",
+            null,
+            null,
+            "The year to which all cashflows are discounted."
+        ],
+        [
+            "model",
+            "duration_unit",
+            "hour",
+            "duration_unit_list",
+            "Defines the base temporal unit of the `model`. Currently supported values are either an `hour` or a `minute`."
+        ],
+        [
+            "model",
+            "is_active",
+            true,
+            "boolean_value_list",
+            "If false, the object is excluded from the model if the tool filter object activity control is specified"
+        ],
+        [
+            "model",
+            "max_gap",
+            0.05,
+            null,
+            "Specifies the maximum optimality gap for the model. Currently only used for the master problem within a decomposed structure"
+        ],
+        [
+            "model",
+            "max_iterations",
+            10.0,
+            null,
+            "Specifies the maximum number of iterations for the model. Currently only used for the master problem within a decomposed structure"
+        ],
+        [
+            "model",
+            "max_mga_iterations",
+            null,
+            null,
+            "Define the number of mga iterations, i.e. how many alternative solutions will be generated."
+        ],
+        [
+            "model",
+            "max_mga_slack",
+            0.05,
+            null,
+            "Defines the maximum slack by which the alternative solution may differ from the original solution (e.g. 5% more than initial objective function value)"
+        ],
+        [
+            "model",
+            "min_iterations",
+            1.0,
+            null,
+            "Specifies the minimum number of iterations for the model. Currently only used for the master problem within a decomposed structure"
+        ],
+        [
+            "model",
+            "model_algorithm",
+            "basic_algorithm",
+            "model_algorithm_list",
+            "The algorithm to run (e.g., basic, MGA)"
+        ],
+        [
+            "model",
+            "model_end",
+            {
+                "type": "date_time",
+                "data": "2000-01-02T00:00:00"
+            },
+            null,
+            "Defines the last timestamp to be modelled. Rolling optimization terminates after passing this point."
+        ],
+        [
+            "model",
+            "model_start",
+            {
+                "type": "date_time",
+                "data": "2000-01-01T00:00:00"
+            },
+            null,
+            "Defines the first timestamp to be modelled. Relative `temporal_blocks` refer to this value for their start and end."
+        ],
+        [
+            "model",
+            "model_type",
+            "spineopt_standard",
+            "model_type_list",
+            "The model type which gives the solution method (e.g. standerd, Benders)"
+        ],
+        [
+            "model",
+            "roll_forward",
+            null,
+            null,
+            "Defines how much the model moves ahead in time between solves in a rolling optimization. If null, everything is solved in as a single optimization."
+        ],
+        [
+            "model",
+            "use_connection_intact_flow",
+            true,
+            "boolean_value_list",
+            "Whether to use `connection_intact_flow` variables, to capture the impact of connection investments on network characteristics via line outage distribution factors (LODF)."
+        ],
+        [
+            "model",
+            "use_economic_representation",
+            false,
+            "boolean_value_list",
+            "If set to true, the investment models uses economic represenation, i.e., multi-year investments will be modeled considering discounts etc."
+        ],
+        [
+            "model",
+            "use_milestone_years",
+            false,
+            "boolean_value_list",
+            "If set to true, the investment models uses milestone years. In other words, operational temporal blocks for one (milestone) year will be scaled up by the discounted duration to represent the entire investment period."
+        ],
+        [
+            "model",
+            "use_tight_compact_formulations",
+            false,
+            "boolean_value_list",
+            "Whether to use tight and compact constraint formulations."
+        ],
+        [
+            "model",
+            "window_duration",
+            null,
+            null,
+            "The duration of the window in case it differs from roll_forward"
+        ],
+        [
+            "model",
+            "window_weight",
+            1,
+            null,
+            "The weight of the window in the rolling subproblem"
+        ],
+        [
+            "model",
+            "write_lodf_file",
+            false,
+            "boolean_value_list",
+            "A boolean flag for whether the LODF values should be written to a results file."
+        ],
+        [
+            "model",
+            "write_mps_file",
+            null,
+            "write_mps_file_list",
+            "A selector for writing an .mps file of the model."
+        ],
+        [
+            "model",
+            "write_ptdf_file",
+            false,
+            "boolean_value_list",
+            "A boolean flag for whether the PTDF values should be written to a results file."
+        ],
+        [
+            "node",
+            "balance_type",
+            "balance_type_node",
+            "balance_type_list",
+            "A selector for how the `nodal_balance` constraint should be handled."
+        ],
+        [
+            "node",
+            "benders_starting_storages_invested",
+            null,
+            null,
+            "Fixes the number of storages invested during the first Benders iteration"
+        ],
+        [
+            "node",
+            "candidate_storages",
+            null,
+            null,
+            "Determines the maximum number of new storages which may be invested in"
+        ],
+        [
+            "node",
+            "demand",
+            0.0,
+            null,
+            "Demand for the `commodity` of a `node`. Energy gains can be represented using negative `demand`."
+        ],
+        [
+            "node",
+            "downward_reserve",
+            false,
+            null,
+            "Identifier for `node`s providing downward reserves"
+        ],
+        [
+            "node",
+            "fix_node_pressure",
+            null,
+            null,
+            "Fixes the corresponding `node_pressure` variable to the provided value"
+        ],
+        [
+            "node",
+            "fix_node_state",
+            null,
+            null,
+            "Fixes the corresponding `node_state` variable to the provided value. Can be used for e.g. fixing boundary conditions."
+        ],
+        [
+            "node",
+            "fix_node_voltage_angle",
+            null,
+            null,
+            "Fixes the corresponding `node_voltage_angle` variable to the provided value"
+        ],
+        [
+            "node",
+            "fix_storages_invested",
+            null,
+            null,
+            "Used to fix the value of the storages_invested variable"
+        ],
+        [
+            "node",
+            "fix_storages_invested_available",
+            null,
+            null,
+            "Used to fix the value of the storages_invested_available variable"
+        ],
+        [
+            "node",
+            "frac_state_loss",
+            0.0,
+            null,
+            "Self-discharge coefficient for `node_state` variables. Effectively, represents the *loss power per unit of state*."
+        ],
+        [
+            "node",
+            "fractional_demand",
+            0.0,
+            null,
+            "The fraction of a `node` group's `demand` applied for the `node` in question."
+        ],
+        [
+            "node",
+            "graph_view_position",
+            null,
+            null,
+            "An optional setting for tweaking the position of the different elements when drawing them via Spine Toolbox Graph View."
+        ],
+        [
+            "node",
+            "has_pressure",
+            false,
+            "boolean_value_list",
+            "A boolean flag for whether a `node` has a `node_pressure` variable."
+        ],
+        [
+            "node",
+            "has_state",
+            false,
+            "boolean_value_list",
+            "A boolean flag for whether a `node` has a `node_state` variable."
+        ],
+        [
+            "node",
+            "has_voltage_angle",
+            false,
+            "boolean_value_list",
+            "A boolean flag for whether a `node` has a `node_voltage_angle` variable."
+        ],
+        [
+            "node",
+            "initial_node_pressure",
+            null,
+            null,
+            "Initializes the corresponding `node_pressure` variable to the provided value"
+        ],
+        [
+            "node",
+            "initial_node_state",
+            null,
+            null,
+            "Initializes the corresponding `node_state` variable to the provided value."
+        ],
+        [
+            "node",
+            "initial_node_voltage_angle",
+            null,
+            null,
+            "Initializes the corresponding `node_voltage_angle` variable to the provided value"
+        ],
+        [
+            "node",
+            "initial_storages_invested",
+            null,
+            null,
+            "Used to initialze the value of the storages_invested variable"
+        ],
+        [
+            "node",
+            "initial_storages_invested_available",
+            null,
+            null,
+            "Used to initialze the value of the storages_invested_available variable"
+        ],
+        [
+            "node",
+            "is_active",
+            true,
+            "boolean_value_list",
+            "If false, the object is excluded from the model if the tool filter object activity control is specified"
+        ],
+        [
+            "node",
+            "is_non_spinning",
+            false,
+            "boolean_value_list",
+            "A boolean flag for whether a `node` is acting as a non-spinning reserve"
+        ],
+        [
+            "node",
+            "is_reserve_node",
+            false,
+            "boolean_value_list",
+            "A boolean flag for whether a `node` is acting as a `reserve_node`"
+        ],
+        [
+            "node",
+            "max_node_pressure",
+            null,
+            null,
+            "Maximum allowed gas pressure at `node`."
+        ],
+        [
+            "node",
+            "max_voltage_angle",
+            null,
+            null,
+            "Maximum allowed voltage angle at `node`."
+        ],
+        [
+            "node",
+            "min_capacity_margin",
+            null,
+            null,
+            "minimum capacity margin applying to the `node` or `node_group`"
+        ],
+        [
+            "node",
+            "min_capacity_margin_penalty",
+            null,
+            null,
+            "penalty to apply to violations of the min capacity_margin constraint of the `node` or `node_group`"
+        ],
+        [
+            "node",
+            "min_node_pressure",
+            null,
+            null,
+            "Minimum allowed gas pressure at `node`."
+        ],
+        [
+            "node",
+            "min_voltage_angle",
+            null,
+            null,
+            "Minimum allowed voltage angle at `node`. "
+        ],
+        [
+            "node",
+            "minimum_reserve_activation_time",
+            null,
+            null,
+            "Duration a certain reserve product needs to be online/available"
+        ],
+        [
+            "node",
+            "nodal_balance_sense",
+            "==",
+            "constraint_sense_list",
+            "A selector for `nodal_balance` constraint sense."
+        ],
+        [
+            "node",
+            "node_opf_type",
+            "node_opf_type_normal",
+            "node_opf_type_list",
+            "A selector for the reference `node` (slack bus) when PTDF-based DC load-flow is enabled."
+        ],
+        [
+            "node",
+            "node_slack_penalty",
+            null,
+            null,
+            "A penalty cost for `node_slack_pos` and `node_slack_neg` variables. The slack variables won't be included in the model unless there's a cost defined for them."
+        ],
+        [
+            "node",
+            "node_state_cap",
+            null,
+            null,
+            "The maximum permitted value for a `node_state` variable."
+        ],
+        [
+            "node",
+            "node_state_min",
+            0.0,
+            null,
+            "The minimum permitted value for a `node_state` variable."
+        ],
+        [
+            "node",
+            "number_of_storages",
+            1.0,
+            null,
+            "Denotes the number of 'sub storages' aggregated to form the modelled `node`."
+        ],
+        [
+            "node",
+            "state_coeff",
+            1.0,
+            null,
+            "Represents the `commodity` content of a `node_state` variable in respect to the `unit_flow` and `connection_flow` variables. Essentially, acts as a coefficient on the `node_state` variable in the `node_injection` constraint."
+        ],
+        [
+            "node",
+            "storage_decommissioning_cost",
+            null,
+            null,
+            "Costs associated with decommissioning a power plant. The costs will b discounted to the `discount_year``at distribted equally over the decommissioning time."
+        ],
+        [
+            "node",
+            "storage_decommissioning_time",
+            {
+                "type": "duration",
+                "data": "0h"
+            },
+            null,
+            "A storage's decommissioning time, i.e., the time between the moment at which a storage decommissioning decision is takien, and the moment at which decommissioning is complete."
+        ],
+        [
+            "node",
+            "storage_discount_rate_technology_specific",
+            0.0,
+            null,
+            "storage-specific discount rate used to calculate the storage's investment costs. If not specified, the model discount rate is used."
+        ],
+        [
+            "node",
+            "storage_fom_cost",
+            null,
+            null,
+            "Fixed operation and maintenance costs of a `node`. Essentially, a cost coefficient on the number of installed units and `node_state_cap` parameters. E.g. EUR/MWh"
+        ],
+        [
+            "node",
+            "storage_investment_cost",
+            null,
+            null,
+            "Determines the investment cost per unit state_cap over the investment life of a storage"
+        ],
+        [
+            "node",
+            "storage_investment_econ_lifetime",
+            null,
+            null,
+            "Economic lifetime for storage investment decisions."
+        ],
+        [
+            "node",
+            "storage_investment_tech_lifetime",
+            null,
+            null,
+            "Maximum technical lifetime for storage investment decisions."
+        ],
+        [
+            "node",
+            "storage_investment_variable_type",
+            "storage_investment_variable_type_integer",
+            "storage_investment_variable_type_list",
+            "Determines whether the storage investment variable is continuous (usually representing capacity) or integer (representing discrete units invested)"
+        ],
+        [
+            "node",
+            "storage_lead_time",
+            {
+                "type": "duration",
+                "data": "0h"
+            },
+            null,
+            "A storage's lead time, i.e., the time between the moment at which a storage investment decision is takien, and the moment at which the storage investment becomes operational."
+        ],
+        [
+            "node",
+            "storages_invested_big_m_mga",
+            null,
+            null,
+            "big_m_mga should be chosen as small as possible but sufficiently large. For units_invested_mga an appropriate big_m_mga would be twice the candidate storages."
+        ],
+        [
+            "node",
+            "storages_invested_mga",
+            false,
+            "boolean_value_list",
+            "Defines whether a certain variable (here: storages_invested) will be considered in the maximal-differences of the mga objective"
+        ],
+        [
+            "node",
+            "storages_invested_mga_weight",
+            1,
+            null,
+            "Used to scale mga variables. For weighted-sum mga method, the length of this weight given as an Array will determine the number of iterations."
+        ],
+        [
+            "node",
+            "tax_in_unit_flow",
+            null,
+            null,
+            "Tax costs for incoming `unit_flows` on this `node`. E.g. EUR/MWh."
+        ],
+        [
+            "node",
+            "tax_net_unit_flow",
+            null,
+            null,
+            "Tax costs for net incoming and outgoing `unit_flows` on this `node`. Incoming flows accrue positive net taxes, and outgoing flows accrue negative net taxes."
+        ],
+        [
+            "node",
+            "tax_out_unit_flow",
+            null,
+            null,
+            "Tax costs for outgoing `unit_flows` from this `node`. E.g. EUR/MWh."
+        ],
+        [
+            "node",
+            "upward_reserve",
+            false,
+            null,
+            "Identifier for `node`s providing upward reserves"
+        ],
+        [
+            "node__node",
+            "diff_coeff",
+            0.0,
+            null,
+            "Commodity diffusion coefficient between two `nodes`. Effectively, denotes the *diffusion power per unit of state* from the first `node` to the second."
+        ],
+        [
+            "node__stochastic_structure",
+            "is_active",
+            true,
+            "boolean_value_list",
+            "If false, the object is excluded from the model if the tool filter object activity control is specified"
+        ],
+        [
+            "node__temporal_block",
+            "cyclic_condition",
+            false,
+            "boolean_value_list",
+            "If the cyclic condition is set to true for a storage node, the `node_state` at the end of the optimization window has to be larger than or equal to the initial storage state."
+        ],
+        [
+            "node__temporal_block",
+            "is_active",
+            true,
+            "boolean_value_list",
+            "If false, the object is excluded from the model if the tool filter object activity control is specified"
+        ],
+        [
+            "node__user_constraint",
+            "demand_coefficient",
+            0.0,
+            null,
+            "coefficient of the specified node's demand in the specified user constraint"
+        ],
+        [
+            "node__user_constraint",
+            "node_state_coefficient",
+            0.0,
+            null,
+            "Coefficient of the specified node's state variable in the specified user constraint."
+        ],
+        [
+            "node__user_constraint",
+            "storages_invested_available_coefficient",
+            0.0,
+            null,
+            "Coefficient of the specified node's storages invested available variable in the specified user constraint."
+        ],
+        [
+            "node__user_constraint",
+            "storages_invested_coefficient",
+            0.0,
+            null,
+            "Coefficient of the specified node's storage investment variable in the specified user constraint."
+        ],
+        [
+            "output",
+            "is_active",
+            true,
+            "boolean_value_list",
+            "If false, the object is excluded from the model if the tool filter object activity control is specified"
+        ],
+        [
+            "output",
+            "output_resolution",
+            null,
+            null,
+            "Temporal resolution of the output variables associated with this `output`."
+        ],
+        [
+            "report",
+            "is_active",
+            true,
+            "boolean_value_list",
+            "If false, the object is excluded from the model if the tool filter object activity control is specified"
+        ],
+        [
+            "report",
+            "output_db_url",
+            null,
+            null,
+            "Database url for SpineOpt output."
+        ],
+        [
+            "report__output",
+            "overwrite_results_on_rolling",
+            true,
+            null,
+            "Whether or not results from further windows should overwrite results from previous ones."
+        ],
+        [
+            "settings",
+            "version",
+            14,
+            null,
+            "Current version of the SpineOpt data structure. Modify it at your own risk (but please don't)."
+        ],
+        [
+            "stage",
+            "is_active",
+            true,
+            "boolean_value_list",
+            "If false, the object is excluded from the model if the tool filter object activity control is specified"
+        ],
+        [
+            "stage",
+            "stage_scenario",
+            null,
+            null,
+            "The scenario that this `stage` should run (EXPERIMENTAL)."
+        ],
+        [
+            "stage__output__connection",
+            "output_resolution",
+            null,
+            null,
+            "A duration or array of durations indicating the points in time where the output of this stage should be fixed in the children. If not specified, then the output is fixed at the end of each child's roling window (EXPERIMENTAL)."
+        ],
+        [
+            "stage__output__node",
+            "output_resolution",
+            null,
+            null,
+            "A duration or array of durations indicating the points in time where the output of this stage should be fixed in the children. If not specified, then the output is fixed at the end of each child's roling window (EXPERIMENTAL)."
+        ],
+        [
+            "stage__output__unit",
+            "output_resolution",
+            null,
+            null,
+            "A duration or array of durations indicating the points in time where the output of this stage should be fixed in the children. If not specified, then the output is fixed at the end of each child's roling window (EXPERIMENTAL)."
+        ],
+        [
+            "stochastic_scenario",
+            "is_active",
+            true,
+            "boolean_value_list",
+            "If false, the object is excluded from the model if the tool filter object activity control is specified"
+        ],
+        [
+            "stochastic_structure",
+            "is_active",
+            true,
+            "boolean_value_list",
+            "If false, the object is excluded from the model if the tool filter object activity control is specified"
+        ],
+        [
+            "stochastic_structure__stochastic_scenario",
+            "stochastic_scenario_end",
+            null,
+            null,
+            "A `Duration` for when a `stochastic_scenario` ends and its `child_stochastic_scenarios` start. Values are interpreted relative to the start of the current solve, and if no value is given, the `stochastic_scenario` is assumed to continue indefinitely."
+        ],
+        [
+            "stochastic_structure__stochastic_scenario",
+            "weight_relative_to_parents",
+            1.0,
+            null,
+            "The weight of the `stochastic_scenario` in the objective function relative to its parents."
+        ],
+        [
+            "temporal_block",
+            "block_end",
+            null,
+            null,
+            "The end time for the `temporal_block`. Can be given either as a `DateTime` for a static end point, or as a `Duration` for an end point relative to the start of the current optimization."
+        ],
+        [
+            "temporal_block",
+            "block_start",
+            null,
+            null,
+            "The start time for the `temporal_block`. Can be given either as a `DateTime` for a static start point, or as a `Duration` for an start point relative to the start of the current optimization."
+        ],
+        [
+            "temporal_block",
+            "is_active",
+            true,
+            "boolean_value_list",
+            "If false, the object is excluded from the model if the tool filter object activity control is specified"
+        ],
+        [
+            "temporal_block",
+            "representative_periods_mapping",
+            null,
+            null,
+            "Map from date time to representative temporal block name"
+        ],
+        [
+            "temporal_block",
+            "resolution",
+            {
+                "type": "duration",
+                "data": "1h"
+            },
+            null,
+            "Temporal resolution of the `temporal_block`. Essentially, divides the period between `block_start` and `block_end` into `TimeSlices` with the input `resolution`."
+        ],
+        [
+            "temporal_block",
+            "weight",
+            1.0,
+            null,
+            "Weighting factor of the temporal block associated with the objective function"
+        ],
+        [
+            "unit",
+            "benders_starting_units_invested",
+            null,
+            null,
+            "Fixes the number of units invested during the first Benders iteration"
+        ],
+        [
+            "unit",
+            "candidate_units",
+            null,
+            null,
+            "Number of units which may be additionally constructed"
+        ],
+        [
+            "unit",
+            "curtailment_cost",
+            null,
+            null,
+            "Costs for curtailing generation. Essentially, accrues costs whenever `unit_flow` not operating at its maximum available capacity. E.g. EUR/MWh"
+        ],
+        [
+            "unit",
+            "fix_units_invested",
+            null,
+            null,
+            "Fix the value of the `units_invested` variable."
+        ],
+        [
+            "unit",
+            "fix_units_invested_available",
+            null,
+            null,
+            "Fix the value of the `units_invested_available` variable"
+        ],
+        [
+            "unit",
+            "fix_units_on",
+            null,
+            null,
+            "Fix the value of the `units_on` variable."
+        ],
+        [
+            "unit",
+            "fix_units_out_of_service",
+            null,
+            null,
+            "Fix the value of the `units_out_of_service` variable."
+        ],
+        [
+            "unit",
+            "fom_cost",
+            null,
+            null,
+            "Fixed operation and maintenance costs of a `unit`. Essentially, a cost coefficient on the existing units (incl. `number_of_units` and `units_invested_available`) and `unit_capacity` parameters. E.g. EUR/MWh"
+        ],
+        [
+            "unit",
+            "forced_availability_factor",
+            null,
+            null,
+            "Availability factor due to outages/deratings."
+        ],
+        [
+            "unit",
+            "graph_view_position",
+            null,
+            null,
+            "An optional setting for tweaking the position of the different elements when drawing them via Spine Toolbox Graph View."
+        ],
+        [
+            "unit",
+            "initial_units_invested",
+            null,
+            null,
+            "Initialize the value of the `units_invested` variable."
+        ],
+        [
+            "unit",
+            "initial_units_invested_available",
+            null,
+            null,
+            "Initialize the value of the `units_invested_available` variable"
+        ],
+        [
+            "unit",
+            "initial_units_on",
+            null,
+            null,
+            "Initialize the value of the `units_on` variable."
+        ],
+        [
+            "unit",
+            "initial_units_out_of_service",
+            null,
+            null,
+            "Initialize the value of the `units_out_of_service` variable."
+        ],
+        [
+            "unit",
+            "is_active",
+            true,
+            "boolean_value_list",
+            "If false, the object is excluded from the model if the tool filter object activity control is specified"
+        ],
+        [
+            "unit",
+            "is_renewable",
+            false,
+            "boolean_value_list",
+            "Whether the unit is renewable - used in the minimum renewable generation constraint within the Benders master problem"
+        ],
+        [
+            "unit",
+            "min_down_time",
+            null,
+            null,
+            "Minimum downtime of a `unit` after it shuts down."
+        ],
+        [
+            "unit",
+            "min_up_time",
+            null,
+            null,
+            "Minimum uptime of a `unit` after it starts up."
+        ],
+        [
+            "unit",
+            "number_of_units",
+            1.0,
+            null,
+            "Denotes the number of 'sub units' aggregated to form the modelled `unit`."
+        ],
+        [
+            "unit",
+            "online_variable_type",
+            "unit_online_variable_type_linear",
+            "unit_online_variable_type_list",
+            "A selector for how the `units_on` variable is represented within the model."
+        ],
+        [
+            "unit",
+            "outage_variable_type",
+            "unit_online_variable_type_none",
+            "unit_online_variable_type_list",
+            "Determines whether the outage variable is integer or continuous or none(no optimisation of maintenance outages)."
+        ],
+        [
+            "unit",
+            "scheduled_outage_duration",
+            null,
+            null,
+            "Specifies the amount of time a unit must be out of service for maintenance as a single block over the course of the optimisation window"
+        ],
+        [
+            "unit",
+            "shut_down_cost",
+            null,
+            null,
+            "Costs of shutting down a 'sub unit', e.g. EUR/shutdown."
+        ],
+        [
+            "unit",
+            "start_up_cost",
+            null,
+            null,
+            "Costs of starting up a 'sub unit', e.g. EUR/startup."
+        ],
+        [
+            "unit",
+            "unit_availability_factor",
+            1.0,
+            null,
+            "Availability of the `unit`, acting as a multiplier on its `unit_capacity`. Typically between 0-1."
+        ],
+        [
+            "unit",
+            "unit_decommissioning_cost",
+            null,
+            null,
+            "Costs associated with decommissioning a power plant. The costs will b discounted to the `discount_year``at distribted equally over the decommissioning time."
+        ],
+        [
+            "unit",
+            "unit_decommissioning_time",
+            {
+                "type": "duration",
+                "data": "0h"
+            },
+            null,
+            "A unit's decommissioning time, i.e., the time between the moment at which a unit decommissioning decision is takien, and the moment at which decommissioning is complete."
+        ],
+        [
+            "unit",
+            "unit_discount_rate_technology_specific",
+            0.0,
+            null,
+            "Unit-specific discount rate used to calculate the unit's investment costs. If not specified, the model discount rate is used."
+        ],
+        [
+            "unit",
+            "unit_investment_cost",
+            null,
+            null,
+            "Investment cost per 'sub unit' built."
+        ],
+        [
+            "unit",
+            "unit_investment_econ_lifetime",
+            null,
+            null,
+            "Economic lifetime for unit investment decisions."
+        ],
+        [
+            "unit",
+            "unit_investment_tech_lifetime",
+            null,
+            null,
+            "Maximum technical lifetime for unit investment decisions."
+        ],
+        [
+            "unit",
+            "unit_investment_variable_type",
+            "unit_investment_variable_type_continuous",
+            "unit_investment_variable_type_list",
+            "Determines whether investment variable is integer or continuous."
+        ],
+        [
+            "unit",
+            "unit_lead_time",
+            {
+                "type": "duration",
+                "data": "0h"
+            },
+            null,
+            "A unit's lead time, i.e., the time between the moment at which a unit investment decision is takien, and the moment at which the unit investment becomes operational."
+        ],
+        [
+            "unit",
+            "units_invested_big_m_mga",
+            null,
+            null,
+            "big_m_mga should be chosen as small as possible but sufficiently large. For units_invested_mga an appropriate big_m_mga would be twice the candidate units."
+        ],
+        [
+            "unit",
+            "units_invested_mga",
+            false,
+            "boolean_value_list",
+            "Defines whether a certain variable (here: units_invested) will be considered in the maximal-differences of the mga objective"
+        ],
+        [
+            "unit",
+            "units_invested_mga_weight",
+            1,
+            null,
+            "Used to scale mga variables. For weightd sum mga method, the length of this weight given as an Array will determine the number of iterations."
+        ],
+        [
+            "unit",
+            "units_on_cost",
+            null,
+            null,
+            "Objective function coefficient on `units_on`. An idling cost, for example"
+        ],
+        [
+            "unit",
+            "units_on_non_anticipativity_margin",
+            null,
+            null,
+            "Margin by which `units_on` variable can differ from the value in the previous window during `non_anticipativity_time`."
+        ],
+        [
+            "unit",
+            "units_on_non_anticipativity_time",
+            null,
+            null,
+            "Period of time where the value of the `units_on` variable has to be fixed to the result from the previous window."
+        ],
+        [
+            "unit",
+            "units_unavailable",
+            0,
+            null,
+            "Represents the number of units out of service"
+        ],
+        [
+            "unit__commodity",
+            "max_cum_in_unit_flow_bound",
+            null,
+            null,
+            "Set a maximum cumulative upper bound for a `unit_flow`"
+        ],
+        [
+            "unit__from_node",
+            "fix_nonspin_ramp_up_unit_flow",
+            null,
+            null,
+            "Fix the `nonspin_ramp_up_unit_flow` variable."
+        ],
+        [
+            "unit__from_node",
+            "fix_nonspin_units_started_up",
+            null,
+            null,
+            "Fix the `nonspin_units_started_up` variable."
+        ],
+        [
+            "unit__from_node",
+            "fix_ramp_up_unit_flow",
+            null,
+            null,
+            "Fix the `ramp_up_unit_flow` variable."
+        ],
+        [
+            "unit__from_node",
+            "fix_start_up_unit_flow",
+            null,
+            null,
+            "Fix the `start_up_unit_flow` variable."
+        ],
+        [
+            "unit__from_node",
+            "fix_unit_flow",
+            null,
+            null,
+            "Fix the `unit_flow` variable."
+        ],
+        [
+            "unit__from_node",
+            "fix_unit_flow_op",
+            null,
+            null,
+            "Fix the `unit_flow_op` variable."
+        ],
+        [
+            "unit__from_node",
+            "fuel_cost",
+            null,
+            null,
+            "Variable fuel costs than can be attributed to a `unit_flow`. E.g. EUR/MWh"
+        ],
+        [
+            "unit__from_node",
+            "graph_view_position",
+            null,
+            null,
+            "An optional setting for tweaking the position of the different elements when drawing them via Spine Toolbox Graph View."
+        ],
+        [
+            "unit__from_node",
+            "initial_nonspin_ramp_up_unit_flow",
+            null,
+            null,
+            "Initialize the `nonspin_ramp_up_unit_flow` variable."
+        ],
+        [
+            "unit__from_node",
+            "initial_nonspin_units_started_up",
+            null,
+            null,
+            "Initialize the `nonspin_units_started_up` variable."
+        ],
+        [
+            "unit__from_node",
+            "initial_ramp_up_unit_flow",
+            null,
+            null,
+            "Initialize the `ramp_up_unit_flow` variable."
+        ],
+        [
+            "unit__from_node",
+            "initial_start_up_unit_flow",
+            null,
+            null,
+            "Initialize the `start_up_unit_flow` variable."
+        ],
+        [
+            "unit__from_node",
+            "initial_unit_flow",
+            null,
+            null,
+            "Initialize the `unit_flow` variable."
+        ],
+        [
+            "unit__from_node",
+            "initial_unit_flow_op",
+            null,
+            null,
+            "Initialize the `unit_flow_op` variable."
+        ],
+        [
+            "unit__from_node",
+            "is_active",
+            true,
+            "boolean_value_list",
+            "If false, the object is excluded from the model if the tool filter object activity control is specified"
+        ],
+        [
+            "unit__from_node",
+            "max_res_shutdown_ramp",
+            null,
+            null,
+            "Max. downward reserve ramp for online units scheduled to shut down for reserve provision"
+        ],
+        [
+            "unit__from_node",
+            "max_res_startup_ramp",
+            null,
+            null,
+            "Maximum non-spinning reserve ramp-up for startups."
+        ],
+        [
+            "unit__from_node",
+            "max_shutdown_ramp",
+            null,
+            null,
+            "Max. downward ramp for units shutting down"
+        ],
+        [
+            "unit__from_node",
+            "max_startup_ramp",
+            null,
+            null,
+            "Maximum ramp-up during startups."
+        ],
+        [
+            "unit__from_node",
+            "max_total_cumulated_unit_flow_from_node",
+            null,
+            null,
+            "Bound on the maximum cumulated flows of a unit group from a node group e.g max consumption of certain commodity."
+        ],
+        [
+            "unit__from_node",
+            "min_res_shutdown_ramp",
+            null,
+            null,
+            "Minimum non-spinning reserve ramp-down for online units providing reserves during shut-downs"
+        ],
+        [
+            "unit__from_node",
+            "min_res_startup_ramp",
+            null,
+            null,
+            "Minimum non-spinning reserve ramp-up for startups."
+        ],
+        [
+            "unit__from_node",
+            "min_shutdown_ramp",
+            null,
+            null,
+            "Minimum ramp-up during startups"
+        ],
+        [
+            "unit__from_node",
+            "min_startup_ramp",
+            null,
+            null,
+            "Minimum ramp-up during startups."
+        ],
+        [
+            "unit__from_node",
+            "min_total_cumulated_unit_flow_from_node",
+            null,
+            null,
+            "Bound on the minimum cumulated flows of a unit group from a node group."
+        ],
+        [
+            "unit__from_node",
+            "min_unit_flow",
+            0.0,
+            null,
+            "Set lower bound of the `unit_flow` variable."
+        ],
+        [
+            "unit__from_node",
+            "minimum_operating_point",
+            null,
+            null,
+            "Minimum level for the `unit_flow` relative to the `units_on` online capacity."
+        ],
+        [
+            "unit__from_node",
+            "operating_points",
+            null,
+            null,
+            "Operating points for piecewise-linear `unit` efficiency approximations."
+        ],
+        [
+            "unit__from_node",
+            "ordered_unit_flow_op",
+            false,
+            "boolean_value_list",
+            "Defines whether the segments of this unit flow are ordered as per the rank of their operating points."
+        ],
+        [
+            "unit__from_node",
+            "ramp_down_cost",
+            null,
+            null,
+            "Costs for ramping down"
+        ],
+        [
+            "unit__from_node",
+            "ramp_down_limit",
+            null,
+            null,
+            "Limit the maximum ramp-down rate of an online unit, given as a fraction of the unit_capacity. [ramp_down_limit] = %/t, e.g. 0.2/h"
+        ],
+        [
+            "unit__from_node",
+            "ramp_up_cost",
+            null,
+            null,
+            "Costs for ramping up"
+        ],
+        [
+            "unit__from_node",
+            "ramp_up_limit",
+            null,
+            null,
+            "Limit the maximum ramp-up rate of an online unit, given as a fraction of the unit_capacity. [ramp_up_limit] = %/t, e.g. 0.2/h"
+        ],
+        [
+            "unit__from_node",
+            "reserve_procurement_cost",
+            null,
+            null,
+            "Procurement cost for reserves"
+        ],
+        [
+            "unit__from_node",
+            "shut_down_limit",
+            null,
+            null,
+            "Maximum ramp-down during shutdowns"
+        ],
+        [
+            "unit__from_node",
+            "start_up_limit",
+            null,
+            null,
+            "Maximum ramp-up during startups"
+        ],
+        [
+            "unit__from_node",
+            "unit_capacity",
+            null,
+            null,
+            "Maximum `unit_flow` capacity of a single 'sub_unit' of the `unit`."
+        ],
+        [
+            "unit__from_node",
+            "unit_conv_cap_to_flow",
+            1.0,
+            null,
+            "Optional coefficient for `unit_capacity` unit conversions in the case the `unit_capacity` value is incompatible with the desired `unit_flow` units."
+        ],
+        [
+            "unit__from_node",
+            "unit_flow_non_anticipativity_margin",
+            null,
+            null,
+            "Margin by which `unit_flow` variable can differ from the value in the previous window during `non_anticipativity_time`."
+        ],
+        [
+            "unit__from_node",
+            "unit_flow_non_anticipativity_time",
+            null,
+            null,
+            "Period of time where the value of the `unit_flow` variable has to be fixed to the result from the previous window."
+        ],
+        [
+            "unit__from_node",
+            "use_unit_capacity_for_investment_cost_scaling",
+            false,
+            "boolean_value_list",
+            "If this boolean parameter is set to `true`, the capacity defined on this `unit__from_node` capacity will be used to scale investment costs (given in e.g. \u20ac/MW)"
+        ],
+        [
+            "unit__from_node",
+            "vom_cost",
+            null,
+            null,
+            "Variable operating costs of a `unit_flow` variable. E.g. EUR/MWh."
+        ],
+        [
+            "unit__from_node__user_constraint",
+            "graph_view_position",
+            null,
+            null,
+            "An optional setting for tweaking the position of the different elements when drawing them via Spine Toolbox Graph View."
+        ],
+        [
+            "unit__from_node__user_constraint",
+            "unit_flow_coefficient",
+            0.0,
+            null,
+            "Coefficient of a `unit_flow` variable for a custom `user_constraint`."
+        ],
+        [
+            "unit__node__node",
+            "fix_ratio_in_in_unit_flow",
+            null,
+            null,
+            "Fix the ratio between two `unit_flows` coming into the `unit` from the two `nodes`."
+        ],
+        [
+            "unit__node__node",
+            "fix_ratio_in_out_unit_flow",
+            null,
+            null,
+            "Fix the ratio between an incoming `unit_flow` from the first `node` and an outgoing `unit_flow` to the second `node`."
+        ],
+        [
+            "unit__node__node",
+            "fix_ratio_out_in_unit_flow",
+            null,
+            null,
+            "Fix the ratio between an outgoing `unit_flow` to the first `node` and an incoming `unit_flow` from the second `node`."
+        ],
+        [
+            "unit__node__node",
+            "fix_ratio_out_out_unit_flow",
+            null,
+            null,
+            "Fix the ratio between two `unit_flows` going from the `unit` into the two `nodes`."
+        ],
+        [
+            "unit__node__node",
+            "fix_units_on_coefficient_in_in",
+            0.0,
+            null,
+            "Optional coefficient for the `units_on` variable impacting the `fix_ratio_in_in_unit_flow` constraint."
+        ],
+        [
+            "unit__node__node",
+            "fix_units_on_coefficient_in_out",
+            0.0,
+            null,
+            "Optional coefficient for the `units_on` variable impacting the `fix_ratio_in_out_unit_flow` constraint."
+        ],
+        [
+            "unit__node__node",
+            "fix_units_on_coefficient_out_in",
+            0.0,
+            null,
+            "Optional coefficient for the `units_on` variable impacting the `fix_ratio_out_in_unit_flow` constraint."
+        ],
+        [
+            "unit__node__node",
+            "fix_units_on_coefficient_out_out",
+            0.0,
+            null,
+            "Optional coefficient for the `units_on` variable impacting the `fix_ratio_out_out_unit_flow` constraint."
+        ],
+        [
+            "unit__node__node",
+            "max_ratio_in_in_unit_flow",
+            null,
+            null,
+            "Maximum ratio between two `unit_flows` coming into the `unit` from the two `nodes`."
+        ],
+        [
+            "unit__node__node",
+            "max_ratio_in_out_unit_flow",
+            null,
+            null,
+            "Maximum ratio between an incoming `unit_flow` from the first `node` and an outgoing `unit_flow` to the second `node`."
+        ],
+        [
+            "unit__node__node",
+            "max_ratio_out_in_unit_flow",
+            null,
+            null,
+            "Maximum ratio between an outgoing `unit_flow` to the first `node` and an incoming `unit_flow` from the second `node`."
+        ],
+        [
+            "unit__node__node",
+            "max_ratio_out_out_unit_flow",
+            null,
+            null,
+            "Maximum ratio between two `unit_flows` going from the `unit` into the two `nodes`."
+        ],
+        [
+            "unit__node__node",
+            "max_units_on_coefficient_in_in",
+            0.0,
+            null,
+            "Optional coefficient for the `units_on` variable impacting the `max_ratio_in_in_unit_flow` constraint."
+        ],
+        [
+            "unit__node__node",
+            "max_units_on_coefficient_in_out",
+            0.0,
+            null,
+            "Optional coefficient for the `units_on` variable impacting the `max_ratio_in_out_unit_flow` constraint."
+        ],
+        [
+            "unit__node__node",
+            "max_units_on_coefficient_out_in",
+            0.0,
+            null,
+            "Optional coefficient for the `units_on` variable impacting the `max_ratio_out_in_unit_flow` constraint."
+        ],
+        [
+            "unit__node__node",
+            "max_units_on_coefficient_out_out",
+            0.0,
+            null,
+            "Optional coefficient for the `units_on` variable impacting the `max_ratio_out_out_unit_flow` constraint."
+        ],
+        [
+            "unit__node__node",
+            "min_ratio_in_in_unit_flow",
+            null,
+            null,
+            "Minimum ratio between two `unit_flows` coming into the `unit` from the two `nodes`."
+        ],
+        [
+            "unit__node__node",
+            "min_ratio_in_out_unit_flow",
+            null,
+            null,
+            "Minimum ratio between an incoming `unit_flow` from the first `node` and an outgoing `unit_flow` to the second `node`."
+        ],
+        [
+            "unit__node__node",
+            "min_ratio_out_in_unit_flow",
+            null,
+            null,
+            "Minimum ratio between an outgoing `unit_flow` to the first `node` and an incoming `unit_flow` from the second `node`."
+        ],
+        [
+            "unit__node__node",
+            "min_ratio_out_out_unit_flow",
+            null,
+            null,
+            "Minimum ratio between two `unit_flows` going from the `unit` into the two `nodes`."
+        ],
+        [
+            "unit__node__node",
+            "min_units_on_coefficient_in_in",
+            0.0,
+            null,
+            "Optional coefficient for the `units_on` variable impacting the `min_ratio_in_in_unit_flow` constraint."
+        ],
+        [
+            "unit__node__node",
+            "min_units_on_coefficient_in_out",
+            0.0,
+            null,
+            "Optional coefficient for the `units_on` variable impacting the `min_ratio_in_out_unit_flow` constraint."
+        ],
+        [
+            "unit__node__node",
+            "min_units_on_coefficient_out_in",
+            0.0,
+            null,
+            "Optional coefficient for the `units_on` variable impacting the `min_ratio_out_in_unit_flow` constraint."
+        ],
+        [
+            "unit__node__node",
+            "min_units_on_coefficient_out_out",
+            0.0,
+            null,
+            "Optional coefficient for the `units_on` variable impacting the `min_ratio_out_out_unit_flow` constraint."
+        ],
+        [
+            "unit__node__node",
+            "unit_idle_heat_rate",
+            0.0,
+            null,
+            "Flow from node1 per unit time and per `units_on` that results in no additional flow to node2"
+        ],
+        [
+            "unit__node__node",
+            "unit_incremental_heat_rate",
+            null,
+            null,
+            "Standard piecewise incremental heat rate where node1 is assumed to be the fuel and node2 is assumed to be electriciy. Assumed monotonically increasing. Array type or single coefficient where the number of coefficients must match the dimensions of `unit_operating_points`"
+        ],
+        [
+            "unit__node__node",
+            "unit_start_flow",
+            0.0,
+            null,
+            "Flow from node1 that is incurred when a unit is started up."
+        ],
+        [
+            "unit__to_node",
+            "fix_nonspin_ramp_down_unit_flow",
+            null,
+            null,
+            "Fix the `nonspin_ramp_down_unit_flow` variable."
+        ],
+        [
+            "unit__to_node",
+            "fix_nonspin_ramp_up_unit_flow",
+            null,
+            null,
+            "Fix the `nonspin_ramp_up_unit_flow` variable."
+        ],
+        [
+            "unit__to_node",
+            "fix_nonspin_units_shut_down",
+            null,
+            null,
+            "Fix the `nonspin_units_shut_down` variable."
+        ],
+        [
+            "unit__to_node",
+            "fix_nonspin_units_started_up",
+            null,
+            null,
+            "Fix the `nonspin_units_started_up` variable."
+        ],
+        [
+            "unit__to_node",
+            "fix_ramp_down_unit_flow",
+            null,
+            null,
+            "Fix the `ramp_down_unit_flow` variable."
+        ],
+        [
+            "unit__to_node",
+            "fix_ramp_up_unit_flow",
+            null,
+            null,
+            "Fix the `ramp_up_unit_flow` variable."
+        ],
+        [
+            "unit__to_node",
+            "fix_shut_down_unit_flow",
+            null,
+            null,
+            "Fix the `shut_down_unit_flow` variable."
+        ],
+        [
+            "unit__to_node",
+            "fix_start_up_unit_flow",
+            null,
+            null,
+            "Fix the `start_up_unit_flow` variable."
+        ],
+        [
+            "unit__to_node",
+            "fix_unit_flow",
+            null,
+            null,
+            "Fix the `unit_flow` variable."
+        ],
+        [
+            "unit__to_node",
+            "fix_unit_flow_op",
+            null,
+            null,
+            "Fix the `unit_flow_op` variable."
+        ],
+        [
+            "unit__to_node",
+            "fuel_cost",
+            null,
+            null,
+            "Variable fuel costs than can be attributed to a `unit_flow`. E.g. EUR/MWh"
+        ],
+        [
+            "unit__to_node",
+            "graph_view_position",
+            null,
+            null,
+            "An optional setting for tweaking the position of the different elements when drawing them via Spine Toolbox Graph View."
+        ],
+        [
+            "unit__to_node",
+            "initial_nonspin_ramp_down_unit_flow",
+            null,
+            null,
+            "Initialize the `nonspin_ramp_down_unit_flow` variable."
+        ],
+        [
+            "unit__to_node",
+            "initial_nonspin_ramp_up_unit_flow",
+            null,
+            null,
+            "Initialize the `nonspin_ramp_up_unit_flow` variable."
+        ],
+        [
+            "unit__to_node",
+            "initial_nonspin_units_shut_down",
+            null,
+            null,
+            "Initialize the `nonspin_units_shut_down` variable."
+        ],
+        [
+            "unit__to_node",
+            "initial_nonspin_units_started_up",
+            null,
+            null,
+            "Initialize the `nonspin_units_started_up` variable."
+        ],
+        [
+            "unit__to_node",
+            "initial_ramp_down_unit_flow",
+            null,
+            null,
+            "Initialize the `ramp_down_unit_flow` variable."
+        ],
+        [
+            "unit__to_node",
+            "initial_ramp_up_unit_flow",
+            null,
+            null,
+            "Initialize the `ramp_up_unit_flow` variable."
+        ],
+        [
+            "unit__to_node",
+            "initial_shut_down_unit_flow",
+            null,
+            null,
+            "Initialize the `shut_down_unit_flow` variable."
+        ],
+        [
+            "unit__to_node",
+            "initial_start_up_unit_flow",
+            null,
+            null,
+            "Initialize the `start_up_unit_flow` variable."
+        ],
+        [
+            "unit__to_node",
+            "initial_unit_flow",
+            null,
+            null,
+            "Initialize the `unit_flow` variable."
+        ],
+        [
+            "unit__to_node",
+            "initial_unit_flow_op",
+            null,
+            null,
+            "Initialize the `unit_flow_op` variable."
+        ],
+        [
+            "unit__to_node",
+            "is_active",
+            true,
+            "boolean_value_list",
+            "If false, the object is excluded from the model if the tool filter object activity control is specified"
+        ],
+        [
+            "unit__to_node",
+            "max_total_cumulated_unit_flow_to_node",
+            null,
+            null,
+            "Bound on the maximum cumulated flows of a unit group to a node group, e.g. total GHG emissions."
+        ],
+        [
+            "unit__to_node",
+            "min_total_cumulated_unit_flow_to_node",
+            null,
+            null,
+            "Bound on the minimum cumulated flows of a unit group to a node group, e.g. total renewable production."
+        ],
+        [
+            "unit__to_node",
+            "min_unit_flow",
+            0.0,
+            null,
+            "Set lower bound of the `unit_flow` variable."
+        ],
+        [
+            "unit__to_node",
+            "minimum_operating_point",
+            null,
+            null,
+            "Minimum level for the `unit_flow` relative to the `units_on` online capacity."
+        ],
+        [
+            "unit__to_node",
+            "operating_points",
+            null,
+            null,
+            "Decomposes the flow variable into a number of separate operating segment variables. Used to in conjunction with `unit_incremental_heat_rate` and/or `user_constraint`s"
+        ],
+        [
+            "unit__to_node",
+            "ordered_unit_flow_op",
+            false,
+            "boolean_value_list",
+            "Defines whether the segments of this unit flow are ordered as per the rank of their operating points."
+        ],
+        [
+            "unit__to_node",
+            "ramp_down_cost",
+            null,
+            null,
+            "Costs of ramping down"
+        ],
+        [
+            "unit__to_node",
+            "ramp_down_limit",
+            null,
+            null,
+            "Limit the maximum ramp-down rate of an online unit, given as a fraction of the unit_capacity. [ramp_down_limit] = %/t, e.g. 0.2/h"
+        ],
+        [
+            "unit__to_node",
+            "ramp_up_cost",
+            null,
+            null,
+            "Costs of ramping up"
+        ],
+        [
+            "unit__to_node",
+            "ramp_up_limit",
+            null,
+            null,
+            "Limit the maximum ramp-up rate of an online unit, given as a fraction of the unit_capacity. [ramp_up_limit] = %/t, e.g. 0.2/h"
+        ],
+        [
+            "unit__to_node",
+            "reserve_procurement_cost",
+            null,
+            null,
+            "Procurement cost for reserves"
+        ],
+        [
+            "unit__to_node",
+            "shut_down_limit",
+            null,
+            null,
+            "Maximum ramp-down during shutdowns"
+        ],
+        [
+            "unit__to_node",
+            "start_up_limit",
+            null,
+            null,
+            "Maximum ramp-up during startups"
+        ],
+        [
+            "unit__to_node",
+            "unit_capacity",
+            null,
+            null,
+            "Maximum `unit_flow` capacity of a single 'sub_unit' of the `unit`."
+        ],
+        [
+            "unit__to_node",
+            "unit_conv_cap_to_flow",
+            1.0,
+            null,
+            "Optional coefficient for `unit_capacity` unit conversions in the case the `unit_capacity` value is incompatible with the desired `unit_flow` units."
+        ],
+        [
+            "unit__to_node",
+            "unit_flow_non_anticipativity_margin",
+            null,
+            null,
+            "Margin by which `unit_flow` variable can differ from the value in the previous window during `non_anticipativity_time`."
+        ],
+        [
+            "unit__to_node",
+            "unit_flow_non_anticipativity_time",
+            null,
+            null,
+            "Period of time where the value of the `unit_flow` variable has to be fixed to the result from the previous window."
+        ],
+        [
+            "unit__to_node",
+            "use_unit_capacity_for_investment_cost_scaling",
+            false,
+            "boolean_value_list",
+            "If this boolean parameter is set to `true`, the capacity defined on this `unit__to_node` capacity will be used to scale investment costs (given in e.g. \u20ac/MW)"
+        ],
+        [
+            "unit__to_node",
+            "vom_cost",
+            null,
+            null,
+            "Variable operating costs of a `unit_flow` variable. E.g. EUR/MWh."
+        ],
+        [
+            "unit__to_node__user_constraint",
+            "graph_view_position",
+            null,
+            null,
+            "An optional setting for tweaking the position of the different elements when drawing them via Spine Toolbox Graph View."
+        ],
+        [
+            "unit__to_node__user_constraint",
+            "unit_flow_coefficient",
+            0.0,
+            null,
+            "Coefficient of a `unit_flow` variable for a custom `user_constraint`."
+        ],
+        [
+            "unit__user_constraint",
+            "units_invested_available_coefficient",
+            0.0,
+            null,
+            "Coefficient of the `units_invested_available` variable in the specified `user_constraint`."
+        ],
+        [
+            "unit__user_constraint",
+            "units_invested_coefficient",
+            0.0,
+            null,
+            "Coefficient of the `units_invested` variable in the specified `user_constraint`."
+        ],
+        [
+            "unit__user_constraint",
+            "units_on_coefficient",
+            0.0,
+            null,
+            "Coefficient of a `units_on` variable for a custom `user_constraint`."
+        ],
+        [
+            "unit__user_constraint",
+            "units_started_up_coefficient",
+            0.0,
+            null,
+            "Coefficient of a `units_started_up` variable for a custom `user_constraint`."
+        ],
+        [
+            "units_on__stochastic_structure",
+            "is_active",
+            true,
+            "boolean_value_list",
+            "If false, the object is excluded from the model if the tool filter object activity control is specified"
+        ],
+        [
+            "units_on__temporal_block",
+            "is_active",
+            true,
+            "boolean_value_list",
+            "If false, the object is excluded from the model if the tool filter object activity control is specified"
+        ],
+        [
+            "user_constraint",
+            "constraint_sense",
+            "==",
+            "constraint_sense_list",
+            "A selector for the sense of the `user_constraint`."
+        ],
+        [
+            "user_constraint",
+            "is_active",
+            true,
+            "boolean_value_list",
+            "If false, the object is excluded from the model if the tool filter object activity control is specified"
+        ],
+        [
+            "user_constraint",
+            "right_hand_side",
+            0.0,
+            null,
+            "The right-hand side, constant term in a `user_constraint`. Can be time-dependent and used e.g. for complicated efficiency approximations."
+        ],
+        [
+            "user_constraint",
+            "user_constraint_slack_penalty",
+            null,
+            null,
+            "A penalty for violating a user constraint."
+        ]
+    ],
+    "parameter_values": [
+        [
+            "node",
+            "electricity_node",
+            "demand",
+            {
+                "type": "map",
+                "index_type": "str",
+                "rank": 1,
+                "data": [
+                    [
+                        "base",
+                        150.0
+                    ],
+                    [
+                        "forecast1",
+                        100.0
+                    ],
+                    [
+                        "forecast2",
+                        120.0
+                    ],
+                    [
+                        "forecast3",
+                        140.0
+                    ]
+                ]
+            },
+            "Base"
+        ],
+        [
+            "node",
+            "fuel_node",
+            "balance_type",
+            "balance_type_none",
+            "Base"
+        ],
+        [
+            "stochastic_structure__stochastic_scenario",
+            [
+                "DAG",
+                "base"
+            ],
+            "stochastic_scenario_end",
+            {
+                "type": "duration",
+                "data": "6h"
+            },
+            "Base"
+        ],
+        [
+            "stochastic_structure__stochastic_scenario",
+            [
+                "DAG",
+                "forecast1"
+            ],
+            "weight_relative_to_parents",
+            0.33,
+            "Base"
+        ],
+        [
+            "stochastic_structure__stochastic_scenario",
+            [
+                "DAG",
+                "forecast2"
+            ],
+            "weight_relative_to_parents",
+            0.34,
+            "Base"
+        ],
+        [
+            "stochastic_structure__stochastic_scenario",
+            [
+                "DAG",
+                "forecast3"
+            ],
+            "weight_relative_to_parents",
+            0.33,
+            "Base"
+        ],
+        [
+            "temporal_block",
+            "flat",
+            "resolution",
+            {
+                "type": "duration",
+                "data": "1h"
+            },
+            "Base"
+        ],
+        [
+            "unit__from_node",
+            [
+                "power_plant_a",
+                "fuel_node"
+            ],
+            "vom_cost",
+            25,
+            "Base"
+        ],
+        [
+            "unit__from_node",
+            [
+                "power_plant_b",
+                "fuel_node"
+            ],
+            "vom_cost",
+            50,
+            "Base"
+        ],
+        [
+            "unit__node__node",
+            [
+                "power_plant_a",
+                "electricity_node",
+                "fuel_node"
+            ],
+            "fix_ratio_out_in_unit_flow",
+            0.7,
+            "Base"
+        ],
+        [
+            "unit__node__node",
+            [
+                "power_plant_b",
+                "electricity_node",
+                "fuel_node"
+            ],
+            "fix_ratio_out_in_unit_flow",
+            0.8,
+            "Base"
+        ],
+        [
+            "unit__to_node",
+            [
+                "power_plant_a",
+                "electricity_node"
+            ],
+            "unit_capacity",
+            100,
+            "Base"
+        ],
+        [
+            "unit__to_node",
+            [
+                "power_plant_b",
+                "electricity_node"
+            ],
+            "unit_capacity",
+            200,
+            "Base"
+        ]
+    ],
+    "alternatives": [
+        [
+            "Base",
+            "Base alternative"
+        ]
+    ]
+}


### PR DESCRIPTION
Originally stochastic.json belonging to the stochastic tutorial did not have an extension. That is how it bypassed the tests. When the extension was corrected, it did cause errors. There seems to be an issue with the DAG of the extended tutorial. The tutorial does not explicitly cover this part so for now it is ok to remove the additional part.

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted according to SpineOpt's style
- [x] Unit tests pass
