### PR TITLE
Up to 2x faster _representative_index_to_coefficient

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,6 +18,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 SpineInterface = "0cda1612-498a-11e9-3c92-77fa82595a4f"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+Memoize = "c03570c3-d221-55d1-a50c-7939bbd78826"
 
 [compat]
 Arrow = "2"

--- a/src/SpineOpt.jl
+++ b/src/SpineOpt.jl
@@ -30,6 +30,7 @@ using Requires
 using JuMP
 using HiGHS
 using Arrow
+using Memoize
 import TOML
 import DataStructures: OrderedDict
 import Dates: CompoundPeriod


### PR DESCRIPTION
I have had a crack a optimising the _representative_index_to_coefficient function. Note that this might partially solve issue #1216. 

The only time that I could find that it was called was in the unit tests so I have based my optimisation on that. For “run_spineopt_representative_periods.jl”, _representative_index_to_coefficient took around 3 seconds on my machine to execute, it now takes 0.7 seconds. Hopefully this improvement scales to the EU case study which I don’t have access to yet (please check on my behalf).

I don’t think any extra extra unit tests are required since the only changes are internal to the function. If some unit tests are required then I would love some help writing them.


## Checklist before merging
- [x] Documentation is up-to-date
- [x] Code has been formatted according to SpineOpt's style
- [x] Unit tests pass
- [x] Verified to improve performance of EU case study mentioned in #1216 (please run on my behalf)
- [ ]  Write unit test
- [ ] Fix bug in code
