### PR TITLE
Fix migration bug for really old databases missing `investment_group`…

### DIFF
--- a/src/data_structure/versions/major_upgrade_1.jl
+++ b/src/data_structure/versions/major_upgrade_1.jl
@@ -487,6 +487,16 @@ end
 
 # Create specific new classes as superclasses and subclasses
 function create_superclasses_and_subclasses(db_url, log_level)
+    # Ensure existence of `investment_group` and `user_constraint`
+    for required_class in ("user_constraint", "investment_group")
+        class_item = run_request(db_url, "call_method", ("get_entity_class_item",), Dict("name" => required_class))
+        if length(class_item) == 0
+            @log log_level 0 string("`$required_class` not found! -> Creating it as an empty class.")
+            check_run_request_return_value(run_request(db_url, "call_method", ("add_entity_class_item",), Dict(
+                "name" => required_class, "dimension_name_list" => [])), log_level
+            )
+        end
+    end
     # Add new classes
     try
         check_run_request_return_value(run_request(db_url, "call_method", ("add_entity_class_item",), Dict(


### PR DESCRIPTION
… or `user_constrant` entirely.

When upgrading really old input databases (e.g. https://github.com/spine-tools/nordic-hydro) which might be missing the `investment_group` or `user_constraint` entity classes, the `create_superclasses_and_subclasses` migration function failed.

Now, `create_superclasses_and_subclasses` checks if these required classes exist, and creates them if not. This way, the superclass migration proceeds as intended.

## Checklist before merging
- [x] Documentation is up-to-date _(No changes)_
- [x] Unit tests have been added/updated accordingly _(No need?)_
- [x] improved [type stability](https://modernjuliaworkflows.org/optimizing/#type_stability) or, when outside the scope of the pull request, at least indicated where and how the code is not properly typed _(Irrelevant)_
- [x] Code has been formatted according to SpineOpt's style
- [x] Unit tests pass
