### PR TITLE
Fix economic discounting duration

### DIFF
--- a/src/data_structure/economic_structure.jl
+++ b/src/data_structure/economic_structure.jl
@@ -596,7 +596,7 @@ function create_discounted_duration(m; stochastic_scenario=nothing, invest_tempo
     timeseries_ind, timeseries_val
 end
 
-function _discounted_duration_coeff(t::TimeSlice; _exact=false)
+function discounted_duration_base(t::TimeSlice; _exact=false)
     # The economic discounting uses 1 Year as the base duration for investment (years) and operation.
     # This means that an `xx_discounted_duration` only counts the number (discounted) of years in an investment period,
     # assuming (1) the "investment period" = n years with n>=1 being an integer, 

--- a/src/data_structure/economic_structure.jl
+++ b/src/data_structure/economic_structure.jl
@@ -596,6 +596,30 @@ function create_discounted_duration(m; stochastic_scenario=nothing, invest_tempo
     timeseries_ind, timeseries_val
 end
 
+function _discounted_duration_coeff(t::TimeSlice; _exact=false)
+    # The economic discounting uses 1 Year as the base duration for investment (years) and operation.
+    # This means that an `xx_discounted_duration` only counts the number (discounted) of years in an investment period,
+    # assuming (1) the "investment period" = n years with n>=1 being an integer, 
+    # and (2) the "operational period" = 1 Year.
+    # Hence, the product `xx_discounted_duration` and `duration(t)` is only valid when t spans no more than 1 year.
+    # When `duration(t)` > 1 Year, the product would double-counts the years in a multi-year investment period setup.
+    # In this case, we need this substituting coefficient for `duration(t)` to represent the length (in hour) of 1 Year.
+
+    # We assume the 1st year of the investment period as the base.
+    _base_duration = TimeSlice(start(t), start(t)+Year(1)) |> duration
+    # average number of years during one investment window period, rounded to integer.
+    _number_of_years = div(duration(t), _base_duration, RoundNearest)
+    
+    # This conditional is irrelevant to whether the asset is investable or not.
+    if _number_of_years <= 1
+        return duration(t)
+    else
+        # _exact=true calculates the average length of 1 Year of a multi-year investment period.
+        # _exact=false assumes the investment period consists of multiple of the base (1 Year).
+        return _exact ? duration(t)/_number_of_years : _base_duration
+    end
+end
+
 """
     generate_decommissioning_conversion_to_discounted_annuities()
 

--- a/src/data_structure/preprocess_data_structure.jl
+++ b/src/data_structure/preprocess_data_structure.jl
@@ -961,7 +961,10 @@ function generate_unit_commitment_parameters()
                 indices(units_on_non_anticipativity_time),
                 indices(fix_units_on),
                 (u for u in indices(candidate_units) if is_candidate(unit=u)),
-                (x.unit for x in indices(units_on_coefficient) if units_on_coefficient(; x...) != 0),
+                (
+                    x.unit for x in indices(units_on_coefficient) 
+                    if units_on_coefficient(; x...) != 0 && !isnothing(units_on_coefficient(; x...))
+                ),
                 (x.unit for x in indices(minimum_operating_point) if minimum_operating_point(; x...) != 0),
                 (x.unit for x in indices(ramp_up_limit)),
                 (x.unit for x in indices(ramp_down_limit)),

--- a/src/data_structure/preprocess_data_structure.jl
+++ b/src/data_structure/preprocess_data_structure.jl
@@ -961,6 +961,7 @@ function generate_unit_commitment_parameters()
                 indices(units_on_non_anticipativity_time),
                 indices(fix_units_on),
                 (u for u in indices(candidate_units) if is_candidate(unit=u)),
+                (x.unit for x in indices(units_on_coefficient) if units_on_coefficient(; x...) != 0),
                 (x.unit for x in indices(minimum_operating_point) if minimum_operating_point(; x...) != 0),
                 (x.unit for x in indices(ramp_up_limit)),
                 (x.unit for x in indices(ramp_down_limit)),

--- a/src/data_structure/preprocess_data_structure.jl
+++ b/src/data_structure/preprocess_data_structure.jl
@@ -961,10 +961,7 @@ function generate_unit_commitment_parameters()
                 indices(units_on_non_anticipativity_time),
                 indices(fix_units_on),
                 (u for u in indices(candidate_units) if is_candidate(unit=u)),
-                (
-                    x.unit for x in indices(units_on_coefficient) 
-                    if units_on_coefficient(; x...) != 0 && !isnothing(units_on_coefficient(; x...))
-                ),
+                (x.unit for x in indices(units_on_coefficient) if units_on_coefficient(; x...) != 0),
                 (x.unit for x in indices(minimum_operating_point) if minimum_operating_point(; x...) != 0),
                 (x.unit for x in indices(ramp_up_limit)),
                 (x.unit for x in indices(ramp_down_limit)),

--- a/src/objective/fixed_om_costs.jl
+++ b/src/objective/fixed_om_costs.jl
@@ -38,8 +38,8 @@ function fixed_om_costs(m, t_range)
             )
             * (
                 !isnothing(multiyear_economic_discounting(model=m.ext[:spineopt].instance)) ?
-                unit_discounted_duration[(unit=u, stochastic_scenario=s, t=t)] * 
-                _discounted_duration_coeff_investable_assets(t) : duration(t)
+                unit_discounted_duration[(unit=u, stochastic_scenario=s, t=t)] * _discounted_duration_coeff(t) : 
+                duration(t)
             )
             * prod(weight(temporal_block=blk) for blk in blocks(t))
             # This term is activated when there is a representative temporal block that includes t.
@@ -62,27 +62,3 @@ function fixed_om_costs(m, t_range)
     )
 end
 #TODO: scenario tree?
-
-function _discounted_duration_coeff_investable_assets(t::TimeSlice; _exact=false)
-    # In our economic discounting functionality, 1 Year is the base duration for investment (years) and operation.
-    # So `unit_discounted_duration` only counts the number (discounted) of years over a multi-year investment period.
-    # Hence, the product `unit_discounted_duration` and `duration(t)` is only valid 
-    # when the TimeSlice t spans no more than 1 year, otherwise the `unit_discounted_duration` would double-counts
-    # the year in a multi-year investment period.
-    # Therefore, when the `duration(t)` > 1 Year, 
-    # we need this substituting coefficient for `duration(t)` to represent the length (in hour) of 1 Year.
-
-    # We assume the 1st year of the investment period as the base.
-    _base_duration = TimeSlice(start(t), start(t)+Year(1)) |> duration
-    # average number of years during one investment window period, rounded to integer.
-    _number_of_years = div(duration(t), _base_duration, RoundNearest)
-    
-    # This conditional is irrelevant to whether the asset is investable or not.
-    if _number_of_years <= 1
-        return duration(t)
-    else
-        # _exact=true calculates the average length of 1 Year of a multi-year investment period.
-        # _exact=false assumes the investment period consists of multiple of the base (1 Year).
-        return _exact ? duration(t)/_number_of_years : _base_duration
-    end
-end

--- a/src/objective/fixed_om_costs.jl
+++ b/src/objective/fixed_om_costs.jl
@@ -29,16 +29,17 @@ function fixed_om_costs(m, t_range)
         m,
         sum(
             + unit_capacity(m; unit=u, node=ng, direction=d, stochastic_scenario=s, t=t)
-            * (
-                !isnothing(multiyear_economic_discounting(model=m.ext[:spineopt].instance)) ? 
-                unit_discounted_duration[(unit=u, stochastic_scenario=s, t=t)] : 1
-            ) 
             * fom_cost(m; unit=u, stochastic_scenario=s, t=t)
             * (
                 + number_of_units(m; unit=u, stochastic_scenario=s, t=t, _default=_default_nb_of_units(u))
                 + (is_candidate(unit=u) ? units_invested_available[u, s, t] : 0)
                 # Default value of `number_of_units` is 1 in the template: assumption for non-investable units.
                 # For investable unit, we assume the `number_of_units`=0 (existing ones) unless explicitly specified.
+            )
+            * (
+                !isnothing(multiyear_economic_discounting(model=m.ext[:spineopt].instance)) ?
+                unit_discounted_duration[(unit=u, stochastic_scenario=s, t=t)] * 
+                _discounted_duration_coeff_investable_assets(t) : duration(t)
             )
             * prod(weight(temporal_block=blk) for blk in blocks(t))
             # This term is activated when there is a representative temporal block that includes t.
@@ -49,7 +50,6 @@ function fixed_om_costs(m, t_range)
                 unit_stochastic_scenario_weight(m; unit=u, stochastic_scenario=s) : 
                 node_stochastic_scenario_weight(m; node=ng, stochastic_scenario=s)
             )
-            * duration(t) 
             for (u, ng, d) in indices(unit_capacity; unit=indices(fom_cost))
             for (u, s, t) in Iterators.flatten(
                 is_candidate(unit=u) ? (units_invested_available_indices(m; unit=u, t=t_range),) :
@@ -62,3 +62,27 @@ function fixed_om_costs(m, t_range)
     )
 end
 #TODO: scenario tree?
+
+function _discounted_duration_coeff_investable_assets(t::TimeSlice; _exact=false)
+    # In our economic discounting functionality, 1 Year is the base duration for investment (years) and operation.
+    # So `unit_discounted_duration` only counts the number (discounted) of years over a multi-year investment period.
+    # Hence, the product `unit_discounted_duration` and `duration(t)` is only valid 
+    # when the TimeSlice t spans no more than 1 year, otherwise the `unit_discounted_duration` would double-counts
+    # the year in a multi-year investment period.
+    # Therefore, when the `duration(t)` > 1 Year, 
+    # we need this substituting coefficient for `duration(t)` to represent the length (in hour) of 1 Year.
+
+    # We assume the 1st year of the investment period as the base.
+    _base_duration = TimeSlice(start(t), start(t)+Year(1)) |> duration
+    # average number of years during one investment window period, rounded to integer.
+    _number_of_years = div(duration(t), _base_duration, RoundNearest)
+    
+    # This conditional is irrelevant to whether the asset is investable or not.
+    if _number_of_years <= 1
+        return duration(t)
+    else
+        # _exact=true calculates the average length of 1 Year of a multi-year investment period.
+        # _exact=false assumes the investment period consists of multiple of the base (1 Year).
+        return _exact ? duration(t)/_number_of_years : _base_duration
+    end
+end

--- a/src/objective/fixed_om_costs.jl
+++ b/src/objective/fixed_om_costs.jl
@@ -38,7 +38,7 @@ function fixed_om_costs(m, t_range)
             )
             * (
                 !isnothing(multiyear_economic_discounting(model=m.ext[:spineopt].instance)) ?
-                unit_discounted_duration[(unit=u, stochastic_scenario=s, t=t)] * _discounted_duration_coeff(t) : 
+                unit_discounted_duration[(unit=u, stochastic_scenario=s, t=t)] * discounted_duration_base(t) : 
                 duration(t)
             )
             * prod(weight(temporal_block=blk) for blk in blocks(t))

--- a/test/data_structure/check_economic_structure.jl
+++ b/test/data_structure/check_economic_structure.jl
@@ -290,6 +290,42 @@ function _test_discounted_duration_consecutive_years()
     end
 end
 
+function _test_discounted_duration_base()
+    @testset "test discounted duration base - intra-year (leap)" begin
+        t_start = Dates.DateTime(2020,1,1)
+        t_end = t_start + Dates.Month(2)
+        ts = SpineInterface.TimeSlice(t_start, t_end)
+        active_duration = SpineInterface.duration(ts)
+        @test SpineOpt.discounted_duration_base(ts) == active_duration == 1440 
+        # 1440: the number of hours in Jan and Feb of a leap year
+    end
+    @testset "test discounted duration base - intra-year (normal)" begin
+        t_start = Dates.DateTime(2021,1,1)
+        t_end = t_start + Dates.Month(2)
+        ts = SpineInterface.TimeSlice(t_start, t_end)
+        active_duration = SpineInterface.duration(ts)
+        @test SpineOpt.discounted_duration_base(ts) == active_duration == 1416
+        # 1416: the number of hours in Jan and Feb of a normal year
+    end
+    number_of_years = 5
+    @testset "test discounted duration base - multi-year (leap)" begin
+        t_start = Dates.DateTime(2020,1,1)
+        t_end = t_start + Dates.Year(number_of_years)
+        ts = SpineInterface.TimeSlice(t_start, t_end)
+        active_duration = SpineInterface.duration(ts)
+        average_year_length = active_duration / number_of_years
+        @test SpineOpt.discounted_duration_base(ts) == 8784 != active_duration
+        @test SpineOpt.discounted_duration_base(ts; _exact=true) == average_year_length != active_duration
+    end
+    @testset "test discounted duration base - multi-year (normal)" begin
+        t_start = Dates.DateTime(2021,1,1)
+        t_end = t_start + Dates.Year(number_of_years)
+        ts = SpineInterface.TimeSlice(t_start, t_end)
+        active_duration = SpineInterface.duration(ts)
+        @test SpineOpt.discounted_duration_base(ts) == 8760 != active_duration 
+    end
+end
+
 function _test_investment_costs__salvage_fraction__capacity_transfer_factor__decommissioning()
     @testset "test investment costs, salvage fraction, capacity transfer factor, decommissioning" begin
         url_in = test_data_example_multiyear_economic_discounting()
@@ -526,6 +562,7 @@ end
 @testset "economic structure" begin
     _test_discounted_duration_milestone_years()
     _test_discounted_duration_consecutive_years()
+    _test_discounted_duration_base()
     _test_investment_costs__salvage_fraction__capacity_transfer_factor__decommissioning()
     _test_technological_discount_factor__investment_costs__salvage_fraction()
     _test_rolling_error_exception()

--- a/test/run_spineopt_benders.jl
+++ b/test/run_spineopt_benders.jl
@@ -180,16 +180,16 @@ function _test_benders_storage()
     @testset "benders_storage" begin
         benders_gap = 1e-6  # needed so that we get the exact master problem solution
         mip_solver_options_benders = unparse_db_value(Map(["HiGHS.jl"], [Map(["mip_rel_gap"], [benders_gap])]))
-        res = 6
+        res = 6 # resolution
         dem = ucap = 10
-        fixuflow = 2 * dem
-        rf = 6
+        fixuflow = 2 * dem # 20
+        rf = 6 # row forward
         look_ahead = 3
         penalty = 100
-        op_cost_no_inv = (fixuflow - dem) * penalty * (24 + look_ahead)
+        op_cost_no_inv = (fixuflow - dem) * penalty * (24 + look_ahead) # (20-10)*100*(24+3) = 27000
         op_cost_inv = 0
-        do_not_inv_cost = op_cost_no_inv - op_cost_inv + 1 # minimum cost at which investment is not profitable
-        do_inv_cost = do_not_inv_cost - 1  # maximum cost at which investment is profitable
+        do_not_inv_cost = op_cost_no_inv - op_cost_inv # minimum cost at which investment is not profitable, 27000
+        do_inv_cost = do_not_inv_cost - 1  # maximum cost at which investment is profitable, 26999
         @testset for should_invest in (true, false)
             s_inv_cost = should_invest ? do_inv_cost : do_not_inv_cost
             url_in, url_out, file_path_out = _test_run_spineopt_benders_setup()
@@ -230,6 +230,7 @@ function _test_benders_storage()
                 ["node", "node_a", "has_state", true],
                 ["node", "node_a", "node_state_cap", 1000],
                 ["node", "node_a", "initial_node_state", 0],
+                # ["node", "node_a", "initial_storages_invested", 0],
                 ["node", "node_a", "candidate_storages", 1],
                 ["node", "node_a", "storage_investment_cost", s_inv_cost],
                 ["node", "node_a", "storage_investment_variable_type", "variable_type_integer"],


### PR DESCRIPTION
- Fixes the calculation of `fixed_om_cost` under the economic discounting setup.
- Spontaneously fixes the Benders unit test for storage
- Add (retrieve) the creation of `units_on` variable triggered by defining `units_on_coefficient` parameter

## Demo case
DB: [discounted-multi-year-invest.json](https://github.com/user-attachments/files/20692269/discounted-multi-year-invest.json)
### Setups
- basic: fom_cost = vom_cost = 1, demand = capacity = 100, all discounting rates = 0
- temporal structure: investment: 2000-2005 (5Y), 2006 (1Y); operation (milestone year 2000): 4M
### Expected objective terms
- fixed_om_costs = 1\*100\*(8784\*5+8760\*1) = 5,268,000
- variable_om_costs = 1\*100\*[ 4M\*5\*3`(for year 2000)` + 4M\*1\*3`(for year 2006)`] = 5,268,000
whereas in the existing calculation: fixed_om_costs = 1\*100\*[(8784\*2+8760\*3)\*5+8760\*1\*1] = 22,800,000

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Unit tests have been added/updated accordingly
> improved [type stability](https://modernjuliaworkflows.org/optimizing/#type_stability) or, when outside the scope of the pull request, at least indicated where and how the code is not properly typed
- [x] Code has been formatted according to SpineOpt's style
- [x] Unit tests pass
