### PR TITLE
Update migration scripts and the template version number

### DIFF
--- a/examples/capacity_planning.json
+++ b/examples/capacity_planning.json
@@ -3403,7 +3403,7 @@
         [
             "settings",
             "version",
-            15,
+            16,
             null,
             "Current version of the SpineOpt data structure. Modify it at your own risk (but please don't)."
         ],

--- a/examples/multi-year_investment_with_econ_params_with_milestones.json
+++ b/examples/multi-year_investment_with_econ_params_with_milestones.json
@@ -3392,7 +3392,7 @@
         [
             "settings",
             "version",
-            15,
+            16,
             null,
             "Current version of the SpineOpt data structure. Modify it at your own risk (but please don't)."
         ],

--- a/examples/multi-year_investment_with_econ_params_without_milestones.json
+++ b/examples/multi-year_investment_with_econ_params_without_milestones.json
@@ -3320,7 +3320,7 @@
         [
             "settings",
             "version",
-            15,
+            16,
             null,
             "Current version of the SpineOpt data structure. Modify it at your own risk (but please don't)."
         ],

--- a/examples/multi-year_investment_without_econ_params.json
+++ b/examples/multi-year_investment_without_econ_params.json
@@ -3483,7 +3483,7 @@
         [
             "settings",
             "version",
-            15,
+            16,
             null,
             "Current version of the SpineOpt data structure. Modify it at your own risk (but please don't)."
         ],

--- a/examples/reserves.json
+++ b/examples/reserves.json
@@ -2027,7 +2027,7 @@
         [
             "settings",
             "version",
-            15,
+            16,
             null,
             "Current version of the SpineOpt data structure. Modify it at your own risk (but please don't)."
         ],

--- a/examples/rolling_horizon.json
+++ b/examples/rolling_horizon.json
@@ -2027,7 +2027,7 @@
         [
             "settings",
             "version",
-            15,
+            16,
             null,
             "Current version of the SpineOpt data structure. Modify it at your own risk (but please don't)."
         ],

--- a/examples/simple_system.json
+++ b/examples/simple_system.json
@@ -2027,7 +2027,7 @@
         [
             "settings",
             "version",
-            15,
+            16,
             null,
             "Current version of the SpineOpt data structure. Modify it at your own risk (but please don't)."
         ],

--- a/examples/stochastic.json
+++ b/examples/stochastic.json
@@ -3313,7 +3313,7 @@
         [
             "settings",
             "version",
-            15,
+            16,
             null,
             "Current version of the SpineOpt data structure. Modify it at your own risk (but please don't)."
         ],

--- a/examples/unit_commitment.json
+++ b/examples/unit_commitment.json
@@ -2027,7 +2027,7 @@
         [
             "settings",
             "version",
-            15,
+            16,
             null,
             "Current version of the SpineOpt data structure. Modify it at your own risk (but please don't)."
         ],

--- a/src/data_structure/migration.jl
+++ b/src/data_structure/migration.jl
@@ -66,7 +66,7 @@ _upgrade_functions = [
 	add_model_algorithm,
 	rename_lifetime_to_tech_lifetime,
 	translate_heatrate_parameters,
-    add_stage_output,
+	add_stage_output,
 ]
 
 """

--- a/src/data_structure/migration.jl
+++ b/src/data_structure/migration.jl
@@ -46,6 +46,11 @@ function add_units_out_of_service_and_min_capacity_margin(db_url, log_level)
 	true
 end
 
+function add_stage_output(db_url, log_level)
+	# No changes, just make sure we load the newest template
+	true
+end
+
 _upgrade_functions = [
 	rename_unit_constraint_to_user_constraint,
 	move_connection_flow_cost,
@@ -61,6 +66,7 @@ _upgrade_functions = [
 	add_model_algorithm,
 	rename_lifetime_to_tech_lifetime,
 	translate_heatrate_parameters,
+    add_stage_output,
 ]
 
 """

--- a/templates/spineopt_template.json
+++ b/templates/spineopt_template.json
@@ -272,7 +272,7 @@
         ["output", "output_resolution", null, null, "Temporal resolution of the output variables associated with this `output`."],
         ["output", "output_type",null,"output_type_list","Type of this `output`."],
         ["report", "output_db_url", null, null, "Database url for SpineOpt output."],
-        ["settings", "version", 15, null, "Current version of the SpineOpt data structure. Modify it at your own risk (but please don't)."],
+        ["settings", "version", 16, null, "Current version of the SpineOpt data structure. Modify it at your own risk (but please don't)."],
         ["stage", "stage_scenario", null, null, "The scenario that this `stage` should run (EXPERIMENTAL)."],
         ["temporal_block", "block_end", null, null, "The end time for the `temporal_block`. Can be given either as a `DateTime` for a static end point, or as a `Duration` for an end point relative to the start of the current optimization."],
         ["temporal_block", "block_start", null, null, "The start time for the `temporal_block`. Can be given either as a `DateTime` for a static start point, or as a `Duration` for an start point relative to the start of the current optimization."],


### PR DESCRIPTION
Change spineopt_template.json version number to 16 and update the migration scripts so that the newest template is loaded.

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted according to SpineOpt's style
- [x] Unit tests pass
