### PR TITLE
default `number_of_units` for non-investable and investable units

### DIFF
--- a/src/constraints/constraint_common.jl
+++ b/src/constraints/constraint_common.jl
@@ -146,7 +146,10 @@ function _default_parameter_value(p::Parameter, entity_class::Union{ObjectClass,
     _default = try
         entity_class.parameter_defaults[p.name]
     catch
-        @error("Parameter $p is not defined in $entity_class, \\but in these entity classes $(p.classes).")
+        @error(
+            "Parameter `$p` is only defined in `$(join(p.classes, "`, `"))`.\n
+            `$entity_class` does not contain the parameter."
+        )
         ParameterValue(nothing)
     end
     return _default.value

--- a/src/constraints/constraint_common.jl
+++ b/src/constraints/constraint_common.jl
@@ -137,6 +137,26 @@ in "src\\data_structure\\preprocess_data_structure.jl".
 """
 _d_reverse(d::Object) = d.name == :to_node ? direction(:from_node) : direction(:to_node)
 
+"""
+    _default_parameter_value(p::Parameter, entity_class::Union{ObjectClass,RelationshipClass})
+
+Obtain the default value of parameter `p` defined in `entity_class` as specified in the input DB.
+"""
+function _default_parameter_value(p::Parameter, entity_class::Union{ObjectClass,RelationshipClass})
+    _default = try
+        entity_class.parameter_defaults[p.name]
+    catch
+        @error("Parameter $p is not defined in $entity_class, \\but in these entity classes $(p.classes).")
+        ParameterValue(nothing)
+    end
+    return _default.value
+end
+
+_default_nb_of_storages(n::Object) = is_candidate(node=n) ? 0 : _default_parameter_value(number_of_storages, node)
+_default_nb_of_units(u::Object) = is_candidate(unit=u) ? 0 : _default_parameter_value(number_of_units, unit)
+_default_nb_of_conns(conn::Object) = is_candidate(connection=conn) ? 
+    0 : _default_parameter_value(number_of_connections, connection)
+
 _overlapping_t(m, time_slices...) = [overlapping_t for t in time_slices for overlapping_t in t_overlaps_t(m; t=t)]
 
 function _check_ptdf_duration(m, t, conns...)

--- a/src/constraints/constraint_connection_flow_capacity.jl
+++ b/src/constraints/constraint_connection_flow_capacity.jl
@@ -135,8 +135,6 @@ function _term_total_number_of_connections(m, conn, ng, d, s_path, t)
     )
 end
 
-_default_nb_of_conns(conn) = is_candidate(connection=conn) ? 0 : 1
-
 function constraint_connection_flow_capacity_indices(m::Model)    
     (
         (connection=conn, node=ng, direction=d, stochastic_path=path, t=t)

--- a/src/constraints/constraint_min_down_time.jl
+++ b/src/constraints/constraint_min_down_time.jl
@@ -44,11 +44,7 @@ function _build_constraint_min_down_time(m::Model, u, s_path, t)
     @fetch units_invested_available, units_on, units_shut_down, nonspin_units_started_up = m.ext[:spineopt].variables
     @build_constraint(
         + sum(
-            + (
-                is_candidate(unit=u) ? 
-                number_of_units(m; unit=u, stochastic_scenario=s, t=t, _default=0) : 
-                number_of_units(m; unit=u, stochastic_scenario=s, t=t)
-            )
+            + number_of_units(m; unit=u, stochastic_scenario=s, t=t, _default=_default_nb_of_units(u))
             + sum(
                 units_invested_available[u, s, t1]
                 for (u, s, t1) in units_invested_available_indices(

--- a/src/constraints/constraint_min_down_time.jl
+++ b/src/constraints/constraint_min_down_time.jl
@@ -44,7 +44,11 @@ function _build_constraint_min_down_time(m::Model, u, s_path, t)
     @fetch units_invested_available, units_on, units_shut_down, nonspin_units_started_up = m.ext[:spineopt].variables
     @build_constraint(
         + sum(
-            + number_of_units(m; unit=u, stochastic_scenario=s, t=t)
+            + (
+                is_candidate(unit=u) ? 
+                number_of_units(m; unit=u, stochastic_scenario=s, t=t, _default=0) : 
+                number_of_units(m; unit=u, stochastic_scenario=s, t=t)
+            )
             + sum(
                 units_invested_available[u, s, t1]
                 for (u, s, t1) in units_invested_available_indices(

--- a/src/constraints/constraint_min_scheduled_outage_duration.jl
+++ b/src/constraints/constraint_min_scheduled_outage_duration.jl
@@ -78,11 +78,7 @@ function _max_sch_out_dur(m::Model, u, s_path, t)
         (
             + scheduled_outage_duration(m; unit=u, stochastic_scenario=s, t=t)
             * round(
-                + (
-                    is_candidate(unit=u) ? 
-                    number_of_units(m; unit=u, stochastic_scenario=s, t=t, _default=0) : 
-                    number_of_units(m; unit=u, stochastic_scenario=s, t=t)
-                )
+                + number_of_units(m; unit=u, stochastic_scenario=s, t=t, _default=_default_nb_of_units(u))
                 + candidate_units(m; unit=u, stochastic_scenario=s, t=t, _default=0)
             )
         )

--- a/src/constraints/constraint_min_scheduled_outage_duration.jl
+++ b/src/constraints/constraint_min_scheduled_outage_duration.jl
@@ -78,7 +78,11 @@ function _max_sch_out_dur(m::Model, u, s_path, t)
         (
             + scheduled_outage_duration(m; unit=u, stochastic_scenario=s, t=t)
             * round(
-                + number_of_units(m; unit=u, stochastic_scenario=s, t=t)
+                + (
+                    is_candidate(unit=u) ? 
+                    number_of_units(m; unit=u, stochastic_scenario=s, t=t, _default=0) : 
+                    number_of_units(m; unit=u, stochastic_scenario=s, t=t)
+                )
                 + candidate_units(m; unit=u, stochastic_scenario=s, t=t, _default=0)
             )
         )

--- a/src/constraints/constraint_units_available.jl
+++ b/src/constraints/constraint_units_available.jl
@@ -53,10 +53,13 @@ function _build_constraint_units_available(m, u, s, t)
             init=0,
         )
         <=
-        # Change the default number of units so that it is zero when candidate units are present
+        # Change the default `number_of_units` so that it is zero when candidate units are present
         # and otherwise 1.
-        + ifelse(is_candidate(unit=u), number_of_units(m; unit=u, stochastic_scenario=s, t=t, _default=0), 
-            number_of_units(m; unit=u, stochastic_scenario=s, t=t) )
+        + (
+            is_candidate(unit=u) ? 
+            number_of_units(m; unit=u, stochastic_scenario=s, t=t, _default=0) : 
+            number_of_units(m; unit=u, stochastic_scenario=s, t=t)
+        )
         - units_unavailable(m; unit=u, stochastic_scenario=s, t=t)
     )
 end

--- a/src/constraints/constraint_units_available.jl
+++ b/src/constraints/constraint_units_available.jl
@@ -55,11 +55,7 @@ function _build_constraint_units_available(m, u, s, t)
         <=
         # Change the default `number_of_units` so that it is zero when candidate units are present
         # and otherwise 1.
-        + (
-            is_candidate(unit=u) ? 
-            number_of_units(m; unit=u, stochastic_scenario=s, t=t, _default=0) : 
-            number_of_units(m; unit=u, stochastic_scenario=s, t=t)
-        )
+        + number_of_units(m; unit=u, stochastic_scenario=s, t=t, _default=_default_nb_of_units(u))
         - units_unavailable(m; unit=u, stochastic_scenario=s, t=t)
     )
 end

--- a/src/generate_forced_outages.jl
+++ b/src/generate_forced_outages.jl
@@ -94,11 +94,7 @@ function generate_forced_outages(url_in, url_out=url_in; alternative="Base")
             m_end,
             mean_time_to_failure(unit=u, _strict=false),
             mean_time_to_repair(unit=u, _strict=false),
-            (
-                is_candidate(unit=u) ? 
-                number_of_units(unit=u, _default=0) : 
-                number_of_units(unit=u)
-            ),
+            number_of_units(unit=u, _default=_default_nb_of_units(u)),
         )
         for u in indices(mean_time_to_failure)
     )

--- a/src/generate_forced_outages.jl
+++ b/src/generate_forced_outages.jl
@@ -94,7 +94,11 @@ function generate_forced_outages(url_in, url_out=url_in; alternative="Base")
             m_end,
             mean_time_to_failure(unit=u, _strict=false),
             mean_time_to_repair(unit=u, _strict=false),
-            number_of_units(unit=u),
+            (
+                is_candidate(unit=u) ? 
+                number_of_units(unit=u, _default=0) : 
+                number_of_units(unit=u)
+            ),
         )
         for u in indices(mean_time_to_failure)
     )

--- a/src/objective/fixed_om_costs.jl
+++ b/src/objective/fixed_om_costs.jl
@@ -34,11 +34,13 @@ function fixed_om_costs(m, t_range)
             ) 
             * fom_cost(m; unit=u, stochastic_scenario=s, t=t)
             * (
-                + number_of_units(m; unit=u, stochastic_scenario=s, t=t)
-                + (
-                    u in intersect(indices(candidate_units), members(u)) ? 
-                    units_invested_available[u, s, t] : 0
-                )
+                is_candidate(unit=u) ? 
+                number_of_units(
+                    m; unit=u, stochastic_scenario=s, t=t, _default=0
+                ) + units_invested_available[u, s, t] : 
+                number_of_units(m; unit=u, stochastic_scenario=s, t=t)
+                # Default value of `number_of_units` is 1 in the template: assumption for non-investable units.
+                # For investable unit, we assume the `number_of_units``=0 (existing ones) unless explicitly specified.
             )
             * prod(weight(temporal_block=blk) for blk in blocks(t))
             # This term is activated when there is a representative temporal block that includes t.

--- a/src/objective/fixed_om_costs.jl
+++ b/src/objective/fixed_om_costs.jl
@@ -34,13 +34,10 @@ function fixed_om_costs(m, t_range)
             ) 
             * fom_cost(m; unit=u, stochastic_scenario=s, t=t)
             * (
-                is_candidate(unit=u) ? 
-                number_of_units(
-                    m; unit=u, stochastic_scenario=s, t=t, _default=0
-                ) + units_invested_available[u, s, t] : 
-                number_of_units(m; unit=u, stochastic_scenario=s, t=t)
+                + number_of_units(m; unit=u, stochastic_scenario=s, t=t, _default=_default_nb_of_units(u))
+                + (is_candidate(unit=u) ? units_invested_available[u, s, t] : 0)
                 # Default value of `number_of_units` is 1 in the template: assumption for non-investable units.
-                # For investable unit, we assume the `number_of_units``=0 (existing ones) unless explicitly specified.
+                # For investable unit, we assume the `number_of_units`=0 (existing ones) unless explicitly specified.
             )
             * prod(weight(temporal_block=blk) for blk in blocks(t))
             # This term is activated when there is a representative temporal block that includes t.

--- a/src/variables/variable_node_state.jl
+++ b/src/variables/variable_node_state.jl
@@ -41,8 +41,6 @@ function node_state_ub(m; node, kwargs...)
     )
 end
 
-_default_nb_of_storages(n) = is_candidate(node=n) ? 0 : 1
-
 """
     add_variable_node_state!(m::Model)
 

--- a/src/variables/variable_unit_flow.jl
+++ b/src/variables/variable_unit_flow.jl
@@ -55,11 +55,7 @@ function unit_flow_ub(m; unit, node, direction, kwargs...)
         || members(node) != [node]
     ) && return NaN
     unit_flow_capacity(m; unit=unit, node=node, direction=direction, kwargs..., _default=NaN) * (
-        + (
-            is_candidate(unit=unit) ? 
-            number_of_units(m; unit=unit, kwargs..., _default=0) : 
-            number_of_units(m; unit=unit, kwargs...)
-        )
+        + number_of_units(m; unit=unit, kwargs..., _default=_default_nb_of_units(u))
         + something(candidate_units(m; unit=unit, kwargs...), 0)
     )
 end

--- a/src/variables/variable_unit_flow.jl
+++ b/src/variables/variable_unit_flow.jl
@@ -55,7 +55,7 @@ function unit_flow_ub(m; unit, node, direction, kwargs...)
         || members(node) != [node]
     ) && return NaN
     unit_flow_capacity(m; unit=unit, node=node, direction=direction, kwargs..., _default=NaN) * (
-        + number_of_units(m; unit=unit, kwargs..., _default=_default_nb_of_units(u))
+        + number_of_units(m; unit=unit, kwargs..., _default=_default_nb_of_units(unit))
         + something(candidate_units(m; unit=unit, kwargs...), 0)
     )
 end

