### PR TITLE
Delete parameter values related to obsolete outputs from spineopt_template

### DIFF
--- a/examples/capacity_planning.json
+++ b/examples/capacity_planning.json
@@ -725,16 +725,6 @@
         ],
         [
             "output",
-            "nonspin_ramp_down_unit_flow",
-            null
-        ],
-        [
-            "output",
-            "nonspin_ramp_up_unit_flow",
-            null
-        ],
-        [
-            "output",
             "nonspin_units_shut_down",
             null
         ],
@@ -751,16 +741,6 @@
         [
             "output",
             "ramp_costs",
-            null
-        ],
-        [
-            "output",
-            "ramp_down_unit_flow",
-            null
-        ],
-        [
-            "output",
-            "ramp_up_unit_flow",
             null
         ],
         [
@@ -785,17 +765,7 @@
         ],
         [
             "output",
-            "shut_down_unit_flow",
-            null
-        ],
-        [
-            "output",
             "start_up_costs",
-            null
-        ],
-        [
-            "output",
-            "start_up_unit_flow",
             null
         ],
         [
@@ -3213,31 +3183,10 @@
         ],
         [
             "unit__from_node",
-            "fix_nonspin_ramp_up_unit_flow",
-            null,
-            null,
-            "Fix the `nonspin_ramp_up_unit_flow` variable."
-        ],
-        [
-            "unit__from_node",
             "fix_nonspin_units_started_up",
             null,
             null,
             "Fix the `nonspin_units_started_up` variable."
-        ],
-        [
-            "unit__from_node",
-            "fix_ramp_up_unit_flow",
-            null,
-            null,
-            "Fix the `ramp_up_unit_flow` variable."
-        ],
-        [
-            "unit__from_node",
-            "fix_start_up_unit_flow",
-            null,
-            null,
-            "Fix the `start_up_unit_flow` variable."
         ],
         [
             "unit__from_node",
@@ -3269,31 +3218,10 @@
         ],
         [
             "unit__from_node",
-            "initial_nonspin_ramp_up_unit_flow",
-            null,
-            null,
-            "Initialize the `nonspin_ramp_up_unit_flow` variable."
-        ],
-        [
-            "unit__from_node",
             "initial_nonspin_units_started_up",
             null,
             null,
             "Initialize the `nonspin_units_started_up` variable."
-        ],
-        [
-            "unit__from_node",
-            "initial_ramp_up_unit_flow",
-            null,
-            null,
-            "Initialize the `ramp_up_unit_flow` variable."
-        ],
-        [
-            "unit__from_node",
-            "initial_start_up_unit_flow",
-            null,
-            null,
-            "Initialize the `start_up_unit_flow` variable."
         ],
         [
             "unit__from_node",
@@ -3696,20 +3624,6 @@
         ],
         [
             "unit__to_node",
-            "fix_nonspin_ramp_down_unit_flow",
-            null,
-            null,
-            "Fix the `nonspin_ramp_down_unit_flow` variable."
-        ],
-        [
-            "unit__to_node",
-            "fix_nonspin_ramp_up_unit_flow",
-            null,
-            null,
-            "Fix the `nonspin_ramp_up_unit_flow` variable."
-        ],
-        [
-            "unit__to_node",
             "fix_nonspin_units_shut_down",
             null,
             null,
@@ -3721,34 +3635,6 @@
             null,
             null,
             "Fix the `nonspin_units_started_up` variable."
-        ],
-        [
-            "unit__to_node",
-            "fix_ramp_down_unit_flow",
-            null,
-            null,
-            "Fix the `ramp_down_unit_flow` variable."
-        ],
-        [
-            "unit__to_node",
-            "fix_ramp_up_unit_flow",
-            null,
-            null,
-            "Fix the `ramp_up_unit_flow` variable."
-        ],
-        [
-            "unit__to_node",
-            "fix_shut_down_unit_flow",
-            null,
-            null,
-            "Fix the `shut_down_unit_flow` variable."
-        ],
-        [
-            "unit__to_node",
-            "fix_start_up_unit_flow",
-            null,
-            null,
-            "Fix the `start_up_unit_flow` variable."
         ],
         [
             "unit__to_node",
@@ -3780,20 +3666,6 @@
         ],
         [
             "unit__to_node",
-            "initial_nonspin_ramp_down_unit_flow",
-            null,
-            null,
-            "Initialize the `nonspin_ramp_down_unit_flow` variable."
-        ],
-        [
-            "unit__to_node",
-            "initial_nonspin_ramp_up_unit_flow",
-            null,
-            null,
-            "Initialize the `nonspin_ramp_up_unit_flow` variable."
-        ],
-        [
-            "unit__to_node",
             "initial_nonspin_units_shut_down",
             null,
             null,
@@ -3805,34 +3677,6 @@
             null,
             null,
             "Initialize the `nonspin_units_started_up` variable."
-        ],
-        [
-            "unit__to_node",
-            "initial_ramp_down_unit_flow",
-            null,
-            null,
-            "Initialize the `ramp_down_unit_flow` variable."
-        ],
-        [
-            "unit__to_node",
-            "initial_ramp_up_unit_flow",
-            null,
-            null,
-            "Initialize the `ramp_up_unit_flow` variable."
-        ],
-        [
-            "unit__to_node",
-            "initial_shut_down_unit_flow",
-            null,
-            null,
-            "Initialize the `shut_down_unit_flow` variable."
-        ],
-        [
-            "unit__to_node",
-            "initial_start_up_unit_flow",
-            null,
-            null,
-            "Initialize the `start_up_unit_flow` variable."
         ],
         [
             "unit__to_node",

--- a/examples/multi-year_investment_without_econ_params.json
+++ b/examples/multi-year_investment_without_econ_params.json
@@ -725,16 +725,6 @@
         ],
         [
             "output",
-            "nonspin_ramp_down_unit_flow",
-            null
-        ],
-        [
-            "output",
-            "nonspin_ramp_up_unit_flow",
-            null
-        ],
-        [
-            "output",
             "nonspin_units_shut_down",
             null
         ],
