### PR TITLE
Add the node availability factor to the model

### DIFF
--- a/examples/capacity_planning.json
+++ b/examples/capacity_planning.json
@@ -2843,6 +2843,13 @@
         ],
         [
             "model",
+            "use_highest_resolution_constraint_ratio_out_in_connection_flow",
+            true,
+            "boolean_value_list",
+            "Whether to use highest resolution for constraint ratio out in connection flow."
+        ],
+        [
+            "model",
             "use_milestone_years",
             false,
             "boolean_value_list",
@@ -2854,13 +2861,6 @@
             false,
             "boolean_value_list",
             "Whether to use tight and compact constraint formulations."
-        ],
-        [
-            "model", 
-            "use_highest_resolution_constraint_ratio_out_in_connection_flow", 
-            true, 
-            "boolean_value_list", 
-            "Whether to use highest resolution for constraint ratio out in connection flow."
         ],
         [
             "model",
@@ -3127,6 +3127,13 @@
             "==",
             "constraint_sense_list",
             "A selector for `nodal_balance` constraint sense."
+        ],
+        [
+            "node",
+            "node_availability_factor",
+            1,
+            null,
+            "Availability of the `node`, acting as a multiplier on its `node_state_cap`. Typically between 0-1."
         ],
         [
             "node",

--- a/examples/multi-year_investment_with_econ_params_with_milestones.json
+++ b/examples/multi-year_investment_with_econ_params_with_milestones.json
@@ -2832,6 +2832,13 @@
         ],
         [
             "model",
+            "use_highest_resolution_constraint_ratio_out_in_connection_flow",
+            true,
+            "boolean_value_list",
+            "Whether to use highest resolution for constraint ratio out in connection flow."
+        ],
+        [
+            "model",
             "use_milestone_years",
             false,
             "boolean_value_list",
@@ -2843,13 +2850,6 @@
             false,
             "boolean_value_list",
             "Whether to use tight and compact constraint formulations."
-        ],
-        [   
-            "model", 
-            "use_highest_resolution_constraint_ratio_out_in_connection_flow", 
-            true, 
-            "boolean_value_list", 
-            "Whether to use highest resolution for constraint ratio out in connection flow."
         ],
         [
             "model",
@@ -3116,6 +3116,13 @@
             "==",
             "constraint_sense_list",
             "A selector for `nodal_balance` constraint sense."
+        ],
+        [
+            "node",
+            "node_availability_factor",
+            1,
+            null,
+            "Availability of the `node`, acting as a multiplier on its `node_state_cap`. Typically between 0-1."
         ],
         [
             "node",

--- a/examples/multi-year_investment_with_econ_params_without_milestones.json
+++ b/examples/multi-year_investment_with_econ_params_without_milestones.json
@@ -2760,6 +2760,13 @@
         ],
         [
             "model",
+            "use_highest_resolution_constraint_ratio_out_in_connection_flow",
+            true,
+            "boolean_value_list",
+            "Whether to use highest resolution for constraint ratio out in connection flow."
+        ],
+        [
+            "model",
             "use_milestone_years",
             false,
             "boolean_value_list",
@@ -2771,13 +2778,6 @@
             false,
             "boolean_value_list",
             "Whether to use tight and compact constraint formulations."
-        ],
-        [
-            "model", 
-            "use_highest_resolution_constraint_ratio_out_in_connection_flow", 
-            true, 
-            "boolean_value_list", 
-            "Whether to use highest resolution for constraint ratio out in connection flow."
         ],
         [
             "model",
@@ -3044,6 +3044,13 @@
             "==",
             "constraint_sense_list",
             "A selector for `nodal_balance` constraint sense."
+        ],
+        [
+            "node",
+            "node_availability_factor",
+            1,
+            null,
+            "Availability of the `node`, acting as a multiplier on its `node_state_cap`. Typically between 0-1."
         ],
         [
             "node",

--- a/examples/multi-year_investment_without_econ_params.json
+++ b/examples/multi-year_investment_without_econ_params.json
@@ -2923,6 +2923,13 @@
         ],
         [
             "model",
+            "use_highest_resolution_constraint_ratio_out_in_connection_flow",
+            true,
+            "boolean_value_list",
+            "Whether to use highest resolution for constraint ratio out in connection flow."
+        ],
+        [
+            "model",
             "use_milestone_years",
             false,
             "boolean_value_list",
@@ -2934,13 +2941,6 @@
             false,
             "boolean_value_list",
             "Whether to use tight and compact constraint formulations."
-        ],
-        [
-            "model", 
-            "use_highest_resolution_constraint_ratio_out_in_connection_flow", 
-            true, 
-            "boolean_value_list", 
-            "Whether to use highest resolution for constraint ratio out in connection flow."
         ],
         [
             "model",
@@ -3207,6 +3207,13 @@
             "==",
             "constraint_sense_list",
             "A selector for `nodal_balance` constraint sense."
+        ],
+        [
+            "node",
+            "node_availability_factor",
+            1,
+            null,
+            "Availability of the `node`, acting as a multiplier on its `node_state_cap`. Typically between 0-1."
         ],
         [
             "node",

--- a/examples/reserves.json
+++ b/examples/reserves.json
@@ -1467,6 +1467,13 @@
         ],
         [
             "model",
+            "use_highest_resolution_constraint_ratio_out_in_connection_flow",
+            true,
+            "boolean_value_list",
+            "Whether to use highest resolution for constraint ratio out in connection flow."
+        ],
+        [
+            "model",
             "use_milestone_years",
             false,
             "boolean_value_list",
@@ -1478,13 +1485,6 @@
             false,
             "boolean_value_list",
             "Whether to use tight and compact constraint formulations."
-        ],
-        [
-            "model", 
-            "use_highest_resolution_constraint_ratio_out_in_connection_flow", 
-            true, 
-            "boolean_value_list", 
-            "Whether to use highest resolution for constraint ratio out in connection flow."
         ],
         [
             "model",
@@ -1751,6 +1751,13 @@
             "==",
             "constraint_sense_list",
             "A selector for `nodal_balance` constraint sense."
+        ],
+        [
+            "node",
+            "node_availability_factor",
+            1,
+            null,
+            "Availability of the `node`, acting as a multiplier on its `node_state_cap`. Typically between 0-1."
         ],
         [
             "node",

--- a/examples/rolling_horizon.json
+++ b/examples/rolling_horizon.json
@@ -1467,6 +1467,13 @@
         ],
         [
             "model",
+            "use_highest_resolution_constraint_ratio_out_in_connection_flow",
+            true,
+            "boolean_value_list",
+            "Whether to use highest resolution for constraint ratio out in connection flow."
+        ],
+        [
+            "model",
             "use_milestone_years",
             false,
             "boolean_value_list",
@@ -1478,13 +1485,6 @@
             false,
             "boolean_value_list",
             "Whether to use tight and compact constraint formulations."
-        ],
-        [
-            "model", 
-            "use_highest_resolution_constraint_ratio_out_in_connection_flow", 
-            true, 
-            "boolean_value_list", 
-            "Whether to use highest resolution for constraint ratio out in connection flow."
         ],
         [
             "model",
@@ -1751,6 +1751,13 @@
             "==",
             "constraint_sense_list",
             "A selector for `nodal_balance` constraint sense."
+        ],
+        [
+            "node",
+            "node_availability_factor",
+            1,
+            null,
+            "Availability of the `node`, acting as a multiplier on its `node_state_cap`. Typically between 0-1."
         ],
         [
             "node",
@@ -4806,6 +4813,13 @@
             100,
             "Base"
         ],