--- a/src/variables/variable_unit_flow.jl
+++ b/src/variables/variable_unit_flow.jl
@@ -55,7 +55,11 @@ function unit_flow_ub(m; unit, node, direction, kwargs...)
         || members(node) != [node]
     ) && return NaN
     unit_flow_capacity(m; unit=unit, node=node, direction=direction, kwargs..., _default=NaN) * (
-        + number_of_units(m; unit=unit, kwargs..., _default=1)
+        + (
+            is_candidate(unit=unit) ? 
+            number_of_units(m; unit=unit, kwargs..., _default=0) : 
+            number_of_units(m; unit=unit, kwargs...)
+        )
         + something(candidate_units(m; unit=unit, kwargs...), 0)
     )
 end

--- a/src/variables/variable_units_on.jl
+++ b/src/variables/variable_units_on.jl
@@ -108,7 +108,11 @@ end
 
 function _get_units_on(m, u, s, t)
     get(m.ext[:spineopt].variables[:units_on], (u, s, t)) do
-        number_of_units(m; unit=u, stochastic_scenario=s, t=t)
+        (
+            is_candidate(unit=u) ? 
+            number_of_units(m; unit=u, stochastic_scenario=s, t=t, _default=0) : 
+            number_of_units(m; unit=u, stochastic_scenario=s, t=t)
+        )
     end
 end
 

