### PR TITLE
Add parameter function `node_state_lower_limit` to the indices function of the minimum node state

### DIFF
--- a/src/constraints/constraint_min_node_state.jl
+++ b/src/constraints/constraint_min_node_state.jl
@@ -84,6 +84,6 @@ function constraint_min_node_state_indices(m::Model)
                     storages_invested_available_indices(m; node=ng, t=t_in_t(m; t_short=t)),
                 )
             )
-        ) if node_state_lower_limit(m; node=ng, stochastic_scenario=path, t=t) > 0
+        ) if realize(node_state_lower_limit(m; node=ng, stochastic_scenario=path, t=t, _strict=false)) > 0
     )
 end

--- a/src/constraints/constraint_min_node_state.jl
+++ b/src/constraints/constraint_min_node_state.jl
@@ -28,6 +28,7 @@ v^{node\_state}_{(n, s, t)} \geq \max(p^{node\_state\_cap}_{(n, s, t)} \cdot p^{
 Please note that the limit represents the maximum of the two terms.
 The first term is the product of the storage capacity and the minimum factor, which is a per-unit value of the storage capacity.
 The second term is the minimum state, given in absolute values.
+The constraint is only generated if either one of the minimum state parameters is greater than zero and there are candidate storage units.
 
 See also
 [node\_state\_cap](@ref),
@@ -83,6 +84,6 @@ function constraint_min_node_state_indices(m::Model)
                     storages_invested_available_indices(m; node=ng, t=t_in_t(m; t_short=t)),
                 )
             )
-        )
+        ) if node_state_lower_limit(m; node=ng, stochastic_scenario=path, t=t) > 0
     )
 end


### PR DESCRIPTION
This pull request updates the logic and documentation for the `constraint_min_node_state` functionality in the `src/constraints/constraint_min_node_state.jl` file. The changes ensure that constraints are only generated when relevant conditions are met, improving efficiency and clarity.

## Checklist before merging
- [ ] Documentation is up-to-date
- [ ] Unit tests have been added/updated accordingly
- [ ] Code has been formatted according to SpineOpt's style
- [ ] Unit tests pass
