### PR TITLE
Change indices function in the fixed_om_costs function

### DIFF
--- a/src/objective/fixed_om_costs.jl
+++ b/src/objective/fixed_om_costs.jl
@@ -46,7 +46,7 @@ function fixed_om_costs(m, t_range)
             # an extended period of time with a weight >=1, e.g. a representative month represents 3 months.
             * duration(t) 
             for (u, ng, d) in indices(unit_capacity; unit=indices(fom_cost))
-            for (u, _n, _d, s, t) in unit_flow_indices(m; unit=u, node=ng, direction=d, t=t_range);
+            for (u, s, t) in units_invested_available_indices(m; unit=u, t=t_range);
             init=0,
         )
     )

--- a/src/objective/fixed_om_costs.jl
+++ b/src/objective/fixed_om_costs.jl
@@ -46,7 +46,14 @@ function fixed_om_costs(m, t_range)
             # an extended period of time with a weight >=1, e.g. a representative month represents 3 months.
             * duration(t) 
             for (u, ng, d) in indices(unit_capacity; unit=indices(fom_cost))
-            for (u, s, t) in units_invested_available_indices(m; unit=u, t=t_range);
+            for (u, s, t) in Iterators.flatten(
+                u in intersect(indices(candidate_units), members(u)) ? 
+                (units_invested_available_indices(m; unit=u, t=t_range),) :
+                ((
+                    (u, s, t) for (u, _n, _d, s, t) 
+                    in unit_flow_indices(m; unit=u, node=ng, direction=d, t=t_range)
+                ),)
+            );
             init=0,
         )
     )


### PR DESCRIPTION
Using `units_invested_available_indices` in the function `fixed_om_costs` to avoid errors when using the representative periods feature.

Fixes #1122 

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted according to SpineOpt's style
- [x] Unit tests pass
