### PR TITLE
Fix non-rolling parameter calls.

### DIFF
--- a/src/constraints/constraint_units_available.jl
+++ b/src/constraints/constraint_units_available.jl
@@ -62,7 +62,7 @@ function _build_constraint_units_available(m, u, s, t)
         + existing_units(m; unit=u, stochastic_scenario=s, t=t, _default=_default_nb_of_units(u))
         - ifelse( # Uses `out_of_service_count_fix` when there's no variable for it to fix?
             !has_out_of_service_variable(unit=u), 
-            out_of_service_count_fix(m; unit=u, stochastic_scenario=s, t=t, _default=0), # Why is the m here in `(m;...)` ?
+            out_of_service_count_fix(m; unit=u, stochastic_scenario=s, t=t, _default=0),
             0
         )
     )

--- a/src/variables/variable_units_on.jl
+++ b/src/variables/variable_units_on.jl
@@ -124,7 +124,7 @@ should hopefully bypass most issues.
 function _get_units_on(m, u, s, t)
     get(m.ext[:spineopt].variables[:units_on], (u, s, t)) do
         (
-            existing_units(unit=u, stochastic_scenario=s, t=t, _default=_default_nb_of_units(u))
+            existing_units(m; unit=u, stochastic_scenario=s, t=t, _default=_default_nb_of_units(u))
             + _get_units_invested_available(m, u, s, t)
             - _get_units_out_of_service(m, u, s, t)
         )

--- a/src/variables/variable_units_on.jl
+++ b/src/variables/variable_units_on.jl
@@ -120,6 +120,10 @@ e.g. minimum load and ramping constraints.
 Currently, this doesn't handle complex time and stochastic structures.
 Defining identical structures for `units_on` and investments
 should hopefully bypass most issues.
+
+Note that this function returns a `Call`,
+as [existing_units](@ref) might need to update as the model rolls.
+See `SpineInterface.realize()` for resolving such calls.
 """
 function _get_units_on(m, u, s, t)
     get(m.ext[:spineopt].variables[:units_on], (u, s, t)) do

--- a/src/variables/variable_units_out_of_service.jl
+++ b/src/variables/variable_units_out_of_service.jl
@@ -83,6 +83,6 @@ but one cannot ensure its existence.
 """
 function _get_units_out_of_service(m, u, s, t)
     get(m.ext[:spineopt].variables[:units_out_of_service], (u, s, t)) do 
-        out_of_service_count_fix(unit=u, stochastic_scenario=s, t=t, _default=0)
+        out_of_service_count_fix(m; unit=u, stochastic_scenario=s, t=t, _default=0)
     end
 end

--- a/test/variables/variables.jl
+++ b/test/variables/variables.jl
@@ -194,8 +194,9 @@ function test_unit_online_variable_type_none()
             key = (u, s, t)
             @test_throws KeyError var_units_on[key...]
             @test_throws KeyError constraint_u_avail[key...]
-            @test SpineOpt._get_units_on(m, key...) == existing_units(unit=u)
-            @test SpineOpt._get_units_invested_available(m, key...) == 0
+            @test realize(SpineOpt._get_units_on(m, key...)) == existing_units(unit=u)
+            @test realize(SpineOpt._get_units_invested_available(m, key...)) == 0
+            @test realize(SpineOpt._get_units_out_of_service(m, key...)) == 0
         end
     end
     @testset "unit_online_variable_type_none_with_investments" begin
@@ -223,8 +224,9 @@ function test_unit_online_variable_type_none()
             key = (u, s, t)
             @test_throws KeyError var_units_on[key...]
             @test_throws KeyError constraint_u_avail[key...]
-            @test SpineOpt._get_units_on(m, u, s, t) == var_units_invested_available[key...] + existing_units(unit=u)
-            @test SpineOpt._get_units_invested_available(m, key...) == var_units_invested_available[key...]
+            @test realize(SpineOpt._get_units_on(m, u, s, t)) == var_units_invested_available[key...] + existing_units(unit=u)
+            @test realize(SpineOpt._get_units_invested_available(m, key...)) == var_units_invested_available[key...]
+            @test realize(SpineOpt._get_units_out_of_service(m, key...)) == 0
         end
     end
 end


### PR DESCRIPTION
Fixes two parameter calls that fail to roll properly which I mistakenly introduced back in #1325.

The `existing_units` and `out_of_service_count_fix` would not roll properly if provided as time-dependent parameters.

I wasted a day trying to write a unit test for this and failed, so we have no safeguards against this happening again. I just have to hope @manuelma tested his original fix in https://github.com/spine-tools/SpineOpt.jl/commit/c47153540917132c61821aba91aa91e89111934d somehow.

## Checklist before merging
- [x] Documentation is up-to-date
- [ ] Unit tests have been added/updated accordingly
- [ ] improved [type stability](https://modernjuliaworkflows.org/optimizing/#type_stability) or, when outside the scope of the pull request, at least indicated where and how the code is not properly typed
- [x] Code has been formatted according to SpineOpt's style
- [x] Unit tests pass