@@ -751,16 +741,6 @@
         [
             "output",
             "ramp_costs",
-            null
-        ],
-        [
-            "output",
-            "ramp_down_unit_flow",
-            null
-        ],
-        [
-            "output",
-            "ramp_up_unit_flow",
             null
         ],
         [
@@ -785,17 +765,7 @@
         ],
         [
             "output",
-            "shut_down_unit_flow",
-            null
-        ],
-        [
-            "output",
             "start_up_costs",
-            null
-        ],
-        [
-            "output",
-            "start_up_unit_flow",
             null
         ],
         [
@@ -3246,31 +3216,10 @@
         ],
         [
             "unit__from_node",
-            "fix_nonspin_ramp_up_unit_flow",
-            null,
-            null,
-            "Fix the `nonspin_ramp_up_unit_flow` variable."
-        ],
-        [
-            "unit__from_node",
             "fix_nonspin_units_started_up",
             null,
             null,
             "Fix the `nonspin_units_started_up` variable."
-        ],
-        [
-            "unit__from_node",
-            "fix_ramp_up_unit_flow",
-            null,
-            null,
-            "Fix the `ramp_up_unit_flow` variable."
-        ],
-        [
-            "unit__from_node",
-            "fix_start_up_unit_flow",
-            null,
-            null,
-            "Fix the `start_up_unit_flow` variable."
         ],
         [
             "unit__from_node",
@@ -3302,31 +3251,10 @@
         ],
         [
             "unit__from_node",
-            "initial_nonspin_ramp_up_unit_flow",
-            null,
-            null,
-            "Initialize the `nonspin_ramp_up_unit_flow` variable."
-        ],
-        [
-            "unit__from_node",
             "initial_nonspin_units_started_up",
             null,
             null,
             "Initialize the `nonspin_units_started_up` variable."
-        ],
-        [
-            "unit__from_node",
-            "initial_ramp_up_unit_flow",
-            null,
-            null,
-            "Initialize the `ramp_up_unit_flow` variable."
-        ],
-        [
-            "unit__from_node",
-            "initial_start_up_unit_flow",
-            null,
-            null,
-            "Initialize the `start_up_unit_flow` variable."
         ],
         [
             "unit__from_node",
@@ -3729,20 +3657,6 @@
         ],
         [
             "unit__to_node",
-            "fix_nonspin_ramp_down_unit_flow",
-            null,
-            null,
-            "Fix the `nonspin_ramp_down_unit_flow` variable."
-        ],
-        [
-            "unit__to_node",
-            "fix_nonspin_ramp_up_unit_flow",
-            null,
-            null,
-            "Fix the `nonspin_ramp_up_unit_flow` variable."
-        ],
-        [
-            "unit__to_node",
             "fix_nonspin_units_shut_down",
             null,
             null,
@@ -3754,34 +3668,6 @@
             null,
             null,
             "Fix the `nonspin_units_started_up` variable."
-        ],
-        [
-            "unit__to_node",
-            "fix_ramp_down_unit_flow",
-            null,
-            null,
-            "Fix the `ramp_down_unit_flow` variable."
-        ],
-        [
-            "unit__to_node",
-            "fix_ramp_up_unit_flow",
-            null,
-            null,
-            "Fix the `ramp_up_unit_flow` variable."
-        ],
-        [
-            "unit__to_node",
-            "fix_shut_down_unit_flow",
-            null,
-            null,
-            "Fix the `shut_down_unit_flow` variable."
-        ],
-        [
-            "unit__to_node",
-            "fix_start_up_unit_flow",
-            null,
-            null,
-            "Fix the `start_up_unit_flow` variable."
         ],
         [
             "unit__to_node",
@@ -3813,20 +3699,6 @@
         ],
         [
             "unit__to_node",
-            "initial_nonspin_ramp_down_unit_flow",
-            null,
-            null,
-            "Initialize the `nonspin_ramp_down_unit_flow` variable."
-        ],
-        [
-            "unit__to_node",
-            "initial_nonspin_ramp_up_unit_flow",
-            null,
-            null,
-            "Initialize the `nonspin_ramp_up_unit_flow` variable."
-        ],
-        [
-            "unit__to_node",
             "initial_nonspin_units_shut_down",
             null,
             null,
@@ -3838,34 +3710,6 @@
             null,
             null,
             "Initialize the `nonspin_units_started_up` variable."
-        ],
-        [
-            "unit__to_node",
-            "initial_ramp_down_unit_flow",
-            null,
-            null,
-            "Initialize the `ramp_down_unit_flow` variable."
-        ],
-        [
-            "unit__to_node",
-            "initial_ramp_up_unit_flow",
-            null,
-            null,
-            "Initialize the `ramp_up_unit_flow` variable."
-        ],
-        [
-            "unit__to_node",
-            "initial_shut_down_unit_flow",
-            null,
-            null,
-            "Initialize the `shut_down_unit_flow` variable."
-        ],
-        [
-            "unit__to_node",
-            "initial_start_up_unit_flow",
-            null,
-            null,
-            "Initialize the `start_up_unit_flow` variable."
         ],
         [
             "unit__to_node",

--- a/examples/reserves.json
+++ b/examples/reserves.json
@@ -735,16 +735,6 @@
         ],
         [
             "output",
-            "nonspin_ramp_down_unit_flow",
-            null
-        ],
-        [
-            "output",
-            "nonspin_ramp_up_unit_flow",
-            null
-        ],
-        [
-            "output",
             "nonspin_units_shut_down",
             null
         ],
