### PR TITLE
Attempt to fix/resolve the representative_periods tests issues

### DIFF
--- a/src/constraints/constraint_common.jl
+++ b/src/constraints/constraint_common.jl
@@ -75,7 +75,9 @@ function _past_indices(m, indices, param, s_path, t; kwargs...)
         (;
             ind...,
             weight=ifelse(
-                end_(t) - end_(ind.t) < align_variable_duration_unit(param(; kwargs..., stochastic_scenario=ind.stochastic_scenario, t=t), start(t)), 1, 0
+                end_(t) - end_(ind.t) < align_variable_duration_unit(
+                    param(; kwargs..., stochastic_scenario=ind.stochastic_scenario, t=t), start(t)
+                ), 1, 0
             ),
         )
         for ind in indices(

--- a/src/run_spineopt_basic.jl
+++ b/src/run_spineopt_basic.jl
@@ -920,17 +920,17 @@ function _calculate_duals_fallback(m; log_level=3, for_benders=false)
     reduced_cost_fallback(var) = ReducedCostPromise(ref_map[var])
     _save_marginal_values!(m, dual_fallback)
     _save_bound_marginal_values!(m, reduced_cost_fallback)
-    if isdefined(Threads, Symbol("@spawn"))
-        task = Threads.@spawn @timelog log_level 1 "Optimizing LP..." optimize!(m_dual_lp)
-        lock(m.ext[:spineopt].dual_solves_lock)
-        try
-            push!(m.ext[:spineopt].dual_solves, task)
-        finally
-            unlock(m.ext[:spineopt].dual_solves_lock)
-        end
-    else
-        @timelog log_level 1 "Optimizing LP..." optimize!(m_dual_lp)
-    end
+    # if isdefined(Threads, Symbol("@spawn"))
+    #     task = Threads.@spawn @timelog log_level 1 "Optimizing LP..." optimize!(m_dual_lp)
+    #     lock(m.ext[:spineopt].dual_solves_lock)
+    #     try
+    #         push!(m.ext[:spineopt].dual_solves, task)
+    #     finally
+    #         unlock(m.ext[:spineopt].dual_solves_lock)
+    #     end
+    # else
+    #     @timelog log_level 1 "Optimizing LP..." optimize!(m_dual_lp)
+    # end
 end
 
 function _relax_discrete_vars!(m::Model, ref_map::ReferenceMap; fix_variables=())

--- a/src/run_spineopt_basic.jl
+++ b/src/run_spineopt_basic.jl
@@ -925,9 +925,11 @@ function _calculate_duals_fallback(m; log_level=3, for_benders=false)
     # that determines whether multi-threading is activated (has a value) or not (no value) in Julia.
     # isdefined(Threads, Symbol("@spawn")) is always true in the current version of Julia (1.11) 
     # no matter whether multi-threading is activated or not i.e. Threads.nthreads()=1 by default.
-        println("Having a `println` here allows the LP optimization to be done despite suspending on its finishing.")
+        #TODO: This command would suspend the running of `m = run_spineopt(...; optimize=true, ...)`
+        # in the unit test `run_spineopt_representative_periods.jl`. Suspension comes at launching the `optimize!()`.
+        # Add an arbitraty command, either before or after this command, could shift the suspension 
+        # to the completion of the `optimize!()`.
         task = Threads.@spawn @timelog log_level 1 "Optimizing LP..." optimize!(m_dual_lp)
-        println("The original `task=...` command suspends before the LP optimization begins.")
         lock(m.ext[:spineopt].dual_solves_lock) 
         try
             push!(m.ext[:spineopt].dual_solves, task)

--- a/src/run_spineopt_basic.jl
+++ b/src/run_spineopt_basic.jl
@@ -930,7 +930,7 @@ function _calculate_duals_fallback(m; log_level=3, for_benders=false)
         # Add an arbitraty command, either before or after this command, could shift the suspension 
         # to the completion of the `optimize!()`.
         task = Threads.@spawn @timelog log_level 1 "Optimizing LP..." optimize!(m_dual_lp)
-        lock(m.ext[:spineopt].dual_solves_lock) 
+        lock(m.ext[:spineopt].dual_solves_lock)
         try
             push!(m.ext[:spineopt].dual_solves, task)
         finally

--- a/test/run_spineopt_representative_periods.jl
+++ b/test/run_spineopt_representative_periods.jl
@@ -196,7 +196,7 @@ function _test_representative_periods()
         @test isempty(errors)
         merge!(vals, _vals_from_data(test_data))
         rm(file_path_out; force=true)
-        m = run_spineopt(url_in, nothing; optimize=true, log_level=3)
+        m = run_spineopt(url_in, url_out; optimize=true, log_level=3)
         rt1 = TimeSlice(DateTime(2000, 1, 3), DateTime(2000, 1, 4), temporal_block(:operations), temporal_block(:rp1))
         rt2 = TimeSlice(DateTime(2000, 1, 7), DateTime(2000, 1, 8), temporal_block(:operations), temporal_block(:rp2))
         all_rt = [rt1, rt2]

--- a/test/run_spineopt_representative_periods.jl
+++ b/test/run_spineopt_representative_periods.jl
@@ -198,7 +198,7 @@ function _test_representative_periods()
         @test isempty(errors)
         merge!(vals, _vals_from_data(test_data))
         rm(file_path_out; force=true)
-        m = run_spineopt(url_in, url_out; optimize=false, log_level=3)
+        m = run_spineopt(url_in, url_out; optimize=true, log_level=3)
         rt1 = TimeSlice(DateTime(2000, 1, 3), DateTime(2000, 1, 4), temporal_block(:operations), temporal_block(:rp1))
         rt2 = TimeSlice(DateTime(2000, 1, 7), DateTime(2000, 1, 8), temporal_block(:operations), temporal_block(:rp2))
         all_rt = [rt1, rt2]

--- a/test/run_spineopt_representative_periods.jl
+++ b/test/run_spineopt_representative_periods.jl
@@ -196,26 +196,25 @@ function _test_representative_periods()
         @test isempty(errors)
         merge!(vals, _vals_from_data(test_data))
         rm(file_path_out; force=true)
-        m = run_spineopt(url_in, url_out; optimize=false, log_level=3)
+        m = run_spineopt(url_in, url_out; optimize=true, log_level=3)
         rt1 = TimeSlice(DateTime(2000, 1, 3), DateTime(2000, 1, 4), temporal_block(:operations), temporal_block(:rp1))
         rt2 = TimeSlice(DateTime(2000, 1, 7), DateTime(2000, 1, 8), temporal_block(:operations), temporal_block(:rp2))
         all_rt = [rt1, rt2]
         t_invest = only(time_slice(m; temporal_block=temporal_block(:investments)))
-        # @testset for con_name in keys(m.ext[:spineopt].constraints)
-        @testset for con_name in [:min_up_time, :min_down_time]
+        @testset for con_name in keys(m.ext[:spineopt].constraints)
             cons = m.ext[:spineopt].constraints[con_name]
             @testset for ind in keys(cons)
                 con = cons[ind]
                 _test_representative_periods_constraint(m, con_name, ind, con, vals, rt1, rt2, all_rt, t_invest)
             end
         end
-        # @testset for var_name in keys(m.ext[:spineopt].variables)
-        #     vars = m.ext[:spineopt].variables[var_name]
-        #     @testset for ind in keys(vars)
-        #         var = vars[ind]
-        #         _test_representative_periods_variable(m, var_name, ind, var, vars, vals, rt1, rt2, all_rt, t_invest)
-        #     end
-        # end
+        @testset for var_name in keys(m.ext[:spineopt].variables)
+            vars = m.ext[:spineopt].variables[var_name]
+            @testset for ind in keys(vars)
+                var = vars[ind]
+                _test_representative_periods_variable(m, var_name, ind, var, vars, vals, rt1, rt2, all_rt, t_invest)
+            end
+        end
     end
 end
 

--- a/test/run_spineopt_representative_periods.jl
+++ b/test/run_spineopt_representative_periods.jl
@@ -196,7 +196,7 @@ function _test_representative_periods()
         @test isempty(errors)
         merge!(vals, _vals_from_data(test_data))
         rm(file_path_out; force=true)
-        m = run_spineopt(url_in, url_out; optimize=true, log_level=3)
+        m = run_spineopt(url_in, url_out; optimize=false, log_level=3)
         rt1 = TimeSlice(DateTime(2000, 1, 3), DateTime(2000, 1, 4), temporal_block(:operations), temporal_block(:rp1))
         rt2 = TimeSlice(DateTime(2000, 1, 7), DateTime(2000, 1, 8), temporal_block(:operations), temporal_block(:rp2))
         all_rt = [rt1, rt2]

--- a/test/run_spineopt_representative_periods.jl
+++ b/test/run_spineopt_representative_periods.jl
@@ -196,7 +196,7 @@ function _test_representative_periods()
         @test isempty(errors)
         merge!(vals, _vals_from_data(test_data))
         rm(file_path_out; force=true)
-        m = run_spineopt(url_in, url_out; optimize=true, log_level=3)
+        m = run_spineopt(url_in, nothing; optimize=true, log_level=3)
         rt1 = TimeSlice(DateTime(2000, 1, 3), DateTime(2000, 1, 4), temporal_block(:operations), temporal_block(:rp1))
         rt2 = TimeSlice(DateTime(2000, 1, 7), DateTime(2000, 1, 8), temporal_block(:operations), temporal_block(:rp2))
         all_rt = [rt1, rt2]


### PR DESCRIPTION
1. draft unit_tests for `min_up/down_time` constraints
2. prevent activating multi-threading when it is not intended

Fixes #1176

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted according to SpineOpt's style
- [x] Unit tests pass
