### PR TITLE
Add functionality for timedependent forced outage

### DIFF
--- a/src/generate_forced_outages.jl
+++ b/src/generate_forced_outages.jl
@@ -19,36 +19,41 @@
 using Distributions
 using Random
 
-function _rand_time(mean_time; resolution)
+function _rand_time(mean_time, u; resolution)
+    mean_time = (typeof(mean_time) == Float64 ? Day(mean_time) : mean_time)
     mean_time = round(mean_time, resolution(1))
     resolution(round(Int, rand(Exponential(iszero(mean_time.value) ? 1e-6 : mean_time.value))))
 end
 
-function _forced_outages(t_start, t_end, mttf, mttr; resolution)
+function _forced_outages(t_start, t_end, mttf, mttr, u; resolution)
     times = []
     t = t_start
     while t < t_end
-        failure_time = t + _rand_time(mttf; resolution)
-        repair_time = failure_time + _rand_time(mttr; resolution)
+        failure_time = t + _rand_time(mttf(unit=u, t=t,_strict=false),u; resolution)
+        test_mttr = _rand_time(mttr(unit=u, t=t,_strict=false),u; resolution)
+        repair_time = failure_time + test_mttr 
         push!(times, (failure_time, repair_time))
         t = repair_time
     end
     times
 end
-_forced_outages(t_start, t_end, ::Nothing, mttr; resolution) = []  # never fails
-_forced_outages(t_start, t_end, ::Nothing, ::Nothing; resolution) = []  # never fails
-_forced_outages(t_start, t_end, mttf, ::Nothing; resolution) = [(t_start + _rand_time(mttf; resolution), t_end)]
+_forced_outages(t_start, t_end, ::Nothing, mttr, u; resolution) = []  # never fails
+_forced_outages(t_start, t_end, ::Nothing, ::Nothing, u; resolution) = []  # never fails
+_forced_outages(t_start, t_end, mttf, ::Nothing, u; resolution) = [(t_start + _rand_time(mttf; resolution), t_end)] #TODO: fix me too
 
-function forced_outage_time_series(t_start, t_end, mttf, mttr; seed=nothing, resolution=Hour)
+function forced_outage_time_series(t_start, t_end, mttf, mttr, u; seed=nothing, resolution=Hour)
     seed === nothing || Random.seed!(seed)
     indices = [t_start]
-    values = [0]
-    for (failure_time, repair_time) in _forced_outages(t_start, t_end, mttf, mttr; resolution)
-        append!(indices, [failure_time, repair_time])
+    values = [0] # TODO: why is first one fixed to 0? I think this should be arbitrary - seems to be for initialization purposes alright, but could be revisited in the future
+    for (failure_time, repair_time) in _forced_outages(t_start, t_end, mttf, mttr, u; resolution)
+        append!(indices, [failure_time, repair_time]) 
         append!(values, [1, 0])
     end
-    push!(indices, t_end)
-    push!(values, 0)
+    # push!(indices, t_end) 
+    # push!(values, 0)
+    # TODO: please advise:
+    # I have uncommented above as I think it'd be better if the timeseries reflects the "true" status (e.g., 1 or 0) 
+    # at the end of the model horizon (especially if timeseries is to be used again for other purpose later on)
     TimeSeries(indices, values)
 end
 