@@ -761,16 +751,6 @@
         [
             "output",
             "ramp_costs",
-            null
-        ],
-        [
-            "output",
-            "ramp_down_unit_flow",
-            null
-        ],
-        [
-            "output",
-            "ramp_up_unit_flow",
             null
         ],
         [
@@ -795,17 +775,7 @@
         ],
         [
             "output",
-            "shut_down_unit_flow",
-            null
-        ],
-        [
-            "output",
             "start_up_costs",
-            null
-        ],
-        [
-            "output",
-            "start_up_unit_flow",
             null
         ],
         [
@@ -3228,31 +3198,10 @@
         ],
         [
             "unit__from_node",
-            "fix_nonspin_ramp_up_unit_flow",
-            null,
-            null,
-            "Fix the `nonspin_ramp_up_unit_flow` variable."
-        ],
-        [
-            "unit__from_node",
             "fix_nonspin_units_started_up",
             null,
             null,
             "Fix the `nonspin_units_started_up` variable."
-        ],
-        [
-            "unit__from_node",
-            "fix_ramp_up_unit_flow",
-            null,
-            null,
-            "Fix the `ramp_up_unit_flow` variable."
-        ],
-        [
-            "unit__from_node",
-            "fix_start_up_unit_flow",
-            null,
-            null,
-            "Fix the `start_up_unit_flow` variable."
         ],
         [
             "unit__from_node",
@@ -3284,31 +3233,10 @@
         ],
         [
             "unit__from_node",
-            "initial_nonspin_ramp_up_unit_flow",
-            null,
-            null,
-            "Initialize the `nonspin_ramp_up_unit_flow` variable."
-        ],
-        [
-            "unit__from_node",
             "initial_nonspin_units_started_up",
             null,
             null,
             "Initialize the `nonspin_units_started_up` variable."
-        ],
-        [
-            "unit__from_node",
-            "initial_ramp_up_unit_flow",
-            null,
-            null,
-            "Initialize the `ramp_up_unit_flow` variable."
-        ],
-        [
-            "unit__from_node",
-            "initial_start_up_unit_flow",
-            null,
-            null,
-            "Initialize the `start_up_unit_flow` variable."
         ],
         [
             "unit__from_node",
@@ -3711,20 +3639,6 @@
         ],
         [
             "unit__to_node",
-            "fix_nonspin_ramp_down_unit_flow",
-            null,
-            null,
-            "Fix the `nonspin_ramp_down_unit_flow` variable."
-        ],
-        [
-            "unit__to_node",
-            "fix_nonspin_ramp_up_unit_flow",
-            null,
-            null,
-            "Fix the `nonspin_ramp_up_unit_flow` variable."
-        ],
-        [
-            "unit__to_node",
             "fix_nonspin_units_shut_down",
             null,
             null,
@@ -3736,34 +3650,6 @@
             null,
             null,
             "Fix the `nonspin_units_started_up` variable."
-        ],
-        [
-            "unit__to_node",
-            "fix_ramp_down_unit_flow",
-            null,
-            null,
-            "Fix the `ramp_down_unit_flow` variable."
-        ],
-        [
-            "unit__to_node",
-            "fix_ramp_up_unit_flow",
-            null,
-            null,
-            "Fix the `ramp_up_unit_flow` variable."
-        ],
-        [
-            "unit__to_node",
-            "fix_shut_down_unit_flow",
-            null,
-            null,
-            "Fix the `shut_down_unit_flow` variable."
-        ],
-        [
-            "unit__to_node",
-            "fix_start_up_unit_flow",
-            null,
-            null,
-            "Fix the `start_up_unit_flow` variable."
         ],
         [
             "unit__to_node",
@@ -3795,20 +3681,6 @@
         ],
         [
             "unit__to_node",
-            "initial_nonspin_ramp_down_unit_flow",
-            null,
-            null,
-            "Initialize the `nonspin_ramp_down_unit_flow` variable."
-        ],
-        [
-            "unit__to_node",
-            "initial_nonspin_ramp_up_unit_flow",
-            null,
-            null,
-            "Initialize the `nonspin_ramp_up_unit_flow` variable."
-        ],
-        [
-            "unit__to_node",
             "initial_nonspin_units_shut_down",
             null,
             null,
@@ -3820,34 +3692,6 @@
             null,
             null,
             "Initialize the `nonspin_units_started_up` variable."
-        ],
-        [
-            "unit__to_node",
-            "initial_ramp_down_unit_flow",
-            null,
-            null,
-            "Initialize the `ramp_down_unit_flow` variable."
-        ],
-        [
-            "unit__to_node",
-            "initial_ramp_up_unit_flow",
-            null,
-            null,
-            "Initialize the `ramp_up_unit_flow` variable."
-        ],
-        [
-            "unit__to_node",
-            "initial_shut_down_unit_flow",
-            null,
-            null,
-            "Initialize the `shut_down_unit_flow` variable."
-        ],
-        [
-            "unit__to_node",
-            "initial_start_up_unit_flow",
-            null,
-            null,
-            "Initialize the `start_up_unit_flow` variable."
         ],
         [
             "unit__to_node",

--- a/examples/rolling_horizon.json
+++ b/examples/rolling_horizon.json
@@ -725,16 +725,6 @@
         ],
         [
             "output",
-            "nonspin_ramp_down_unit_flow",
-            null
-        ],
-        [
-            "output",
-            "nonspin_ramp_up_unit_flow",
-            null
-        ],
-        [
-            "output",
             "nonspin_units_shut_down",
             null
         ],