+        [
+            "node",
+            "electricity_node",
+            "node_availability_factor",
+            1,
+            "Base"
+        ],        
         [
             "node",
             "electricity_node",

--- a/examples/simple_system.json
+++ b/examples/simple_system.json
@@ -1467,6 +1467,13 @@
         ],
         [
             "model",
+            "use_highest_resolution_constraint_ratio_out_in_connection_flow",
+            true,
+            "boolean_value_list",
+            "Whether to use highest resolution for constraint ratio out in connection flow."
+        ],
+        [
+            "model",
             "use_milestone_years",
             false,
             "boolean_value_list",
@@ -1478,13 +1485,6 @@
             false,
             "boolean_value_list",
             "Whether to use tight and compact constraint formulations."
-        ],
-        [
-            "model", 
-            "use_highest_resolution_constraint_ratio_out_in_connection_flow", 
-            true, 
-            "boolean_value_list", 
-            "Whether to use highest resolution for constraint ratio out in connection flow."
         ],
         [
             "model",
@@ -1751,6 +1751,13 @@
             "==",
             "constraint_sense_list",
             "A selector for `nodal_balance` constraint sense."
+        ],
+        [
+            "node",
+            "node_availability_factor",
+            1,
+            null,
+            "Availability of the `node`, acting as a multiplier on its `node_state_cap`. Typically between 0-1."
         ],
         [
             "node",

--- a/examples/stochastic.json
+++ b/examples/stochastic.json
@@ -2753,6 +2753,13 @@
         ],
         [
             "model",
+            "use_highest_resolution_constraint_ratio_out_in_connection_flow",
+            true,
+            "boolean_value_list",
+            "Whether to use highest resolution for constraint ratio out in connection flow."
+        ],
+        [
+            "model",
             "use_milestone_years",
             false,
             "boolean_value_list",
@@ -2764,13 +2771,6 @@
             false,
             "boolean_value_list",
             "Whether to use tight and compact constraint formulations."
-        ],
-        [
-            "model", 
-            "use_highest_resolution_constraint_ratio_out_in_connection_flow", 
-            true, 
-            "boolean_value_list", 
-            "Whether to use highest resolution for constraint ratio out in connection flow."
         ],
         [
             "model",
@@ -3037,6 +3037,13 @@
             "==",
             "constraint_sense_list",
             "A selector for `nodal_balance` constraint sense."
+        ],
+        [
+            "node",
+            "node_availability_factor",
+            1,
+            null,
+            "Availability of the `node`, acting as a multiplier on its `node_state_cap`. Typically between 0-1."
         ],
         [
             "node",

--- a/examples/unit_commitment.json
+++ b/examples/unit_commitment.json
@@ -1467,6 +1467,13 @@
         ],
         [
             "model",
+            "use_highest_resolution_constraint_ratio_out_in_connection_flow",
+            true,
+            "boolean_value_list",
+            "Whether to use highest resolution for constraint ratio out in connection flow."
+        ],
+        [
+            "model",
             "use_milestone_years",
             false,
             "boolean_value_list",
@@ -1478,13 +1485,6 @@
             false,
             "boolean_value_list",
             "Whether to use tight and compact constraint formulations."
-        ],
-        [
-            "model", 
-            "use_highest_resolution_constraint_ratio_out_in_connection_flow", 
-            true, 
-            "boolean_value_list", 
-            "Whether to use highest resolution for constraint ratio out in connection flow."
         ],
         [
             "model",
@@ -1751,6 +1751,13 @@
             "==",
             "constraint_sense_list",
             "A selector for `nodal_balance` constraint sense."
+        ],
+        [
+            "node",
+            "node_availability_factor",
+            1,
+            null,
+            "Availability of the `node`, acting as a multiplier on its `node_state_cap`. Typically between 0-1."
         ],
         [
             "node",

--- a/src/constraints/constraint_node_state_capacity.jl
+++ b/src/constraints/constraint_node_state_capacity.jl
@@ -51,7 +51,7 @@ function _build_constraint_node_state_capacity(m::Model, ng, s_path, t)
         )
         <=
         + sum(
-            + node_state_cap(m; node=ng, stochastic_scenario=s, t=t)
+            + node_state_capacity(m; node=ng, stochastic_scenario=s, t=t)
             * (
                 + number_of_storages(m; node=ng, stochastic_scenario=s, t=t, _default=_default_nb_of_storages(n))
                 + sum(

--- a/src/constraints/constraint_node_state_capacity.jl
+++ b/src/constraints/constraint_node_state_capacity.jl
@@ -22,7 +22,7 @@
 To limit the storage content, the $v_{node\_state}$ variable needs be constrained by the following equation:
 
 ```math
-v^{node\_state}_{(n, s, t)} \leq p^{node\_state\_cap}_{(n, s, t)} \quad \forall n \in node : p^{has\_state}_{(n)}, \, \forall (s,t)
+v^{node\_state}_{(n, s, t)} \leq p^{node\_state\_cap}_{(n, s, t)} \cdot p^{node\_availability\_factor}_{(n, s, t)} \quad \forall n \in node : p^{has\_state}_{(n)}, \, \forall (s,t)
 ```
 
 The discharging and charging behavior of storage nodes can be described through unit(s),
@@ -33,6 +33,7 @@ the [unit flow ratio constraints](@ref constraint_ratio_unit_flow).
 
 See also
 [node\_state\_cap](@ref),
+[node\_availability\_factor](@ref),
 [has\_state](@ref).
 """
 function add_constraint_node_state_capacity!(m::Model)

--- a/src/data_structure/preprocess_data_structure.jl
+++ b/src/data_structure/preprocess_data_structure.jl
@@ -46,6 +46,7 @@ function preprocess_data_structure()
     generate_is_boundary()
     generate_unit_flow_capacity()
     generate_connection_flow_capacity()
+    generate_node_state_capacity()
     generate_unit_commitment_parameters()
 end
 
@@ -840,6 +841,21 @@ function generate_connection_flow_capacity()
     @eval begin
         connection_flow_capacity = $connection_flow_capacity
         export connection_flow_capacity
+    end
+end
+
+function generate_node_state_capacity()
+    function _node_state_capacity(f; node=node, _default=nothing, kwargs...)
+        _prod_or_nothing(
+            f(node_state_cap; node=node, _default=_default, kwargs...),
+            f(node_availability_factor; node=node, kwargs...),
+        )
+    end
+
+    node_state_capacity = ParameterFunction(_node_state_capacity)
+    @eval begin
+        node_state_capacity = $node_state_capacity
+        export node_state_capacity
     end
 end
 

--- a/src/variables/variable_node_state.jl
+++ b/src/variables/variable_node_state.jl
@@ -36,7 +36,7 @@ function node_state_indices(m::Model; node=anything, stochastic_scenario=anythin
 end
 
 function node_state_ub(m; node, kwargs...)
-    node_state_cap(m; node=node, kwargs..., _default=NaN) * (
+    node_state_capacity(m; node=node, kwargs..., _default=NaN) * (
         + number_of_storages(m; node=node, kwargs..., _default=_default_nb_of_storages(node))
         + something(candidate_storages(m; node=node, kwargs...), 0)
     )

--- a/templates/spineopt_template.json
+++ b/templates/spineopt_template.json
@@ -246,6 +246,7 @@
         ["node", "node_opf_type", "node_opf_type_normal", "node_opf_type_list", "A selector for the reference `node` (slack bus) when PTDF-based DC load-flow is enabled."],
         ["node", "node_slack_penalty", null, null, "A penalty cost for `node_slack_pos` and `node_slack_neg` variables. The slack variables won't be included in the model unless there's a cost defined for them."],
         ["node", "node_state_cap", null, null, "The maximum permitted value for a `node_state` variable."],
+        ["node", "node_availability_factor", 1.0, null, "Availability of the `node`, acting as a multiplier on its `node_state_cap`. Typically between 0-1."],
         ["node", "node_state_min", 0.0, null, "The minimum permitted value for a `node_state` variable."],
         ["node", "number_of_storages", 1.0, null, "Denotes the number of 'sub storages' aggregated to form the modelled `node`."],
         ["node", "state_coeff", 1.0, null, "Represents the `commodity` content of a `node_state` variable in respect to the `unit_flow` and `connection_flow` variables. Essentially, acts as a coefficient on the `node_state` variable in the `node_injection` constraint."],

--- a/test/constraints/constraint_node.jl
+++ b/test/constraints/constraint_node.jl
@@ -600,8 +600,10 @@ function test_constraint_node_state_capacity_investments()
         url_in = _test_constraint_node_setup()
         candidate_storages = 1
         node_capacity = 400
+        node_availability_factor = 0.8
         object_parameter_values = [
             ["node", "node_c", "node_state_cap", node_capacity],
+            ["node", "node_c", "node_availability_factor", node_availability_factor],
             ["node", "node_c", "has_state", true],
             ["node", "node_c", "candidate_storages", candidate_storages],
         ]
@@ -625,7 +627,7 @@ function test_constraint_node_state_capacity_investments()
             con_key = (n, [s], t)
             var_n_st = var_node_state[var_n_st_key...]
             var_s_inv_av = var_storages_invested_available[var_s_in_av_key...]
-            expected_con = @build_constraint(var_n_st <= node_capacity * var_s_inv_av)
+            expected_con = @build_constraint(var_n_st <= node_capacity * node_availability_factor * var_s_inv_av)
             con = constraint[con_key...]
             observed_con = constraint_object(con)
             @test _is_constraint_equal(observed_con, expected_con)


### PR DESCRIPTION
The key changes include the addition of a new `node_availability_factor` parameter for nodes and updating the unit capacity constraint accordingly.

### Updates to Node State Capacity Constraint:

* **Renaming and Refactoring:**
  - Renamed the function `node_state_cap` to `node_state_capacity` for improved clarity and consistency across the codebase. This change affects its usage in `constraint_node_state_capacity.jl` and `variable_node_state.jl`.

* **New Parameter:**
  - Added a new parameter `node_availability_factor` in the `spineopt_template.json` file. This parameter acts as a multiplier (typically between 0 and 1) on the `node_state_capacity`, representing the availability of a node.

### Preprocessing Enhancements:

* **New Preprocessing Function:**
  - Introduced a new function `generate_node_state_capacity()` in `preprocess_data_structure.jl`. This function calculates the node state capacity by combining `node_state_cap` and `node_availability_factor`. It was also added to the preprocessing pipeline.

### Update JSON example files:
* Added the `node_availability_factor` parameter to the examples JSON files (e.g., `examples/6_unit_system.json`, `examples/capacity_planning.json`, `examples/simple_system.json`).

Fixes #1199

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted according to SpineOpt's style
- [x] Unit tests pass