--- a/src/variables/variable_units_on.jl
+++ b/src/variables/variable_units_on.jl
@@ -108,11 +108,7 @@ end
 
 function _get_units_on(m, u, s, t)
     get(m.ext[:spineopt].variables[:units_on], (u, s, t)) do
-        (
-            is_candidate(unit=u) ? 
-            number_of_units(m; unit=u, stochastic_scenario=s, t=t, _default=0) : 
-            number_of_units(m; unit=u, stochastic_scenario=s, t=t)
-        )
+        number_of_units(unit=u, _default=_default_nb_of_units(u))
     end
 end
 

--- a/test/objective/objective.jl
+++ b/test/objective/objective.jl
@@ -70,91 +70,42 @@ function _test_objective_setup()
     url_in
 end
 
-function test_fom_cost_case1()
-    @testset "fom_cost case1" begin
+function test_fom_cost_case_1a()
+    # When given a non-investable unit without defining `number_of_units`, 
+    # the model uses the template default `number_of_units`=1. 
+    @testset "fom_cost case 1a" begin
         url_in = _test_objective_setup()
         unit_capacity = 100
         fom_cost = 8
-        number_of_units = 2
-        candidate_units = 3
+        number_of_units_template_default = 1
         object_parameter_values = [
             ["unit", "unit_ab", "fom_cost", fom_cost],
-            ["unit", "unit_ab", "number_of_units", number_of_units],
-            ["unit", "unit_ab", "candidate_units", candidate_units],
-        ]
-        relationships = [
-            ["unit__investment_temporal_block", ["unit_ab", "hourly"]],
-            ["unit__investment_stochastic_structure", ["unit_ab", "stochastic"]],
         ]
         relationship_parameter_values = [
             ["unit__to_node", ["unit_ab", "node_b"], "unit_capacity", unit_capacity],
         ]
         SpineInterface.import_data(
             url_in; 
-            relationships=relationships, 
             object_parameter_values=object_parameter_values,
             relationship_parameter_values=relationship_parameter_values
         )
         m = run_spineopt(url_in; log_level=0, optimize=false)