@@ -751,16 +741,6 @@
         [
             "output",
             "ramp_costs",
-            null
-        ],
-        [
-            "output",
-            "ramp_down_unit_flow",
-            null
-        ],
-        [
-            "output",
-            "ramp_up_unit_flow",
             null
         ],
         [
@@ -785,17 +765,7 @@
         ],
         [
             "output",
-            "shut_down_unit_flow",
-            null
-        ],
-        [
-            "output",
             "start_up_costs",
-            null
-        ],
-        [
-            "output",
-            "start_up_unit_flow",
             null
         ],
         [
@@ -3238,31 +3208,10 @@
         ],
         [
             "unit__from_node",
-            "fix_nonspin_ramp_up_unit_flow",
-            null,
-            null,
-            "Fix the `nonspin_ramp_up_unit_flow` variable."
-        ],
-        [
-            "unit__from_node",
             "fix_nonspin_units_started_up",
             null,
             null,
             "Fix the `nonspin_units_started_up` variable."
-        ],
-        [
-            "unit__from_node",
-            "fix_ramp_up_unit_flow",
-            null,
-            null,
-            "Fix the `ramp_up_unit_flow` variable."
-        ],
-        [
-            "unit__from_node",
-            "fix_start_up_unit_flow",
-            null,
-            null,
-            "Fix the `start_up_unit_flow` variable."
         ],
         [
             "unit__from_node",
@@ -3294,31 +3243,10 @@
         ],
         [
             "unit__from_node",
-            "initial_nonspin_ramp_up_unit_flow",
-            null,
-            null,
-            "Initialize the `nonspin_ramp_up_unit_flow` variable."
-        ],
-        [
-            "unit__from_node",
             "initial_nonspin_units_started_up",
             null,
             null,
             "Initialize the `nonspin_units_started_up` variable."
-        ],
-        [
-            "unit__from_node",
-            "initial_ramp_up_unit_flow",
-            null,
-            null,
-            "Initialize the `ramp_up_unit_flow` variable."
-        ],
-        [
-            "unit__from_node",
-            "initial_start_up_unit_flow",
-            null,
-            null,
-            "Initialize the `start_up_unit_flow` variable."
         ],
         [
             "unit__from_node",
@@ -3714,20 +3642,6 @@
         ],
         [
             "unit__to_node",
-            "fix_nonspin_ramp_down_unit_flow",
-            null,
-            null,
-            "Fix the `nonspin_ramp_down_unit_flow` variable."
-        ],
-        [
-            "unit__to_node",
-            "fix_nonspin_ramp_up_unit_flow",
-            null,
-            null,
-            "Fix the `nonspin_ramp_up_unit_flow` variable."
-        ],
-        [
-            "unit__to_node",
             "fix_nonspin_units_shut_down",
             null,
             null,
@@ -3739,34 +3653,6 @@
             null,
             null,
             "Fix the `nonspin_units_started_up` variable."
-        ],
-        [
-            "unit__to_node",
-            "fix_ramp_down_unit_flow",
-            null,
-            null,
-            "Fix the `ramp_down_unit_flow` variable."
-        ],
-        [
-            "unit__to_node",
-            "fix_ramp_up_unit_flow",
-            null,
-            null,
-            "Fix the `ramp_up_unit_flow` variable."
-        ],
-        [
-            "unit__to_node",
-            "fix_shut_down_unit_flow",
-            null,
-            null,
-            "Fix the `shut_down_unit_flow` variable."
-        ],
-        [
-            "unit__to_node",
-            "fix_start_up_unit_flow",
-            null,
-            null,
-            "Fix the `start_up_unit_flow` variable."
         ],
         [
             "unit__to_node",
@@ -3798,20 +3684,6 @@
         ],
         [
             "unit__to_node",
-            "initial_nonspin_ramp_down_unit_flow",
-            null,
-            null,
-            "Initialize the `nonspin_ramp_down_unit_flow` variable."
-        ],
-        [
-            "unit__to_node",
-            "initial_nonspin_ramp_up_unit_flow",
-            null,
-            null,
-            "Initialize the `nonspin_ramp_up_unit_flow` variable."
-        ],
-        [
-            "unit__to_node",
             "initial_nonspin_units_shut_down",
             null,
             null,
@@ -3823,34 +3695,6 @@
             null,
             null,
             "Initialize the `nonspin_units_started_up` variable."
-        ],
-        [
-            "unit__to_node",
-            "initial_ramp_down_unit_flow",
-            null,
-            null,
-            "Initialize the `ramp_down_unit_flow` variable."
-        ],
-        [
-            "unit__to_node",
-            "initial_ramp_up_unit_flow",
-            null,
-            null,
-            "Initialize the `ramp_up_unit_flow` variable."
-        ],
-        [
-            "unit__to_node",
-            "initial_shut_down_unit_flow",
-            null,
-            null,
-            "Initialize the `shut_down_unit_flow` variable."
-        ],
-        [
-            "unit__to_node",
-            "initial_start_up_unit_flow",
-            null,
-            null,
-            "Initialize the `start_up_unit_flow` variable."
         ],
         [
             "unit__to_node",

--- a/examples/simple_system.json
+++ b/examples/simple_system.json
@@ -725,16 +725,6 @@
         ],
         [
             "output",
-            "nonspin_ramp_down_unit_flow",
-            null
-        ],
-        [
-            "output",
-            "nonspin_ramp_up_unit_flow",
-            null
-        ],
-        [
-            "output",
             "nonspin_units_shut_down",
             null
         ],
