### PR TITLE
Add troubleshooting for long names in the solver

### DIFF
--- a/docs/src/getting_started/troubleshooting.md
+++ b/docs/src/getting_started/troubleshooting.md
@@ -8,6 +8,11 @@ Have you created a new project? File > New project
 ## I get an error that the 'model' object is not defined in the database
 That tends to happen when you accidentally switched your input and output in the Run SpineOpt tool.
 
+## Solver throws error `Name too long`
+Variables and constraints names in SpineOpt sometimes can be longer than the maximum name length the solvers allow. If you get this error, we recommend using the solver parameters to run it ingnoring the names. For instance, Gurobi has the parameter `IgnoreNames` which allows to run without the names but returning the solution with the original names in the model.
+
+To setup the solver parameters you can look at the [How-to section](@ref how-to-change-solver) guide change the solver and define its parameters.
+
 ## SpineOpt and SpineInterface are out of sync
 Some of the development of SpineOpt depends on the development of SpineInterface and vice versa. At some points in time that can create an incompatibility between the two.
 

--- a/docs/src/how_to/change_the_solver.md
+++ b/docs/src/how_to/change_the_solver.md
@@ -1,4 +1,4 @@
-# How to change the solver
+# [How to change the solver](@id how-to-change-solver)
 
 If you want to change the solver for your optimization problem in SpineOpt, here is some guidance:
 - You can change the solvers in your input datastore using the `db_lp_solver` and `db_mip_solver` parameter values of the `model` object.


### PR DESCRIPTION
This pull request includes updates to the documentation to address a common solver error and provide guidance on changing solver parameters in SpineOpt.

Documentation updates:

* [`docs/src/getting_started/troubleshooting.md`](diffhunk://#diff-71f97fe067e112765767b69ec61531216040d3f04c918ab8e5773d408e019d44R11-R15): Added a new section to address the "Name too long" error thrown by solvers and provided a solution using solver parameters.
* [`docs/src/how_to/change_the_solver.md`](diffhunk://#diff-f6e131ab1bfed54bece1555437c1d583a22e10a29331c98e4e7abc692fb1d73aL1-R1): Updated the header to include an encoded reference for easier navigation within the documentation.

Fixes #1126

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted according to SpineOpt's style
- [x] Unit tests pass
