### PR TITLE
Omit optimization from unit tests when we can get away with it?

### DIFF
--- a/test/run_spineopt.jl
+++ b/test/run_spineopt.jl
@@ -866,7 +866,7 @@ function _test_time_limit()
         rm(file_path_out; force=true)
         windows = [TimeSlice(t, t + Hour(6)) for t in DateTime(2000, 1, 1):Hour(6):DateTime(2000, 1, 1, 18)]
         msgs = ["no solution available for instance - window $w - moving on..." for w in windows]
-        @test_logs(min_level=Warn, ((:warn, msg) for msg in msgs)..., run_spineopt(url_in, url_out; log_level=0))
+        @test_logs(min_level=Warn, ((:warn, msg) for msg in msgs)..., run_spineopt(url_in, url_out; log_level=0, optimize=false))
     end
 end
 
@@ -904,7 +904,7 @@ function _test_add_event_handler()
     @testset "add_event_handler" begin
         url_in, url_out, file_path_out = _test_run_spineopt_setup()
         called = false
-        m = run_spineopt(url_in, url_out; log_level=0) do m
+        m = run_spineopt(url_in, url_out; log_level=0, optimize=false) do m
             add_event_handler!(m, :model_built) do m
                 called = true
             end

--- a/test/run_spineopt.jl
+++ b/test/run_spineopt.jl
@@ -866,7 +866,7 @@ function _test_time_limit()
         rm(file_path_out; force=true)
         windows = [TimeSlice(t, t + Hour(6)) for t in DateTime(2000, 1, 1):Hour(6):DateTime(2000, 1, 1, 18)]
         msgs = ["no solution available for instance - window $w - moving on..." for w in windows]
-        @test_logs(min_level=Warn, ((:warn, msg) for msg in msgs)..., run_spineopt(url_in, url_out; log_level=0, optimize=false))
+        @test_logs(min_level=Warn, ((:warn, msg) for msg in msgs)..., run_spineopt(url_in, url_out; log_level=0))
     end
 end
 

--- a/test/run_spineopt_mga.jl
+++ b/test/run_spineopt_mga.jl
@@ -183,7 +183,7 @@ function _test_run_spineopt_mga()
             object_parameter_values=object_parameter_values,
             relationship_parameter_values=relationship_parameter_values
         )
-        m = run_spineopt(url_in; log_level=1)
+        m = run_spineopt(url_in; log_level=1, optimize=false)
         var_units_invested = m.ext[:spineopt].variables[:units_invested]
         var_unit_flow = m.ext[:spineopt].variables[:unit_flow]
         var_connections_invested = m.ext[:spineopt].variables[:connections_invested]
@@ -548,7 +548,7 @@ function _test_run_spineopt_mga_2()
             object_parameter_values=object_parameter_values,
             relationship_parameter_values=relationship_parameter_values
         )
-        m = run_spineopt(url_in; log_level=1)
+        m = run_spineopt(url_in; log_level=1, optimize=false)
         var_units_invested = m.ext[:spineopt].variables[:units_invested]
         var_unit_flow = m.ext[:spineopt].variables[:unit_flow]
         var_connections_invested = m.ext[:spineopt].variables[:connections_invested]

--- a/test/run_spineopt_monte_carlo.jl
+++ b/test/run_spineopt_monte_carlo.jl
@@ -112,6 +112,7 @@ function _test_monte_carlo()
         import_data(url_in, "Add test data"; test_data...)
         rm(file_path_out; force=true)
         run_spineopt(url_in, url_out; log_level=3)
+        # FIXME: Tasku: There are no actual tests besides that nothing crashes?
     end
 end
 

--- a/test/run_spineopt_multi_stage.jl
+++ b/test/run_spineopt_multi_stage.jl
@@ -239,7 +239,7 @@ function _test_run_spineopt_lt_storage_benders_storage_investment_with_slack_pen
         ]
     )
     import_data(url_in, "Add penalty data"; slack_penalty_data...)
-    m = run_spineopt(url_in, url_out; log_level=0, filters=Dict("scenario" => "base")) do m
+    m = run_spineopt(url_in, url_out; log_level=0, filters=Dict("scenario" => "base"), optimize=false) do m
         add_event_handler!(m, :window_about_to_solve) do m, k
             @testset for out_name in keys(out_pv_by_node_by_name)
                 out_pv_by_node = out_pv_by_node_by_name[out_name]

--- a/test/run_spineopt_representative_periods.jl
+++ b/test/run_spineopt_representative_periods.jl
@@ -198,7 +198,7 @@ function _test_representative_periods()
         @test isempty(errors)
         merge!(vals, _vals_from_data(test_data))
         rm(file_path_out; force=true)
-        m = run_spineopt(url_in, url_out; log_level=3)
+        m = run_spineopt(url_in, url_out; log_level=3, optimize=false)
         rt1 = TimeSlice(DateTime(2000, 1, 3), DateTime(2000, 1, 4), temporal_block(:operations), temporal_block(:rp1))
         rt2 = TimeSlice(DateTime(2000, 1, 7), DateTime(2000, 1, 8), temporal_block(:operations), temporal_block(:rp2))
         all_rt = [rt1, rt2]

--- a/test/variables/variables.jl
+++ b/test/variables/variables.jl
@@ -183,7 +183,7 @@ function test_unit_online_variable_type_none()
             ["model", "instance", "roll_forward", unparse_db_value(Hour(1))],
         ]
         SpineInterface.import_data(url_in; object_parameter_values=object_parameter_values)
-        m = run_spineopt(url_in; log_level=0, optimize=true)
+        m = run_spineopt(url_in; log_level=0, optimize=false)
         var_units_on = m.ext[:spineopt].variables[:units_on]
         constraint_u_avail = m.ext[:spineopt].constraints[:units_available]
         scenarios = (stochastic_scenario(:parent), stochastic_scenario(:child))


### PR DESCRIPTION
Adding some `optimize=false` kwargs for unit tests where we can get away with it. This might technically speed up some unit tests and **currently bypasses the weird freeze in `test/run_spineopt_representative_periods.jl`**.

FYI @DillonJ @datejada @nnhjy, I made this PR mostly just to see if it passes GitHub tests.

Whether this is the way to go, I don't know 🤷 

Fixes #1176 ?

## Checklist before merging
- [x] Documentation is up-to-date _(no changes)_
- [x] Unit tests have been added/updated accordingly _(unnecessary optimization skipped)_
- [x] Code has been formatted according to SpineOpt's style _(only adding kwargs)_
- [x] Unit tests pass _(at least on my machine)_