@@ -751,16 +741,6 @@
         [
             "output",
             "ramp_costs",
-            null
-        ],
-        [
-            "output",
-            "ramp_down_unit_flow",
-            null
-        ],
-        [
-            "output",
-            "ramp_up_unit_flow",
             null
         ],
         [
@@ -785,17 +765,7 @@
         ],
         [
             "output",
-            "shut_down_unit_flow",
-            null
-        ],
-        [
-            "output",
             "start_up_costs",
-            null
-        ],
-        [
-            "output",
-            "start_up_unit_flow",
             null
         ],
         [
@@ -3158,31 +3128,10 @@
         ],
         [
             "unit__from_node",
-            "fix_nonspin_ramp_up_unit_flow",
-            null,
-            null,
-            "Fix the `nonspin_ramp_up_unit_flow` variable."
-        ],
-        [
-            "unit__from_node",
             "fix_nonspin_units_started_up",
             null,
             null,
             "Fix the `nonspin_units_started_up` variable."
-        ],
-        [
-            "unit__from_node",
-            "fix_ramp_up_unit_flow",
-            null,
-            null,
-            "Fix the `ramp_up_unit_flow` variable."
-        ],
-        [
-            "unit__from_node",
-            "fix_start_up_unit_flow",
-            null,
-            null,
-            "Fix the `start_up_unit_flow` variable."
         ],
         [
             "unit__from_node",
@@ -3214,31 +3163,10 @@
         ],
         [
             "unit__from_node",
-            "initial_nonspin_ramp_up_unit_flow",
-            null,
-            null,
-            "Initialize the `nonspin_ramp_up_unit_flow` variable."
-        ],
-        [
-            "unit__from_node",
             "initial_nonspin_units_started_up",
             null,
             null,
             "Initialize the `nonspin_units_started_up` variable."
-        ],
-        [
-            "unit__from_node",
-            "initial_ramp_up_unit_flow",
-            null,
-            null,
-            "Initialize the `ramp_up_unit_flow` variable."
-        ],
-        [
-            "unit__from_node",
-            "initial_start_up_unit_flow",
-            null,
-            null,
-            "Initialize the `start_up_unit_flow` variable."
         ],
         [
             "unit__from_node",
@@ -3641,20 +3569,6 @@
         ],
         [
             "unit__to_node",
-            "fix_nonspin_ramp_down_unit_flow",
-            null,
-            null,
-            "Fix the `nonspin_ramp_down_unit_flow` variable."
-        ],
-        [
-            "unit__to_node",
-            "fix_nonspin_ramp_up_unit_flow",
-            null,
-            null,
-            "Fix the `nonspin_ramp_up_unit_flow` variable."
-        ],
-        [
-            "unit__to_node",
             "fix_nonspin_units_shut_down",
             null,
             null,
@@ -3666,34 +3580,6 @@
             null,
             null,
             "Fix the `nonspin_units_started_up` variable."
-        ],
-        [
-            "unit__to_node",
-            "fix_ramp_down_unit_flow",
-            null,
-            null,
-            "Fix the `ramp_down_unit_flow` variable."
-        ],
-        [
-            "unit__to_node",
-            "fix_ramp_up_unit_flow",
-            null,
-            null,
-            "Fix the `ramp_up_unit_flow` variable."
-        ],
-        [
-            "unit__to_node",
-            "fix_shut_down_unit_flow",
-            null,
-            null,
-            "Fix the `shut_down_unit_flow` variable."
-        ],
-        [
-            "unit__to_node",
-            "fix_start_up_unit_flow",
-            null,
-            null,
-            "Fix the `start_up_unit_flow` variable."
         ],
         [
             "unit__to_node",
@@ -3725,20 +3611,6 @@
         ],
         [
             "unit__to_node",
-            "initial_nonspin_ramp_down_unit_flow",
-            null,
-            null,
-            "Initialize the `nonspin_ramp_down_unit_flow` variable."
-        ],
-        [
-            "unit__to_node",
-            "initial_nonspin_ramp_up_unit_flow",
-            null,
-            null,
-            "Initialize the `nonspin_ramp_up_unit_flow` variable."
-        ],
-        [
-            "unit__to_node",
             "initial_nonspin_units_shut_down",
             null,
             null,
@@ -3750,34 +3622,6 @@
             null,
             null,
             "Initialize the `nonspin_units_started_up` variable."
-        ],
-        [
-            "unit__to_node",
-            "initial_ramp_down_unit_flow",
-            null,
-            null,
-            "Initialize the `ramp_down_unit_flow` variable."
-        ],
-        [
-            "unit__to_node",
-            "initial_ramp_up_unit_flow",
-            null,
-            null,
-            "Initialize the `ramp_up_unit_flow` variable."
-        ],
-        [
-            "unit__to_node",
-            "initial_shut_down_unit_flow",
-            null,
-            null,
-            "Initialize the `shut_down_unit_flow` variable."
-        ],
-        [
-            "unit__to_node",
-            "initial_start_up_unit_flow",
-            null,
-            null,
-            "Initialize the `start_up_unit_flow` variable."
         ],
         [
             "unit__to_node",

--- a/examples/stochastic.json
+++ b/examples/stochastic.json
@@ -725,16 +725,6 @@
         ],
         [
             "output",
-            "nonspin_ramp_down_unit_flow",
-            null
-        ],
-        [
-            "output",
-            "nonspin_ramp_up_unit_flow",
-            null
-        ],
-        [
-            "output",
             "nonspin_units_shut_down",
             null
         ],
