### PR TITLE
Add options to improve model creation speed

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -36,6 +36,7 @@ pages = [
         "Installation" => joinpath("getting_started", "installation.md"),
         "Verify installation" => joinpath("getting_started", "recommended_workflow.md"),
         "Troubleshooting" => joinpath("getting_started", "troubleshooting.md"),
+        "Performace tips" => joinpath("getting_started", "performance_tips.md"),
     ],
     "Tutorials" => Any[
         "Webinars" => joinpath("tutorial", "webinars.md"),

--- a/docs/src/getting_started/performance_tips.md
+++ b/docs/src/getting_started/performance_tips.md
@@ -1,0 +1,3 @@
+# [Perfomance tips](@id performance_tips)
+
+By default, SpineOpt generates names for variables when creating models in JuMP. These names help users quickly identify data issues if the model becomes infeasible. However, generating these names can add extra computational overhead. For more information, see the [JuMP documentation](https://jump.dev/JuMP.jl/stable/tutorials/getting_started/performance_tips/#Disable-string-names). To improve the speed of SpineOpt runs, users can disable name creation by passing the argument `use_model_names = false` when calling the function [run_spineopt](https://spine-tools.github.io/SpineOpt.jl/latest/library/#SpineOpt.run_spineopt).

--- a/src/run_spineopt.jl
+++ b/src/run_spineopt.jl
@@ -339,6 +339,7 @@ function create_model(mip_solver, lp_solver, use_direct_model)
     m_mp = if model_type(model=instance) === :spineopt_benders
         m_mp = Base.invokelatest(_do_create_model, mip_solver, use_direct_model)
         m_mp.ext[:spineopt] = SpineOptExt(instance, lp_solver, m_mp)
+        JuMP.set_string_names_on_creation(m_mp, false)
         m_mp
     end
     model_by_stage = OrderedDict()

--- a/src/run_spineopt.jl
+++ b/src/run_spineopt.jl
@@ -432,7 +432,7 @@ _parse_solver_option(value::Bool) = value
 _parse_solver_option(value::Number) = isinteger(value) ? convert(Int64, value) : value
 _parse_solver_option(value) = string(value)
 
-_do_create_model(mip_solver, use_direct_model) = use_direct_model ? direct_model(mip_solver) : Model(mip_solver)
+_do_create_model(mip_solver, use_direct_model) = use_direct_model ? direct_model(mip_solver) : Model(mip_solver; add_bridges = false)
 
 struct SpineOptExt
     instance::Object

--- a/src/run_spineopt.jl
+++ b/src/run_spineopt.jl
@@ -361,7 +361,7 @@ function create_model(mip_solver, lp_solver, use_direct_model, use_model_names, 
     instance = first(model())
     mip_solver = _mip_solver(instance, mip_solver)
     lp_solver = _lp_solver(instance, lp_solver)
-    if model_type(model=instance) === :mga_algorithm && !add_bridges
+    if model_algorithm(model=instance) === :mga_algorithm && !add_bridges
         add_bridges = true
         @warn "Bridges are required for MGA algorithm - adding them"
     end

--- a/src/run_spineopt.jl
+++ b/src/run_spineopt.jl
@@ -36,7 +36,7 @@ A new Spine database is created at `url_out` if one doesn't exist.
 - `mip_solver=nothing`: a MIP solver to use if no MIP solver specified in the DB.
 - `lp_solver=nothing`: a LP solver to use if no LP solver specified in the DB.
 - `use_direct_model::Bool=false`: whether or not to use `JuMP.direct_model` to build the `Model` object.
-- `use_model_names::Bool=false`: whether or not to use the names in the model.
+- `use_model_names::Bool=true`: whether or not to use the names in the model.
 - `add_bridges::Bool=false` whether or not bridges from JuMP to the solver should be added to the model.
 - `optimize::Bool=true`: whether or not to optimise the model (useful for running tests).
 - `update_names::Bool=false`: whether or not to update variable and constraint names after the model rolls
@@ -90,7 +90,7 @@ function run_spineopt(
     mip_solver=nothing,
     lp_solver=nothing,
     use_direct_model=false,
-    use_model_names=false,
+    use_model_names=true,
     add_bridges=false,
     optimize=true,
     update_names=false,
@@ -226,7 +226,7 @@ function prepare_spineopt(
     mip_solver=nothing,
     lp_solver=nothing,
     use_direct_model=false,
-    use_model_names=false,
+    use_model_names=true,
     add_bridges=false,
 )
     @log log_level 0 "Reading input data from $(_real_url(url_in))..."

--- a/src/run_spineopt.jl
+++ b/src/run_spineopt.jl
@@ -348,6 +348,7 @@ function create_model(mip_solver, lp_solver, use_direct_model)
     end
     m = Base.invokelatest(_do_create_model, mip_solver, use_direct_model)
     m.ext[:spineopt] = SpineOptExt(instance, lp_solver, m_mp, model_by_stage)
+    JuMP.set_string_names_on_creation(m, false)
     m
 end
 

--- a/src/run_spineopt.jl
+++ b/src/run_spineopt.jl
@@ -37,6 +37,7 @@ A new Spine database is created at `url_out` if one doesn't exist.
 - `lp_solver=nothing`: a LP solver to use if no LP solver specified in the DB.
 - `use_direct_model::Bool=false`: whether or not to use `JuMP.direct_model` to build the `Model` object.
 - `use_model_names::Bool=false`: whether or not to use the names in the model.
+- `add_bridges::Bool=false` whether or not bridges from JuMP to the solver should be added to the model.
 - `optimize::Bool=true`: whether or not to optimise the model (useful for running tests).
 - `update_names::Bool=false`: whether or not to update variable and constraint names after the model rolls
    (expensive).
@@ -90,6 +91,7 @@ function run_spineopt(
     lp_solver=nothing,
     use_direct_model=false,
     use_model_names=false,
+    add_bridges=false,
     optimize=true,
     update_names=false,
     alternative="",
@@ -110,6 +112,7 @@ function run_spineopt(
             lp_solver=lp_solver,
             use_direct_model=use_direct_model,
             use_model_names=use_model_names,
+            add_bridges=add_bridges,
             optimize=optimize,
             update_names=update_names,
             alternative=alternative,
@@ -130,6 +133,7 @@ function _run_spineopt(
     lp_solver,
     use_direct_model,
     use_model_names,
+    add_bridges,
     log_level,
     alternative,
     kwargs...,
@@ -141,7 +145,18 @@ function _run_spineopt(
     println("[SpineInterface version $si_ver (git hash: $si_git_hash)]")
     t_start = now()
     @log log_level 1 "Execution started at $t_start"
-    m = prepare_spineopt(url_in; upgrade, filters, templates, mip_solver, lp_solver, use_direct_model, use_model_names, log_level)
+    m = prepare_spineopt(
+            url_in;
+            upgrade,
+            filters,
+            templates,
+            mip_solver,
+            lp_solver,
+            use_direct_model,
+            use_model_names,
+            add_bridges,
+            log_level
+        )
     f(m)
     run_spineopt!(m, url_out; log_level, alternative, kwargs...)
     t_end = now()
@@ -198,6 +213,7 @@ or a `Dict` (e.g. manually created or parsed from a json file).
 - `lp_solver`
 - `use_direct_model`
 - `use_model_names`
+- `add_bridges`
 
 See [run_spineopt](@ref) for the description of the keyword arguments.
 """
@@ -211,6 +227,7 @@ function prepare_spineopt(
     lp_solver=nothing,
     use_direct_model=false,
     use_model_names=false,
+    add_bridges=false,
 )
     @log log_level 0 "Reading input data from $(_real_url(url_in))..."
     _check_version(url_in; log_level, upgrade)
@@ -242,7 +259,7 @@ function prepare_spineopt(
             end
         end
     end
-    create_model(mip_solver, lp_solver, use_direct_model, use_model_names)
+    create_model(mip_solver, lp_solver, use_direct_model, use_model_names, add_bridges)
 end
 
 function _init_data_from_db(url_in, log_level, upgrade, templates, filters, scenario="")
@@ -332,29 +349,34 @@ function run_spineopt!(
 end
 
 """
-    create_model(mip_solver, lp_solver, use_direct_model, use_model_names)
+    create_model(mip_solver, lp_solver, use_direct_model, use_model_names, add_bridges)
 
 A `JuMP.Model` extended to be used with SpineOpt.
 `mip_solver` and `lp_solver` are 'optimizer factories' to be passed to `JuMP.Model` or `JuMP.direct_model`;
 `use_direct_model` is a `Bool` indicating whether `JuMP.Model` or `JuMP.direct_model` should be used.
 `use_model_names` is a `Bool` indicating whether the names in the model should be used.
+`add_bridges` is a `Bool` indicating whether bridges from JuMP to the solver should be added to the model.
 """
-function create_model(mip_solver, lp_solver, use_direct_model, use_model_names)
+function create_model(mip_solver, lp_solver, use_direct_model, use_model_names, add_bridges)
     instance = first(model())
     mip_solver = _mip_solver(instance, mip_solver)
     lp_solver = _lp_solver(instance, lp_solver)
+    if model_type(model=instance) === :mga_algorithm && !add_bridges
+        add_bridges = true
+        @warn "Bridges are required for MGA algorithm - adding them"
+    end
     m_mp = if model_type(model=instance) === :spineopt_benders
-        m_mp = Base.invokelatest(_do_create_model, mip_solver, use_direct_model)
+        m_mp = Base.invokelatest(_do_create_model, mip_solver, use_direct_model, add_bridges)
         m_mp.ext[:spineopt] = SpineOptExt(instance, lp_solver, m_mp)
         JuMP.set_string_names_on_creation(m_mp, use_model_names)
         m_mp
     end
     model_by_stage = OrderedDict()
     for st in sort(stage(); lt=(x, y) -> y in stage__child_stage(stage1=x))
-        model_by_stage[st] = stage_m = Base.invokelatest(_do_create_model, mip_solver, use_direct_model)
+        model_by_stage[st] = stage_m = Base.invokelatest(_do_create_model, mip_solver, use_direct_model, add_bridges)
         stage_m.ext[:spineopt] = SpineOptExt(instance, lp_solver, m_mp; stage=st)
     end
-    m = Base.invokelatest(_do_create_model, mip_solver, use_direct_model)
+    m = Base.invokelatest(_do_create_model, mip_solver, use_direct_model, add_bridges)
     m.ext[:spineopt] = SpineOptExt(instance, lp_solver, m_mp, model_by_stage)
     JuMP.set_string_names_on_creation(m, use_model_names)
     m
@@ -432,7 +454,7 @@ _parse_solver_option(value::Bool) = value
 _parse_solver_option(value::Number) = isinteger(value) ? convert(Int64, value) : value
 _parse_solver_option(value) = string(value)
 
-_do_create_model(mip_solver, use_direct_model) = use_direct_model ? direct_model(mip_solver) : Model(mip_solver; add_bridges = false)
+_do_create_model(mip_solver, use_direct_model, add_bridges) = use_direct_model ? direct_model(mip_solver) : Model(mip_solver; add_bridges = add_bridges)
 
 struct SpineOptExt
     instance::Object

--- a/test/data_structure/temporal_structure.jl
+++ b/test/data_structure/temporal_structure.jl
@@ -24,7 +24,7 @@ function _is_time_slice_set_equal(ts_a, ts_b)
 end
 
 function _model()
-    m = Model()
+    m = Model(; add_bridges = false)
     JuMP.set_string_names_on_creation(m, false)
     m.ext[:spineopt] = SpineOpt.SpineOptExt(first(model()), nothing)
     m

--- a/test/data_structure/temporal_structure.jl
+++ b/test/data_structure/temporal_structure.jl
@@ -25,6 +25,7 @@ end
 
 function _model()
     m = Model()
+    JuMP.set_string_names_on_creation(m, false)
     m.ext[:spineopt] = SpineOpt.SpineOptExt(first(model()), nothing)
     m
 end


### PR DESCRIPTION
Following the performance tips from [JuMP docs](https://jump.dev/JuMP.jl/stable/tutorials/getting_started/performance_tips/#Performance-tips), this PR implements the following option in the `run_spineopt` function:

- `use_model_names`(default = `true`): whether or not to create the model with names
- `add_bridges`(default = `false`): whether or not bridges from JuMP to the solver should be added to the model

**Notes**

- The `use_model_names` default is equal to `true`, so the users can gain more speed when creating the model by setting this option to `false`.

- The `add_bridges` option is set to `true` for the MGA algorithm, since it is necessary to run that feature.

Fixes #1148 

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted according to SpineOpt's style
- [x] Unit tests pass
