### PR TITLE
Up to 7x faster _save_outputs!()

### DIFF
--- a/src/run_spineopt_basic.jl
+++ b/src/run_spineopt_basic.jl
@@ -995,8 +995,8 @@ function _do_save_outputs!(m, output_names, output_suffix; weight=1)
         end
         by_suffix = get!(m.ext[:spineopt].outputs, out_name, Dict())
         by_window = get!(by_suffix, output_suffix, Dict())
-        by_window[w_start, w_end] = collect(Iterators.map(((ind, val),) ->
-         (_static(ind), weight * val), something(value, param)))
+        by_window[w_start, w_end] = Dict(Iterators.map(((ind, val),) ->
+            (_static(ind), weight * val), _output_value_by_ind(m, something(value, param))))
     end
 end
 

--- a/src/run_spineopt_basic.jl
+++ b/src/run_spineopt_basic.jl
@@ -995,7 +995,8 @@ function _do_save_outputs!(m, output_names, output_suffix; weight=1)
         end
         by_suffix = get!(m.ext[:spineopt].outputs, out_name, Dict())
         by_window = get!(by_suffix, output_suffix, Dict())
-        by_window[w_start, w_end] = collect(Iterators.map(((ind, val),) -> (_static(ind), weight * val), something(value, param)))
+        by_window[w_start, w_end] = collect(Iterators.map(((ind, val),) ->
+         (_static(ind), weight * val), something(value, param)))
     end
 end
 

--- a/src/run_spineopt_basic.jl
+++ b/src/run_spineopt_basic.jl
@@ -995,13 +995,11 @@ function _do_save_outputs!(m, output_names, output_suffix; weight=1)
         end
         by_suffix = get!(m.ext[:spineopt].outputs, out_name, Dict())
         by_window = get!(by_suffix, output_suffix, Dict())
-        by_window[w_start, w_end] = Dict(
-            _static(ind) => weight * val for (ind, val) in _output_value_by_ind(m, something(value, param))
-        )
+        by_window[w_start, w_end] = collect(Iterators.map(((ind, val),) -> (_static(ind), weight * val), something(value, param)))
     end
 end
 
-_static(ind::NamedTuple) = (; (k => _static(v) for (k, v) in pairs(ind))...)
+_static(ind::NamedTuple) = NamedTuple{keys(ind)}(map(_static, values(ind)))
 _static(t::TimeSlice) = (start(t), end_(t))
 _static(x) = x
 


### PR DESCRIPTION
Changed 'for' loops to 'map' to remove a bottleneck. 

The code is very similar but note that I have changed a dictionary to a vector of pairs with [collect()](https://docs.julialang.org/en/v1/base/iterators/#Base.Iterators.map). \[Edit: not anymore, it's a dictionary again :)]


## Checklist before merging
- [x] Documentation is up-to-date
- [ ] No extra unit tests needed?
- [x] Code has been formatted according to SpineOpt's style
- [x] Unit tests pass