@@ -751,16 +741,6 @@
         [
             "output",
             "ramp_costs",
-            null
-        ],
-        [
-            "output",
-            "ramp_down_unit_flow",
-            null
-        ],
-        [
-            "output",
-            "ramp_up_unit_flow",
             null
         ],
         [
@@ -785,17 +765,7 @@
         ],
         [
             "output",
-            "shut_down_unit_flow",
-            null
-        ],
-        [
-            "output",
             "start_up_costs",
-            null
-        ],
-        [
-            "output",
-            "start_up_unit_flow",
             null
         ],
         [
@@ -3251,31 +3221,10 @@
         ],
         [
             "unit__from_node",
-            "fix_nonspin_ramp_up_unit_flow",
-            null,
-            null,
-            "Fix the `nonspin_ramp_up_unit_flow` variable."
-        ],
-        [
-            "unit__from_node",
             "fix_nonspin_units_started_up",
             null,
             null,
             "Fix the `nonspin_units_started_up` variable."
-        ],
-        [
-            "unit__from_node",
-            "fix_ramp_up_unit_flow",
-            null,
-            null,
-            "Fix the `ramp_up_unit_flow` variable."
-        ],
-        [
-            "unit__from_node",
-            "fix_start_up_unit_flow",
-            null,
-            null,
-            "Fix the `start_up_unit_flow` variable."
         ],
         [
             "unit__from_node",
@@ -3307,31 +3256,10 @@
         ],
         [
             "unit__from_node",
-            "initial_nonspin_ramp_up_unit_flow",
-            null,
-            null,
-            "Initialize the `nonspin_ramp_up_unit_flow` variable."
-        ],
-        [
-            "unit__from_node",
             "initial_nonspin_units_started_up",
             null,
             null,
             "Initialize the `nonspin_units_started_up` variable."
-        ],
-        [
-            "unit__from_node",
-            "initial_ramp_up_unit_flow",
-            null,
-            null,
-            "Initialize the `ramp_up_unit_flow` variable."
-        ],
-        [
-            "unit__from_node",
-            "initial_start_up_unit_flow",
-            null,
-            null,
-            "Initialize the `start_up_unit_flow` variable."
         ],
         [
             "unit__from_node",
@@ -3734,20 +3662,6 @@
         ],
         [
             "unit__to_node",
-            "fix_nonspin_ramp_down_unit_flow",
-            null,
-            null,
-            "Fix the `nonspin_ramp_down_unit_flow` variable."
-        ],
-        [
-            "unit__to_node",
-            "fix_nonspin_ramp_up_unit_flow",
-            null,
-            null,
-            "Fix the `nonspin_ramp_up_unit_flow` variable."
-        ],
-        [
-            "unit__to_node",
             "fix_nonspin_units_shut_down",
             null,
             null,
@@ -3759,34 +3673,6 @@
             null,
             null,
             "Fix the `nonspin_units_started_up` variable."
-        ],
-        [
-            "unit__to_node",
-            "fix_ramp_down_unit_flow",
-            null,
-            null,
-            "Fix the `ramp_down_unit_flow` variable."
-        ],
-        [
-            "unit__to_node",
-            "fix_ramp_up_unit_flow",
-            null,
-            null,
-            "Fix the `ramp_up_unit_flow` variable."
-        ],
-        [
-            "unit__to_node",
-            "fix_shut_down_unit_flow",
-            null,
-            null,
-            "Fix the `shut_down_unit_flow` variable."
-        ],
-        [
-            "unit__to_node",
-            "fix_start_up_unit_flow",
-            null,
-            null,
-            "Fix the `start_up_unit_flow` variable."
         ],
         [
             "unit__to_node",
@@ -3818,20 +3704,6 @@
         ],
         [
             "unit__to_node",
-            "initial_nonspin_ramp_down_unit_flow",
-            null,
-            null,
-            "Initialize the `nonspin_ramp_down_unit_flow` variable."
-        ],
-        [
-            "unit__to_node",
-            "initial_nonspin_ramp_up_unit_flow",
-            null,
-            null,
-            "Initialize the `nonspin_ramp_up_unit_flow` variable."
-        ],
-        [
-            "unit__to_node",
             "initial_nonspin_units_shut_down",
             null,
             null,
@@ -3843,34 +3715,6 @@
             null,
             null,
             "Initialize the `nonspin_units_started_up` variable."
-        ],
-        [
-            "unit__to_node",
-            "initial_ramp_down_unit_flow",
-            null,
-            null,
-            "Initialize the `ramp_down_unit_flow` variable."
-        ],
-        [
-            "unit__to_node",
-            "initial_ramp_up_unit_flow",
-            null,
-            null,
-            "Initialize the `ramp_up_unit_flow` variable."
-        ],
-        [
-            "unit__to_node",
-            "initial_shut_down_unit_flow",
-            null,
-            null,
-            "Initialize the `shut_down_unit_flow` variable."
-        ],
-        [
-            "unit__to_node",
-            "initial_start_up_unit_flow",
-            null,
-            null,
-            "Initialize the `start_up_unit_flow` variable."
         ],
         [
             "unit__to_node",

--- a/examples/unit_commitment.json
+++ b/examples/unit_commitment.json
@@ -725,16 +725,6 @@
         ],
         [
             "output",
-            "nonspin_ramp_down_unit_flow",
-            null
-        ],
-        [
-            "output",
-            "nonspin_ramp_up_unit_flow",
-            null
-        ],
-        [
-            "output",
             "nonspin_units_shut_down",
             null
         ],
