### PR TITLE
Make .install_spinedb_api.jl accept spinedb_api Git ref as command line argument

### DIFF
--- a/.install_spinedb_api.jl
+++ b/.install_spinedb_api.jl
@@ -4,5 +4,10 @@ pkg"registry add https://github.com/spine-tools/SpineJuliaRegistry"
 pkg"add PyCall"
 using PyCall
 python = PyCall.pyprogramname
+if isempty(ARGS)
+    spine_db_api_git_ref = "master"
+else
+    spine_db_api_git_ref = ARGS[1]
+end
 run(`$python -m pip install --user setuptools-scm`)
-run(`$python -m pip install --user git+https://github.com/spine-tools/Spine-Database-API`)
+run(`$python -m pip install --user git+https://github.com/spine-tools/Spine-Database-API@$spine_db_api_git_ref`)


### PR DESCRIPTION
Needed to force unit tests to use the correct `spinedb_api` Git branch when the tests are called from Spine-Database-API repository.

No associated issue.

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted according to SpineOpt's style
- [ ] Unit tests pass