-        var_units_invested_available = m.ext[:spineopt].variables[:units_invested_available]
         
         duration = length(time_slice(m; temporal_block=temporal_block(:two_hourly)))
         scenarios = (stochastic_scenario(:parent), stochastic_scenario(:child))
         time_slices = time_slice(m; temporal_block=temporal_block(:hourly))
         expected_obj = fom_cost * unit_capacity * duration *
         sum(             
-            (number_of_units + var_units_invested_available[unit(:unit_ab), s, t]) 
-            for (s, t) in zip(scenarios, time_slices)
+            number_of_units_template_default for (s, t) in zip(scenarios, time_slices)
         )
         observed_obj = objective_function(m)
         @test observed_obj == expected_obj
     end
 end
 
-function test_fom_cost_case2()
-    @testset "fom_cost case2" begin
-        url_in = _test_objective_setup()
-        unit_capacity = 100
-        fom_cost = 8
-        number_of_units = 0
-        # The template provides the parameter `number_of_units` with a default value of 1.
-        candidate_units = 3
-        object_parameter_values = [
-            ["unit", "unit_ab", "fom_cost", fom_cost],
-            ["unit", "unit_ab", "number_of_units", number_of_units],
-            ["unit", "unit_ab", "candidate_units", candidate_units],
-        ]
-        relationships = [
-            ["unit__investment_temporal_block", ["unit_ab", "hourly"]],
-            ["unit__investment_stochastic_structure", ["unit_ab", "stochastic"]],
-        ]
-        relationship_parameter_values = [
-            ["unit__to_node", ["unit_ab", "node_b"], "unit_capacity", unit_capacity],
-        ]
-        SpineInterface.import_data(
-            url_in; 
-            relationships=relationships, 
-            object_parameter_values=object_parameter_values,
-            relationship_parameter_values=relationship_parameter_values
-        )
-        m = run_spineopt(url_in; log_level=0, optimize=false)
-        var_units_invested_available = m.ext[:spineopt].variables[:units_invested_available]
-        
-        duration = length(time_slice(m; temporal_block=temporal_block(:two_hourly)))
-        scenarios = (stochastic_scenario(:parent), stochastic_scenario(:child))
-        time_slices = time_slice(m; temporal_block=temporal_block(:hourly))
-        expected_obj = fom_cost * unit_capacity * duration *
-        sum(             
-            (number_of_units + var_units_invested_available[unit(:unit_ab), s, t]) 
-            for (s, t) in zip(scenarios, time_slices)
-        )
-        observed_obj = objective_function(m)
-        @test observed_obj == expected_obj
-    end
-end
-
-function test_fom_cost_case3()
-    @testset "fom_cost case3" begin
+function test_fom_cost_case_1b()
+    # When a non-investable unit with `number_of_units` explicitly defined ... 
+    @testset "fom_cost case 1b" begin
         url_in = _test_objective_setup()
         unit_capacity = 100
         fom_cost = 8
