### PR TITLE
Don't create the model in prepare_spineopt

### DIFF
--- a/src/run_spineopt.jl
+++ b/src/run_spineopt.jl
@@ -147,7 +147,7 @@ function _run_spineopt(
     t_start = now()
     @log log_level 1 "Execution started at $t_start"
     prepare_spineopt(url_in; upgrade, filters, templates, log_level)
-    m = create_model(mip_solver, lp_solver, use_direct_model, use_model_names, add_bridges)
+    m = create_model(; mip_solver, lp_solver, use_direct_model, use_model_names, add_bridges)
     f(m)
     run_spineopt!(m, url_out; log_level, alternative, kwargs...)
     t_end = now()
@@ -380,7 +380,7 @@ A `JuMP.Model` extended to be used with SpineOpt.
 `add_bridges` is a `Bool` indicating whether bridges from JuMP to the solver should be added to the model.
 """
 function create_model(
-    mip_solver=nothing, lp_solver=nothing, use_direct_model=false, use_model_names=true, add_bridges=false
+    ; mip_solver=nothing, lp_solver=nothing, use_direct_model=false, use_model_names=true, add_bridges=false
 )
     instance = first(model())
     mip_solver = _mip_solver(instance, mip_solver)

--- a/src/run_spineopt.jl
+++ b/src/run_spineopt.jl
@@ -146,18 +146,8 @@ function _run_spineopt(
     println("[SpineInterface version $si_ver (git hash: $si_git_hash)]")
     t_start = now()
     @log log_level 1 "Execution started at $t_start"
-    m = prepare_spineopt(
-            url_in;
-            upgrade,
-            filters,
-            templates,
-            mip_solver,
-            lp_solver,
-            use_direct_model,
-            use_model_names,
-            add_bridges,
-            log_level
-        )
+    prepare_spineopt(url_in; upgrade, filters, templates, log_level)
+    m = create_model(mip_solver, lp_solver, use_direct_model, use_model_names, add_bridges)
     f(m)
     run_spineopt!(m, url_out; log_level, alternative, kwargs...)
     t_end = now()
@@ -291,7 +281,7 @@ function prepare_spineopt(
         end
     end
     _set_value_translator()
-    create_model(mip_solver, lp_solver, use_direct_model, use_model_names, add_bridges)
+    nothing
 end
 
 function _init_data_from_db(url_in, log_level, upgrade, templates, filters, scenario="")
@@ -389,7 +379,9 @@ A `JuMP.Model` extended to be used with SpineOpt.
 `use_model_names` is a `Bool` indicating whether the names in the model should be used.
 `add_bridges` is a `Bool` indicating whether bridges from JuMP to the solver should be added to the model.
 """
-function create_model(mip_solver, lp_solver, use_direct_model, use_model_names, add_bridges)
+function create_model(
+    mip_solver=nothing, lp_solver=nothing, use_direct_model=false, use_model_names=true, add_bridges=false
+)
     instance = first(model())
     mip_solver = _mip_solver(instance, mip_solver)
     lp_solver = _lp_solver(instance, lp_solver)


### PR DESCRIPTION
This is to support distributed execution of several spineopt instances.

Long explanation: so at the moment it is not possible to read the data from the DB *and* run SpineOpt in parallel. It is only possible to do the second part in parallel, running SpineOpt (which is already a lot of parallelism to exploit, nevertheless). But reading the DB in parallel is simply not possible because if there is a stage, then we need to apply the stage scenario filter to read the data for the stage, and if several workers are trying to do this in parallel, they will find the DB in an uncertain state. For example, one worker could set the filter and before resetting it, another worker could come and try to set the filter again, and so on.

So the DB needs to be read in sequence, and then when all the workers have read the DB in sequence, they can run SpineOpt in parallel. That's the way it its.

This PR makes the above possible by calling `prepare_spineopt(url_in)` in sequence, and then calling `m = create_model()`
followed by `run_spineopt!(m, url_out)` in parallel.

But before this commit, the model was created and returned by `prepare_spineopt` which was not good, because then one would need to fetch the model from the worker process in the first (sequential) step and send it back to the same worker for the second (parallel) step, and the model object in JuMP doesn't support this passing accross processes.


## Checklist before merging
- [ ] Documentation is up-to-date
- [ ] Unit tests have been added/updated accordingly
- [ ] improved [type stability](https://modernjuliaworkflows.org/optimizing/#type_stability) or, when outside the scope of the pull request, at least indicated where and how the code is not properly typed
- [ ] Code has been formatted according to SpineOpt's style
- [ ] Unit tests pass
