### PR TITLE
Use `align_variable_duration_unit` function instead of `convert_to_days`

### DIFF
--- a/src/constraints/constraint_common.jl
+++ b/src/constraints/constraint_common.jl
@@ -75,7 +75,7 @@ function _past_indices(m, indices, param, s_path, t; kwargs...)
         (;
             ind...,
             weight=ifelse(
-                end_(t) - end_(ind.t) < align_variable_duration_unit(param(m; kwargs..., stochastic_scenario=ind.stochastic_scenario, t=t), end_(t)), 1, 0
+                end_(t) - end_(ind.t) < align_variable_duration_unit(param(m; kwargs..., stochastic_scenario=ind.stochastic_scenario, t=t), start(t)), 1, 0
             ),
         )
         for ind in indices(

--- a/src/constraints/constraint_common.jl
+++ b/src/constraints/constraint_common.jl
@@ -75,7 +75,7 @@ function _past_indices(m, indices, param, s_path, t; kwargs...)
         (;
             ind...,
             weight=ifelse(
-                end_(t) - end_(ind.t) < align_variable_duration_unit(param(m; kwargs..., stochastic_scenario=ind.stochastic_scenario, t=t), start(t)), 1, 0
+                end_(t) - end_(ind.t) < align_variable_duration_unit(param(; kwargs..., stochastic_scenario=ind.stochastic_scenario, t=t), start(t)), 1, 0
             ),
         )
         for ind in indices(

--- a/src/constraints/constraint_common.jl
+++ b/src/constraints/constraint_common.jl
@@ -71,15 +71,11 @@ past_units_on_indices(m, param, u, s_path, t) = _past_indices(m, units_on_indice
 function _past_indices(m, indices, param, s_path, t; kwargs...)
     look_behind = maximum(maximum_parameter_value(param(; kwargs..., stochastic_scenario=s, t=t)) for s in s_path)
     
-    convert_to_days(duration::Year) = Day(Dates.value(duration) * 366)
-    convert_to_days(duration::Month) = Day(Dates.value(duration) * 31)
-    convert_to_days(duration) = duration
-
     (
         (;
             ind...,
             weight=ifelse(
-                end_(t) - end_(ind.t) < convert_to_days(param(m; kwargs..., stochastic_scenario=ind.stochastic_scenario, t=t)), 1, 0
+                end_(t) - end_(ind.t) < align_variable_duration_unit(param(m; kwargs..., stochastic_scenario=ind.stochastic_scenario, t=t), end_(t)), 1, 0
             ),
         )
         for ind in indices(


### PR DESCRIPTION
Reusing the function `align_variable_duration_unit` instead of creating a new one `convert_to_days`

Fixes #1152

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted according to SpineOpt's style
- [x] Unit tests pass