@@ -179,6 +130,90 @@ function test_fom_cost_case3()
         expected_obj = fom_cost * unit_capacity * duration *
         sum(             
             number_of_units for (s, t) in zip(scenarios, time_slices)
+        )
+        observed_obj = objective_function(m)
+        @test observed_obj == expected_obj
+    end
+end
+
+function test_fom_cost_case_2a()
+    # When given an investable unit without defining `number_of_units`, 
+    # the model uses the new default `number_of_units`=0. 
+    @testset "fom_cost case 2a" begin
+        url_in = _test_objective_setup()
+        unit_capacity = 100
+        fom_cost = 8
+        number_of_units_fomulation_default = 0
+        candidate_units = 3
+        object_parameter_values = [
+            ["unit", "unit_ab", "fom_cost", fom_cost],
+            ["unit", "unit_ab", "candidate_units", candidate_units],
+        ]
+        relationships = [
+            ["unit__investment_temporal_block", ["unit_ab", "hourly"]],
+            ["unit__investment_stochastic_structure", ["unit_ab", "stochastic"]],
+        ]
+        relationship_parameter_values = [
+            ["unit__to_node", ["unit_ab", "node_b"], "unit_capacity", unit_capacity],
+        ]
+        SpineInterface.import_data(
+            url_in; 
+            relationships=relationships, 
+            object_parameter_values=object_parameter_values,
+            relationship_parameter_values=relationship_parameter_values
+        )
+        m = run_spineopt(url_in; log_level=0, optimize=false)
+        var_units_invested_available = m.ext[:spineopt].variables[:units_invested_available]
+        
+        duration = length(time_slice(m; temporal_block=temporal_block(:two_hourly)))
+        scenarios = (stochastic_scenario(:parent), stochastic_scenario(:child))
+        time_slices = time_slice(m; temporal_block=temporal_block(:hourly))
+        expected_obj = fom_cost * unit_capacity * duration *
+        sum(             
+            (number_of_units_fomulation_default + var_units_invested_available[unit(:unit_ab), s, t]) 
+            for (s, t) in zip(scenarios, time_slices)
+        )
+        observed_obj = objective_function(m)
+        @test observed_obj == expected_obj
+    end
+end
+
+function test_fom_cost_case_2b()
+    # When an investable unit with `number_of_units` explicitly defined ... 
+    @testset "fom_cost case 2b" begin
+        url_in = _test_objective_setup()
+        unit_capacity = 100
+        fom_cost = 8
+        number_of_units = 2
+        candidate_units = 3
+        object_parameter_values = [
+            ["unit", "unit_ab", "fom_cost", fom_cost],
+            ["unit", "unit_ab", "number_of_units", number_of_units],
+            ["unit", "unit_ab", "candidate_units", candidate_units],
+        ]
+        relationships = [
+            ["unit__investment_temporal_block", ["unit_ab", "hourly"]],
+            ["unit__investment_stochastic_structure", ["unit_ab", "stochastic"]],
+        ]
+        relationship_parameter_values = [
+            ["unit__to_node", ["unit_ab", "node_b"], "unit_capacity", unit_capacity],
+        ]
+        SpineInterface.import_data(
+            url_in; 
+            relationships=relationships, 
+            object_parameter_values=object_parameter_values,
+            relationship_parameter_values=relationship_parameter_values
+        )
+        m = run_spineopt(url_in; log_level=0, optimize=false)
+        var_units_invested_available = m.ext[:spineopt].variables[:units_invested_available]
+        
+        duration = length(time_slice(m; temporal_block=temporal_block(:two_hourly)))
+        scenarios = (stochastic_scenario(:parent), stochastic_scenario(:child))
+        time_slices = time_slice(m; temporal_block=temporal_block(:hourly))
+        expected_obj = fom_cost * unit_capacity * duration *
+        sum(             
+            (number_of_units + var_units_invested_available[unit(:unit_ab), s, t]) 
+            for (s, t) in zip(scenarios, time_slices)
         )
         observed_obj = objective_function(m)
         @test observed_obj == expected_obj
@@ -393,9 +428,10 @@ function test_units_on_cost()
 end
 
 @testset "objective" begin
-    test_fom_cost_case1()
-    test_fom_cost_case2()
-    test_fom_cost_case3()
+    test_fom_cost_case_1a()
+    test_fom_cost_case_1b()
+    test_fom_cost_case_2a()
+    test_fom_cost_case_2b()
     test_fuel_cost()
     test_unit_investment_cost()
     test_node_slack_penalty()


### PR DESCRIPTION
Fixes #1163 

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted according to SpineOpt's style
- [x] Unit tests pass
