### PR TITLE
Set default values for economic parameters

### DIFF
--- a/src/data_structure/economic_structure.jl
+++ b/src/data_structure/economic_structure.jl
@@ -130,6 +130,12 @@ function generate_capacity_transfer_factor!(m::Model, obj_cls::ObjectClass, econ
     invest_temporal_block = economic_parameters[obj_cls][:set_invest_temporal_block]
     param_name = economic_parameters[obj_cls][:set_capacity_transfer_factor]
 
+    # Default value of 1 for all (investable + non-investable)
+    for id in obj_cls()
+        pvals = parameter_value(1)
+        add_object_parameter_values!(obj_cls, Dict(id => Dict(param_name => pvals)))
+    end
+
     for id in invest_temporal_block(temporal_block=anything)
         if (
             !isnothing(tech_lifetime(; Dict(obj_cls.name => id)...)) ||
@@ -238,12 +244,15 @@ function generate_conversion_to_discounted_annuities!(m::Model, obj_cls::ObjectC
     discnt_year = discount_year(model=instance)
     conversion_to_discounted_annuities = Dict()
     investment_indices = economic_parameters[obj_cls][:set_investment_indices]
+    invest_temporal_block = economic_parameters[obj_cls][:set_invest_temporal_block]
     lead_time = economic_parameters[obj_cls][:set_lead_time]
     econ_lifetime = economic_parameters[obj_cls][:set_econ_lifetime]
     param_name = economic_parameters[obj_cls][:set_conversion_to_discounted_annuities] # this is MARKUP^AN
 
     for id in obj_cls()
-        if (discount_rate(model=model()[1]) == 0 || isnothing(discount_rate(model=model()[1])))
+        # if the discount rate is 0 or not defined, the conversion factor is 1
+        # or if the object is not investable, the conversion factor is also 1
+        if (discount_rate(model=model()[1]) == 0 || isnothing(discount_rate(model=model()[1])) || !(id in invest_temporal_block(temporal_block=anything)))
             pvals = parameter_value(1)
         else
             stochastic_map_vector = unique([x.stochastic_scenario for x in investment_indices(m)])
@@ -366,7 +375,14 @@ function generate_salvage_fraction!(m::Model, obj_cls::ObjectClass, economic_par
     econ_lifetime = economic_parameters[obj_cls][:set_econ_lifetime]
     invest_temporal_block = economic_parameters[obj_cls][:set_invest_temporal_block]
     param_name = economic_parameters[obj_cls][:set_salvage_fraction]
+     
+    # Default value of 0 for all (investable + non-investable)
+    for id in obj_cls()
+        pvals = parameter_value(0)
+        add_object_parameter_values!(obj_cls, Dict(id => Dict(param_name => pvals)))
+    end
 
+    # Only for investable objects
     for id in invest_temporal_block(temporal_block=anything)
         if id in indices(econ_lifetime)
             stochastic_map_vector = unique([x.stochastic_scenario for x in investment_indices(m)])
@@ -599,6 +615,12 @@ function generate_decommissioning_conversion_to_discounted_annuities!(
     decom_time = economic_parameters[obj_cls][:set_decom_time]
     decom_cost = economic_parameters[obj_cls][:set_decom_cost]
     param_name = economic_parameters[obj_cls][:set_decommissioning_conversion_to_discounted_annuities]
+
+    # Default value of 1 for all (decommissionable + non-decommissionable)
+    for id in obj_cls()
+        pvals = parameter_value(1)
+        add_object_parameter_values!(obj_cls, Dict(id => Dict(param_name => pvals)))
+    end
 
     for id in indices(decom_cost)
         stochastic_map_vector = unique([x.stochastic_scenario for x in investment_indices(m)])

--- a/test/data_structure/check_economic_structure.jl
+++ b/test/data_structure/check_economic_structure.jl
@@ -17,7 +17,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #############################################################################
 
-@testset "economic structure" begin
+function test_data_example_economic_representation()
     url_in = "sqlite://"
     test_data = Dict(
         :objects => [
@@ -134,8 +134,58 @@
             ["unit__node__node", ["unit_bc", "node_b", "node_c"], "fix_ratio_out_in_unit_flow", 1.0],
         ],
     )
+    _load_test_data(url_in, test_data)
+    url_in
+end
+
+function test_data_minimal_feasible_example_economic_representation()
+    url_in = "sqlite://"
+    test_data = Dict(
+        :objects => [
+            ["model", "instance"],
+            ["temporal_block", "hourly"],
+            ["temporal_block", "two_year"],
+            ["stochastic_structure", "deterministic"],
+            ["unit", "unit_ab"],
+            ["unit", "unit_ab_only_operation"],
+            ["node", "node_a"],
+            ["node", "node_b"],
+            ["stochastic_scenario", "parent"],
+        ],
+        :relationships => [
+            ["model__default_temporal_block", ["instance", "hourly"]],
+            ["model__default_investment_temporal_block", ["instance", "two_year"]],
+            ["model__default_investment_stochastic_structure", ["instance", "deterministic"]],
+            ["node__temporal_block", ["node_a", "hourly"]],
+            ["node__temporal_block", ["node_b", "hourly"]],
+            ["node__stochastic_structure", ["node_a", "deterministic"]],
+            ["node__stochastic_structure", ["node_b", "deterministic"]],
+            ["stochastic_structure__stochastic_scenario", ["deterministic", "parent"]],
+            ["unit__from_node", ["unit_ab", "node_a"]],
+            ["unit__to_node", ["unit_ab", "node_b"]],
+            ["unit__node__node", ["unit_ab", "node_b", "node_a"]],
+        ],
+        :object_parameter_values => [
+            ["model", "instance", "model_start", Dict("type" => "date_time", "data" => "2030-01-01T00:00:00")],
+            ["model", "instance", "model_end", Dict("type" => "date_time", "data" => "2032-01-01T00:00:00")],
+            ["model", "instance", "duration_unit", "hour"],
+            ["model", "instance", "model_type", "spineopt_standard"],
+            ["temporal_block", "hourly", "resolution", Dict("type" => "duration", "data" => "1h")],
+            ["temporal_block", "two_year", "resolution", Dict("type" => "duration", "data" => "2Y")],
+        ],
+        :relationship_parameter_values => [
+            ["connection__node__node", ["connection_ab", "node_a", "node_b"], "fix_ratio_out_in_connection_flow", 1.0],
+            ["unit__node__node", ["unit_ab", "node_b", "node_a"], "fix_ratio_out_in_unit_flow", 1.0],
+            
+        ],
+    )
+    _load_test_data(url_in, test_data)
+    url_in
+end
+
+@testset "economic structure" begin
     @testset "test discounted duration - using milestone years, w/o inv. blocks" begin
-        _load_test_data(url_in, test_data)
+        url_in = test_data_example_economic_representation()
         discnt_year = Dict("type" => "date_time", "data" => "2020-01-01T00:00:00")
         discnt_rate = 0.05
         use_mlstne_year = true
@@ -179,7 +229,7 @@
         ) rtol = 1e-6
     end
     @testset "test discounted duration - w/o using milestone years" begin
-        _load_test_data(url_in, test_data)
+        url_in = test_data_example_economic_representation()
         discnt_year = Dict("type" => "date_time", "data" => "2020-01-01T00:00:00")
         discnt_rate = 0.05
         use_mlstne_year = false
@@ -197,7 +247,7 @@
     end
 
     @testset "test investment costs, salvage fraction, capacity transfer factor, decommissioning" begin
-        _load_test_data(url_in, test_data)
+        url_in = test_data_example_economic_representation()
         discnt_year = Dict("type" => "date_time", "data" => "2020-01-01T00:00:00")
         discnt_rate = 0.05
         use_mlstne_year = false
@@ -246,7 +296,7 @@
     end
 
     @testset "test technological discount factor, investment costs, salvage fraction" begin
-        _load_test_data(url_in, test_data)
+        url_in = test_data_example_economic_representation()
         discnt_year = Dict("type" => "date_time", "data" => "2020-01-01T00:00:00")
         discnt_rate = 0.05
         tech_discnt_rate = 0.85
@@ -281,7 +331,7 @@
         @test expected_coe_obj ≈ observed_coe_obj rtol = 1e-6
     end
     @testset "test rolling error exception" begin
-        _load_test_data(url_in, test_data)
+        url_in = test_data_example_economic_representation()
         discnt_year = Dict("type" => "date_time", "data" => "2020-01-01T00:00:00")
         discnt_rate = 0.05
         tech_discnt_rate = 0.85
@@ -305,7 +355,7 @@
         @test_throws ErrorException run_spineopt(url_in; optimize=false, log_level=1)
     end
     @testset "test Benders error exception" begin
-        _load_test_data(url_in, test_data)
+        url_in = test_data_example_economic_representation()
         discnt_year = Dict("type" => "date_time", "data" => "2020-01-01T00:00:00")
         discnt_rate = 0.05
         tech_discnt_rate = 0.85
@@ -327,5 +377,71 @@
         ]
         SpineInterface.import_data(url_in; object_parameter_values=object_parameter_values)
         @test_throws ErrorException run_spineopt(url_in; optimize=false, log_level=1)
+    end
+    @testset "test saving outputs" begin
+        url_in = test_data_minimal_feasible_example_economic_representation()
+        discnt_year = Dict("type" => "date_time", "data" => "2020-01-01T00:00:00")
+        discnt_rate = 0.05
+        tech_discnt_rate = 0.85
+        use_eco_re = true
+        use_mlstne_year = false
+        candidate_unts = 1
+        num_of_units = 0
+        inv_cost = 2
+        objects = [
+            ["unit", "unit_ab_only_operation"],
+        ]
+        relationships = [
+            ["unit__from_node", ["unit_ab_only_operation", "node_a"]],
+            ["unit__to_node", ["unit_ab_only_operation", "node_b"]],
+        ]
+        relationship_parameter_values = [
+            ["unit__from_node", ["unit_ab", "node_a"], "vom_cost", 25],
+            ["unit__from_node", ["unit_ab_only_operation", "node_a"], "vom_cost", 25],
+            ["unit__to_node", ["unit_ab", "node_b"], "unit_capacity", 200],
+            ["unit__to_node", ["unit_ab_only_operation", "node_b"], "unit_capacity", 100],
+            ["unit__node__node", ["unit_ab_only_operation", "node_b", "node_a"], "fix_ratio_out_in_unit_flow", 1.0],
+        ]
+        object_parameter_values = [
+            ["model", "instance", "discount_rate", discnt_rate],
+            ["model", "instance", "discount_year", discnt_year],
+            ["model", "instance", "use_milestone_years", use_mlstne_year],
+            ["model", "instance", "use_economic_representation", use_eco_re],
+            ["node", "node_b", "demand", 100],
+            ["node", "node_a", "balance_type_list", "balance_type_none"],
+            ["unit", "unit_ab", "candidate_units", candidate_unts],
+            ["unit", "unit_ab", "number_of_units", num_of_units],
+            ["unit", "unit_ab", "unit_investment_cost", inv_cost],
+            ["unit", "unit_ab", "unit_discount_rate_technology_specific", tech_discnt_rate],
+            ["unit", "unit_ab", "unit_lead_time", Dict("type" => "duration", "data" => "1Y")],
+            ["unit", "unit_ab", "unit_investment_tech_lifetime", Dict("type" => "duration", "data" => "5Y")],
+            ["unit", "unit_ab", "unit_investment_econ_lifetime", Dict("type" => "duration", "data" => "5Y")],
+        ]
+        SpineInterface.import_data(url_in; 
+            relationships=relationships, 
+            relationship_parameter_values=relationship_parameter_values, 
+            object_parameter_values=object_parameter_values)
+        # Here we need to run the optimization to be able to save the economic parameters
+        m = run_spineopt(url_in; optimize=true, log_level=0)
+        unit_salvage_fraction = []
+        unit_discounted_duration = []
+        unit_conversion_to_discounted_annuities = []
+        unit_tech_discount_factor = []
+        for id in unit()
+            u_ts = [ind.t for ind in unit_flow_indices(m; unit=id)]
+            key_param = Dict(unit.name => id, stochastic_scenario.name => stochastic_scenario(:parent))
+            push!(unit_salvage_fraction, SpineOpt.unit_salvage_fraction(; key_param..., t=u_ts[1]))
+            push!(unit_discounted_duration, SpineOpt.unit_discounted_duration(; key_param..., t=u_ts[1]))
+            push!(unit_conversion_to_discounted_annuities, SpineOpt.unit_conversion_to_discounted_annuities(; key_param..., t=u_ts[1]))
+            push!(unit_tech_discount_factor, SpineOpt.unit_tech_discount_factor(; key_param..., t=u_ts[1]))
+        end
+        # Ideally we would like to check if saving the results throws an error when the economic parameters do not have default values
+        # Without default values, the error happens in _save_outputs!() in run_spineopt_basic.jl
+        # But it is not possible to check this directly, so we use an alternative here
+        # The following tests check if every unit has a value for each of the economic parameters, i.e., if there are default values
+        @test length(unit()) == length(unit_salvage_fraction) 
+        @test length(unit()) == length(unit_discounted_duration) 
+        @test length(unit()) == length(unit_conversion_to_discounted_annuities) 
+        @test length(unit()) == length(unit_tech_discount_factor)       
     end
 end


### PR DESCRIPTION
Give default values for economic parameters to ensure that they can be saved without errors.

## Checklist before merging
- [ ] Documentation is up-to-date
- [ ] Unit tests have been added/updated accordingly
- [ ] Code has been formatted according to SpineOpt's style
- [ ] Unit tests pass