@@ -76,26 +81,29 @@ Parameter `units_unavailable` will be written for those units in the output DB h
     using SpineOpt
     m = generate_forced_outages(
         raw"sqlite:///C:\\path\\to\\your\\input_db.sqlite", 
-        raw"sqlite:///C:\\path\\to\\your\\output_db.sqlite"
-    )
+        raw"sqlite:///C:\\path\\to\\your\\output_db.sqlite", 
+        on_conflict="replace")
 
 """
-function generate_forced_outages(url_in, url_out=url_in; alternative="Base")
-    using_spinedb(url_in, @__MODULE__)
+function generate_forced_outages(url_in, url_out=url_in; alternative="Base", on_conflict="replace")
+    #Added the "on_conflict = replace" argument: In most cases, I believe we'd want to overwrite outages rahter than append
+    # e.g. I could see running this script twixe would add overproportional amount of outages to the timeseries
+    using_spinedb(url_in)
     m_start = minimum(model_start(model=m) for m in model())
     m_end = maximum(model_end(model=m) for m in model())
     forced_outage_ts = Dict(
-        u => forced_outage_time_series(
-            m_start,
-            m_end,
-            mean_time_to_failure(unit=u, _strict=false),
-            mean_time_to_repair(unit=u, _strict=false)
+        (unit = u,) => forced_outage_time_series(
+            m_start, #model start
+            m_end, #model end
+            mean_time_to_failure,#(unit=u, _strict=false),
+            mean_time_to_repair,#(unit=u, _strict=false)
+            u,
         )
         for u in indices(mean_time_to_failure)
     )
     if !isempty(forced_outage_ts)
         write_parameters(
-            Dict(:units_unavailable => forced_outage_ts), url_out; alternative=alternative
+            Dict(:units_unavailable => forced_outage_ts), url_out; alternative=alternative, on_conflict=on_conflict
         )
     end
 end

--- a/src/generate_forced_outages.jl
+++ b/src/generate_forced_outages.jl
@@ -30,8 +30,7 @@ function _forced_outages(t_start, t_end, mttf, mttr, u; resolution)
     t = t_start
     while t < t_end
         failure_time = t + _rand_time(mttf(unit=u, t=t,_strict=false),u; resolution)
-        test_mttr = _rand_time(mttr(unit=u, t=t,_strict=false),u; resolution)
-        repair_time = failure_time + test_mttr 
+        repair_time = failure_time + _rand_time(mttr(unit=u, t=t,_strict=false),u; resolution)
         push!(times, (failure_time, repair_time))
         t = repair_time
     end

--- a/src/generate_forced_outages.jl
+++ b/src/generate_forced_outages.jl
@@ -39,7 +39,7 @@ function _forced_outages(t_start, t_end, mttf, mttr, u; resolution)
 end
 _forced_outages(t_start, t_end, ::Nothing, mttr, u; resolution) = []  # never fails
 _forced_outages(t_start, t_end, ::Nothing, ::Nothing, u; resolution) = []  # never fails
-_forced_outages(t_start, t_end, mttf, ::Nothing, u; resolution) = [(t_start + _rand_time(mttf; resolution), t_end)] #TODO: fix me too
+_forced_outages(t_start, t_end, mttf, ::Nothing, u; resolution) = [(t_start + _rand_time(mttf; resolution), t_end)] # How do address this for time-dependent outage rate?
 
 function forced_outage_time_series(t_start, t_end, mttf, mttr, u; seed=nothing, resolution=Hour)
     seed === nothing || Random.seed!(seed)
@@ -87,16 +87,16 @@ Parameter `units_unavailable` will be written for those units in the output DB h
 """
 function generate_forced_outages(url_in, url_out=url_in; alternative="Base", on_conflict="replace")
     #Added the "on_conflict = replace" argument: In most cases, I believe we'd want to overwrite outages rahter than append
-    # e.g. I could see running this script twixe would add overproportional amount of outages to the timeseries
-    using_spinedb(url_in)
+    # e.g. I could see running this script twice would add overproportional amount of outages to the timeseries
+    using_spinedb(url_in, @__MODULE__)
     m_start = minimum(model_start(model=m) for m in model())
     m_end = maximum(model_end(model=m) for m in model())
     forced_outage_ts = Dict(
         (unit = u,) => forced_outage_time_series(
-            m_start, #model start
-            m_end, #model end
-            mean_time_to_failure,#(unit=u, _strict=false),
-            mean_time_to_repair,#(unit=u, _strict=false)
+            m_start,
+            m_end,
+            mean_time_to_failure,
+            mean_time_to_repair,
             u,
         )
         for u in indices(mean_time_to_failure)


### PR DESCRIPTION
In order to account for time-dependent outage rates (e.g., influenced by weather, see for example: [Murphy - A time-dependent model of generator failures and recoveries captures correlated events and quantifies temperature dependence](https://www.sciencedirect.com/science/article/pii/S0306261919311870), it'd be nice to be able to support MTTF and MTTR as timeseries parameters. The adaptation for this script supports this, with the caveat that timeseries currently only supports Float values. The script will treat Floats as number of Days for respective parameters. 

Other than minor update to write_parameter function (was outdated) and added the keyword "on_conflict"=replace. The latter one seemed reasonable as I was testing and noticed that I created "more and more" outages, as the script would append the timeseries, leading to erroneous timeseries for forced outages. I left it as an optional keyword, In case e.g. do want to append an existing timeseries (e.g., originally created for year x, and now appended for year y, as long as they don't overlap)

Fixes # (no issue addressed)

## Checklist before merging
- [ ] Documentation is up-to-date
- [ ] Unit tests have been added/updated accordingly - no unit test available for this script yet. This should however be established in the future
- [ ] Code has been formatted according to SpineOpt's style - probably not yet, there's a few comments reviewers need to check out first before
- [ ] Unit tests pass (N/A)