@@ -751,16 +741,6 @@
         [
             "output",
             "ramp_costs",
-            null
-        ],
-        [
-            "output",
-            "ramp_down_unit_flow",
-            null
-        ],
-        [
-            "output",
-            "ramp_up_unit_flow",
             null
         ],
         [
@@ -785,17 +765,7 @@
         ],
         [
             "output",
-            "shut_down_unit_flow",
-            null
-        ],
-        [
-            "output",
             "start_up_costs",
-            null
-        ],
-        [
-            "output",
-            "start_up_unit_flow",
             null
         ],
         [
@@ -3222,31 +3192,10 @@
         ],
         [
             "unit__from_node",
-            "fix_nonspin_ramp_up_unit_flow",
-            null,
-            null,
-            "Fix the `nonspin_ramp_up_unit_flow` variable."
-        ],
-        [
-            "unit__from_node",
             "fix_nonspin_units_started_up",
             null,
             null,
             "Fix the `nonspin_units_started_up` variable."
-        ],
-        [
-            "unit__from_node",
-            "fix_ramp_up_unit_flow",
-            null,
-            null,
-            "Fix the `ramp_up_unit_flow` variable."
-        ],
-        [
-            "unit__from_node",
-            "fix_start_up_unit_flow",
-            null,
-            null,
-            "Fix the `start_up_unit_flow` variable."
         ],
         [
             "unit__from_node",
@@ -3278,31 +3227,10 @@
         ],
         [
             "unit__from_node",
-            "initial_nonspin_ramp_up_unit_flow",
-            null,
-            null,
-            "Initialize the `nonspin_ramp_up_unit_flow` variable."
-        ],
-        [
-            "unit__from_node",
             "initial_nonspin_units_started_up",
             null,
             null,
             "Initialize the `nonspin_units_started_up` variable."
-        ],
-        [
-            "unit__from_node",
-            "initial_ramp_up_unit_flow",
-            null,
-            null,
-            "Initialize the `ramp_up_unit_flow` variable."
-        ],
-        [
-            "unit__from_node",
-            "initial_start_up_unit_flow",
-            null,
-            null,
-            "Initialize the `start_up_unit_flow` variable."
         ],
         [
             "unit__from_node",
@@ -3705,20 +3633,6 @@
         ],
         [
             "unit__to_node",
-            "fix_nonspin_ramp_down_unit_flow",
-            null,
-            null,
-            "Fix the `nonspin_ramp_down_unit_flow` variable."
-        ],
-        [
-            "unit__to_node",
-            "fix_nonspin_ramp_up_unit_flow",
-            null,
-            null,
-            "Fix the `nonspin_ramp_up_unit_flow` variable."
-        ],
-        [
-            "unit__to_node",
             "fix_nonspin_units_shut_down",
             null,
             null,
@@ -3730,34 +3644,6 @@
             null,
             null,
             "Fix the `nonspin_units_started_up` variable."
-        ],
-        [
-            "unit__to_node",
-            "fix_ramp_down_unit_flow",
-            null,
-            null,
-            "Fix the `ramp_down_unit_flow` variable."
-        ],
-        [
-            "unit__to_node",
-            "fix_ramp_up_unit_flow",
-            null,
-            null,
-            "Fix the `ramp_up_unit_flow` variable."
-        ],
-        [
-            "unit__to_node",
-            "fix_shut_down_unit_flow",
-            null,
-            null,
-            "Fix the `shut_down_unit_flow` variable."
-        ],
-        [
-            "unit__to_node",
-            "fix_start_up_unit_flow",
-            null,
-            null,
-            "Fix the `start_up_unit_flow` variable."
         ],
         [
             "unit__to_node",
@@ -3789,20 +3675,6 @@
         ],
         [
             "unit__to_node",
-            "initial_nonspin_ramp_down_unit_flow",
-            null,
-            null,
-            "Initialize the `nonspin_ramp_down_unit_flow` variable."
-        ],
-        [
-            "unit__to_node",
-            "initial_nonspin_ramp_up_unit_flow",
-            null,
-            null,
-            "Initialize the `nonspin_ramp_up_unit_flow` variable."
-        ],
-        [
-            "unit__to_node",
             "initial_nonspin_units_shut_down",
             null,
             null,
@@ -3814,34 +3686,6 @@
             null,
             null,
             "Initialize the `nonspin_units_started_up` variable."
-        ],
-        [
-            "unit__to_node",
-            "initial_ramp_down_unit_flow",
-            null,
-            null,
-            "Initialize the `ramp_down_unit_flow` variable."
-        ],
-        [
-            "unit__to_node",
-            "initial_ramp_up_unit_flow",
-            null,
-            null,
-            "Initialize the `ramp_up_unit_flow` variable."
-        ],
-        [
-            "unit__to_node",
-            "initial_shut_down_unit_flow",
-            null,
-            null,
-            "Initialize the `shut_down_unit_flow` variable."
-        ],
-        [
-            "unit__to_node",
-            "initial_start_up_unit_flow",
-            null,
-            null,
-            "Initialize the `start_up_unit_flow` variable."
         ],
         [
             "unit__to_node",

--- a/templates/archetypes/unit_commitment_restrictions.json
+++ b/templates/archetypes/unit_commitment_restrictions.json
@@ -102,15 +102,9 @@
         ["unit", "unit_investment_variable_type", "unit_investment_variable_type_continuous", "unit_investment_variable_type_list", "Determines whether investment variable is integer or continuous."]
     ],
     "relationship_parameters": [
-        ["unit__to_node", "fix_nonspin_ramp_down_unit_flow", null, null, "Fix the `nonspin_ramp_down_unit_flow` variable."],
-        ["unit__to_node", "fix_nonspin_ramp_up_unit_flow", null, null, "Fix the `nonspin_ramp_up_unit_flow` variable."],
         ["unit__to_node", "fix_nonspin_units_shut_down", null, null, "Fix the `nonspin_units_shut_down` variable."],
         ["unit__to_node", "fix_nonspin_units_started_up", null, null, "Fix the `nonspin_units_started_up` variable."],
         ["unit__to_node", "fix_nonspin_units_starting_up", null, null, "Fix the `nonspin_units_starting_up` variable."],
-        ["unit__to_node", "fix_ramp_down_unit_flow", null, null, "Fix the `ramp_down_unit_flow` variable."],
-        ["unit__to_node", "fix_ramp_up_unit_flow", null, null, "Fix the `ramp_up_unit_flow` variable."],
-        ["unit__to_node", "fix_shut_down_unit_flow", null, null, "Fix the `shut_down_unit_flow` variable."],
-        ["unit__to_node", "fix_start_up_unit_flow", null, null, "Fix the `start_up_unit_flow` variable."],
         ["unit__to_node", "fix_unit_flow", null, null, "Fix the `unit_flow` variable."],
         ["unit__to_node", "fix_unit_flow_op", null, null, "Fix the `unit_flow_op` variable."],
         ["unit__to_node", "fuel_cost", null, null, "Variable fuel costs than can be attributed to a `unit_flow`. E.g. EUR/MWh"],

--- a/templates/archetypes/units_ramping_and_non-spinning_reserve_restrictions.json
+++ b/templates/archetypes/units_ramping_and_non-spinning_reserve_restrictions.json
@@ -100,15 +100,9 @@
         ["unit", "unit_investment_variable_type", "unit_investment_variable_type_continuous", "unit_investment_variable_type_list", "Determines whether investment variable is integer or continuous."]
     ],
     "relationship_parameters": [
-        ["unit__to_node", "fix_nonspin_ramp_down_unit_flow", null, null, "Fix the `nonspin_ramp_down_unit_flow` variable."],
-        ["unit__to_node", "fix_nonspin_ramp_up_unit_flow", null, null, "Fix the `nonspin_ramp_up_unit_flow` variable."],
         ["unit__to_node", "fix_nonspin_units_shut_down", null, null, "Fix the `nonspin_units_shut_down` variable."],
         ["unit__to_node", "fix_nonspin_units_started_up", null, null, "Fix the `nonspin_units_started_up` variable."],
         ["unit__to_node", "fix_nonspin_units_starting_up", null, null, "Fix the `nonspin_units_starting_up` variable."],
-        ["unit__to_node", "fix_ramp_down_unit_flow", null, null, "Fix the `ramp_down_unit_flow` variable."],
-        ["unit__to_node", "fix_ramp_up_unit_flow", null, null, "Fix the `ramp_up_unit_flow` variable."],
-        ["unit__to_node", "fix_shut_down_unit_flow", null, null, "Fix the `shut_down_unit_flow` variable."],
-        ["unit__to_node", "fix_start_up_unit_flow", null, null, "Fix the `start_up_unit_flow` variable."],
         ["unit__to_node", "fix_unit_flow", null, null, "Fix the `unit_flow` variable."],
         ["unit__to_node", "fix_unit_flow_op", null, null, "Fix the `unit_flow_op` variable."],
         ["unit__to_node", "fuel_cost", null, null, "Variable fuel costs than can be attributed to a `unit_flow`. E.g. EUR/MWh"],

--- a/templates/archetypes/units_ramping_and_spinning_reserve_restrictions.json
+++ b/templates/archetypes/units_ramping_and_spinning_reserve_restrictions.json
@@ -100,15 +100,9 @@
         ["unit", "unit_investment_variable_type", "unit_investment_variable_type_continuous", "unit_investment_variable_type_list", "Determines whether investment variable is integer or continuous."]
     ],
     "relationship_parameters": [
-        ["unit__to_node", "fix_nonspin_ramp_down_unit_flow", null, null, "Fix the `nonspin_ramp_down_unit_flow` variable."],
-        ["unit__to_node", "fix_nonspin_ramp_up_unit_flow", null, null, "Fix the `nonspin_ramp_up_unit_flow` variable."],
         ["unit__to_node", "fix_nonspin_units_shut_down", null, null, "Fix the `nonspin_units_shut_down` variable."],
         ["unit__to_node", "fix_nonspin_units_started_up", null, null, "Fix the `nonspin_units_started_up` variable."],
         ["unit__to_node", "fix_nonspin_units_starting_up", null, null, "Fix the `nonspin_units_starting_up` variable."],
-        ["unit__to_node", "fix_ramp_down_unit_flow", null, null, "Fix the `ramp_down_unit_flow` variable."],
-        ["unit__to_node", "fix_ramp_up_unit_flow", null, null, "Fix the `ramp_up_unit_flow` variable."],
-        ["unit__to_node", "fix_shut_down_unit_flow", null, null, "Fix the `shut_down_unit_flow` variable."],
-        ["unit__to_node", "fix_start_up_unit_flow", null, null, "Fix the `start_up_unit_flow` variable."],
         ["unit__to_node", "fix_unit_flow", null, null, "Fix the `unit_flow` variable."],
         ["unit__to_node", "fix_unit_flow_op", null, null, "Fix the `unit_flow_op` variable."],
         ["unit__to_node", "fuel_cost", null, null, "Variable fuel costs than can be attributed to a `unit_flow`. E.g. EUR/MWh"],

--- a/templates/archetypes/units_ramping_restrictions.json
+++ b/templates/archetypes/units_ramping_restrictions.json
@@ -100,15 +100,9 @@
         ["unit", "unit_investment_variable_type", "unit_investment_variable_type_continuous", "unit_investment_variable_type_list", "Determines whether investment variable is integer or continuous."]
     ],
     "relationship_parameters": [
-        ["unit__to_node", "fix_nonspin_ramp_down_unit_flow", null, null, "Fix the `nonspin_ramp_down_unit_flow` variable."],
-        ["unit__to_node", "fix_nonspin_ramp_up_unit_flow", null, null, "Fix the `nonspin_ramp_up_unit_flow` variable."],
         ["unit__to_node", "fix_nonspin_units_shut_down", null, null, "Fix the `nonspin_units_shut_down` variable."],
         ["unit__to_node", "fix_nonspin_units_started_up", null, null, "Fix the `nonspin_units_started_up` variable."],
         ["unit__to_node", "fix_nonspin_units_starting_up", null, null, "Fix the `nonspin_units_starting_up` variable."],
-        ["unit__to_node", "fix_ramp_down_unit_flow", null, null, "Fix the `ramp_down_unit_flow` variable."],
-        ["unit__to_node", "fix_ramp_up_unit_flow", null, null, "Fix the `ramp_up_unit_flow` variable."],
-        ["unit__to_node", "fix_shut_down_unit_flow", null, null, "Fix the `shut_down_unit_flow` variable."],
-        ["unit__to_node", "fix_start_up_unit_flow", null, null, "Fix the `start_up_unit_flow` variable."],
         ["unit__to_node", "fix_unit_flow", null, null, "Fix the `unit_flow` variable."],
         ["unit__to_node", "fix_unit_flow_op", null, null, "Fix the `unit_flow_op` variable."],
         ["unit__to_node", "fuel_cost", null, null, "Variable fuel costs than can be attributed to a `unit_flow`. E.g. EUR/MWh"],

--- a/templates/spineopt_template.json
+++ b/templates/spineopt_template.json
@@ -736,14 +736,8 @@
         ["output","node_slack_pos","output_type","variable","Base"],
         ["output","node_state","output_type","variable","Base"],
         ["output","node_voltage_angle","output_type","variable","Base"],
-        ["output","nonspin_ramp_down_unit_flow","output_type","variable","Base"],
-        ["output","nonspin_ramp_up_unit_flow","output_type","variable","Base"],
         ["output","nonspin_units_shut_down","output_type","variable","Base"],
         ["output","nonspin_units_started_up","output_type","variable","Base"],
-        ["output","ramp_down_unit_flow","output_type","variable","Base"],
-        ["output","ramp_up_unit_flow","output_type","variable","Base"],
-        ["output","shut_down_unit_flow","output_type","variable","Base"],
-        ["output","start_up_unit_flow","output_type","variable","Base"],
         ["output","storages_decommissioned","output_type","variable","Base"],
         ["output","storages_invested","output_type","variable","Base"],
         ["output","storages_invested_available","output_type","variable","Base"],
@@ -952,5 +946,8 @@
         ["output","constraint_investment_group_minimum_entities_invested_available","Base", true],
         ["output","constraint_unit_lifetime","Base", true],
         ["output","constraint_non_spinning_reserves_shut_down_upper_bound","Base", true]
+    ],
+    "alternatives": [
+        ["Base","Base alternative"]
     ]
 }


### PR DESCRIPTION
Parameter values of these outputs were causing issues when importing the template:
- `nonspin_ramp_down_unit_flow`
- `nonspin_ramp_up_unit_flow`
- `ramp_down_unit_flow`
- `ramp_up_unit_flow`
- `shut_down_unit_flow`
- `start_up_unit_flow` Deleting also entities and parameter definitions related to those (obsolete) variables from the archetypes and examples. 

Fixes # 1164

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted according to SpineOpt's style
- [x] Unit tests pass
