### PR TITLE
Report output resolution

### DIFF
--- a/docs/src/concept_reference/output_resolution.md
+++ b/docs/src/concept_reference/output_resolution.md
@@ -3,3 +3,6 @@ The [output\_resolution](@ref) parameter indicates the resolution at which [outp
 If `null` (the default), then results are reported at the highest available resolution from the model.
 If [output\_resolution](@ref) is a duration value, then results are aggregated at that resolution before being reported.
 At the moment, the aggregation is simply performed by taking the average value.
+
+When [output\_resolution](@ref) is defined on the [report\_\_output](@ref) level,
+it takes priority over other resolutions for that [report](@ref).

--- a/examples/6_unit_system.json
+++ b/examples/6_unit_system.json
@@ -81898,7 +81898,7 @@
         [
             "connection__from_node__user_constraint",
             "coefficient_for_connection_flow",
-            0.0,
+            null,
             null,
             "Defines the user constraint coefficient on the connection flow variable in the from direction."
         ],
@@ -82062,21 +82062,21 @@
         [
             "connection__to_node__user_constraint",
             "coefficient_for_connection_flow",
-            0.0,
+            null,
             null,
             "Defines the user constraint coefficient on the connection flow variable in the to direction."
         ],
         [
             "connection__user_constraint",
             "coefficient_for_connections_invested",
-            0.0,
+            null,
             null,
             "Coefficient of `connections_invested` in the specific `user_constraint`"
         ],
         [
             "connection__user_constraint",
             "coefficient_for_connections_invested_available",
-            0.0,
+            null,
             null,
             "Coefficient of `connections_invested_available` in the specific `user_constraint`"
         ],
@@ -83037,28 +83037,28 @@
         [
             "node__user_constraint",
             "coefficient_for_demand",
-            0.0,
+            null,
             null,
             "Coefficient of the specified node's demand in the specified user constraint."
         ],
         [
             "node__user_constraint",
             "coefficient_for_node_state",
-            0.0,
+            null,
             null,
             "Coefficient of the specified node's state variable in the specified user constraint."
         ],
         [
             "node__user_constraint",
             "coefficient_for_storages_invested",
-            0.0,
+            null,
             null,
             "Coefficient of the specified node's storage investment variable in the specified user constraint."
         ],
         [
             "node__user_constraint",
             "coefficient_for_storages_invested_available",
-            0.0,
+            null,
             null,
             "Coefficient of the specified node's storages invested available variable in the specified user constraint."
         ],
@@ -83082,6 +83082,13 @@
             null,
             null,
             "Database url for SpineOpt output."
+        ],
+        [
+            "report__output",
+            "output_resolution",
+            null,
+            null,
+            "Temporal resolution of the output for this specific report. Overrides the output-level output_resolution if set."
         ],
         [
             "report__output",
@@ -83662,28 +83669,28 @@
         [
             "unit__user_constraint",
             "coefficient_for_units_invested",
-            0.0,
+            null,
             null,
             "Coefficient of the `units_invested` variable in the specified `user_constraint`."
         ],
         [
             "unit__user_constraint",
             "coefficient_for_units_invested_available",
-            0.0,
+            null,
             null,
             "Coefficient of the `units_invested_available` variable in the specified `user_constraint`."
         ],
         [
             "unit__user_constraint",
             "coefficient_for_units_on",
-            0.0,
+            null,
             null,
             "Coefficient of a `units_on` variable for a custom `user_constraint`."
         ],
         [
             "unit__user_constraint",
             "coefficient_for_units_started_up",
-            0.0,
+            null,
             null,
             "Coefficient of a `units_started_up` variable for a custom `user_constraint`."
         ],
@@ -83739,7 +83746,7 @@
         [
             "unit_flow__user_constraint",
             "coefficient_for_unit_flow",
-            0.0,
+            null,
             null,
             "Coefficient of a `unit_flow` variable for a custom `user_constraint`."
         ],
@@ -84969,14 +84976,6 @@
             "report__output",
             [
                 "report",
-                "ramp_costs"
-            ],
-            null
-        ],
-        [
-            "report__output",
-            [
-                "report",
                 "renewable_curtailment_costs"
             ],
             null
@@ -85074,14 +85073,6 @@
             [
                 "report",
                 "unit_investment_costs"
-            ],
-            null
-        ],
-        [
-            "report__output",
-            [
-                "report",
-                "units_available"
             ],
             null
         ],

--- a/examples/capacity_planning.json
+++ b/examples/capacity_planning.json
@@ -2252,7 +2252,7 @@
         [
             "connection__from_node__user_constraint",
             "coefficient_for_connection_flow",
-            0.0,
+            null,
             null,
             "Defines the user constraint coefficient on the connection flow variable in the from direction."
         ],
@@ -2416,21 +2416,21 @@
         [
             "connection__to_node__user_constraint",
             "coefficient_for_connection_flow",
-            0.0,
+            null,
             null,
             "Defines the user constraint coefficient on the connection flow variable in the to direction."
         ],
         [
             "connection__user_constraint",
             "coefficient_for_connections_invested",
-            0.0,
+            null,
             null,
             "Coefficient of `connections_invested` in the specific `user_constraint`"
         ],
         [
             "connection__user_constraint",
             "coefficient_for_connections_invested_available",
-            0.0,
+            null,
             null,
             "Coefficient of `connections_invested_available` in the specific `user_constraint`"
         ],
@@ -3391,28 +3391,28 @@
         [
             "node__user_constraint",
             "coefficient_for_demand",
-            0.0,
+            null,
             null,
             "Coefficient of the specified node's demand in the specified user constraint."
         ],
         [
             "node__user_constraint",
             "coefficient_for_node_state",
-            0.0,
+            null,
             null,
             "Coefficient of the specified node's state variable in the specified user constraint."
         ],
         [
             "node__user_constraint",
             "coefficient_for_storages_invested",
-            0.0,
+            null,
             null,
             "Coefficient of the specified node's storage investment variable in the specified user constraint."
         ],
         [
             "node__user_constraint",
             "coefficient_for_storages_invested_available",
-            0.0,
+            null,
             null,
             "Coefficient of the specified node's storages invested available variable in the specified user constraint."
         ],
@@ -3436,6 +3436,13 @@
             null,
             null,
             "Database url for SpineOpt output."
+        ],
+        [
+            "report__output",
+            "output_resolution",
+            null,
+            null,
+            "Temporal resolution of the output for this specific report. Overrides the output-level output_resolution if set."
         ],
         [
             "report__output",
@@ -4016,28 +4023,28 @@
         [
             "unit__user_constraint",
             "coefficient_for_units_invested",
-            0.0,
+            null,
             null,
             "Coefficient of the `units_invested` variable in the specified `user_constraint`."
         ],
         [
             "unit__user_constraint",
             "coefficient_for_units_invested_available",
-            0.0,
+            null,
             null,
             "Coefficient of the `units_invested_available` variable in the specified `user_constraint`."
         ],
         [
             "unit__user_constraint",
             "coefficient_for_units_on",
-            0.0,
+            null,
             null,
             "Coefficient of a `units_on` variable for a custom `user_constraint`."
         ],
         [
             "unit__user_constraint",
             "coefficient_for_units_started_up",
-            0.0,
+            null,
             null,
             "Coefficient of a `units_started_up` variable for a custom `user_constraint`."
         ],
@@ -4093,7 +4100,7 @@
         [
             "unit_flow__user_constraint",
             "coefficient_for_unit_flow",
-            0.0,
+            null,
             null,
             "Coefficient of a `unit_flow` variable for a custom `user_constraint`."
         ],

--- a/examples/multi-year_investment_with_econ_discounting_consecutives.json
+++ b/examples/multi-year_investment_with_econ_discounting_consecutives.json
@@ -2108,7 +2108,7 @@
         [
             "connection__from_node__user_constraint",
             "coefficient_for_connection_flow",
-            0.0,
+            null,
             null,
             "Defines the user constraint coefficient on the connection flow variable in the from direction."
         ],
@@ -2272,21 +2272,21 @@
         [
             "connection__to_node__user_constraint",
             "coefficient_for_connection_flow",
-            0.0,
+            null,
             null,
             "Defines the user constraint coefficient on the connection flow variable in the to direction."
         ],
         [
             "connection__user_constraint",
             "coefficient_for_connections_invested",
-            0.0,
+            null,
             null,
             "Coefficient of `connections_invested` in the specific `user_constraint`"
         ],
         [
             "connection__user_constraint",
             "coefficient_for_connections_invested_available",
-            0.0,
+            null,
             null,
             "Coefficient of `connections_invested_available` in the specific `user_constraint`"
         ],
@@ -3247,28 +3247,28 @@
         [
             "node__user_constraint",
             "coefficient_for_demand",
-            0.0,
+            null,
             null,
             "Coefficient of the specified node's demand in the specified user constraint."
         ],
         [
             "node__user_constraint",
             "coefficient_for_node_state",
-            0.0,
+            null,
             null,
             "Coefficient of the specified node's state variable in the specified user constraint."
         ],
         [
             "node__user_constraint",
             "coefficient_for_storages_invested",
-            0.0,
+            null,
             null,
             "Coefficient of the specified node's storage investment variable in the specified user constraint."
         ],
         [
             "node__user_constraint",
             "coefficient_for_storages_invested_available",
-            0.0,
+            null,
             null,
             "Coefficient of the specified node's storages invested available variable in the specified user constraint."
         ],
@@ -3292,6 +3292,13 @@
             null,
             null,
             "Database url for SpineOpt output."
+        ],
+        [
+            "report__output",
+            "output_resolution",
+            null,
+            null,
+            "Temporal resolution of the output for this specific report. Overrides the output-level output_resolution if set."
         ],
         [
             "report__output",
@@ -3872,28 +3879,28 @@
         [
             "unit__user_constraint",
             "coefficient_for_units_invested",
-            0.0,
+            null,
             null,
             "Coefficient of the `units_invested` variable in the specified `user_constraint`."
         ],
         [
             "unit__user_constraint",
             "coefficient_for_units_invested_available",
-            0.0,
+            null,
             null,
             "Coefficient of the `units_invested_available` variable in the specified `user_constraint`."
         ],
         [
             "unit__user_constraint",
             "coefficient_for_units_on",
-            0.0,
+            null,
             null,
             "Coefficient of a `units_on` variable for a custom `user_constraint`."
         ],
         [
             "unit__user_constraint",
             "coefficient_for_units_started_up",
-            0.0,
+            null,
             null,
             "Coefficient of a `units_started_up` variable for a custom `user_constraint`."
         ],
@@ -3949,7 +3956,7 @@
         [
             "unit_flow__user_constraint",
             "coefficient_for_unit_flow",
-            0.0,
+            null,
             null,
             "Coefficient of a `unit_flow` variable for a custom `user_constraint`."
         ],

--- a/examples/multi-year_investment_with_econ_discounting_milestones.json
+++ b/examples/multi-year_investment_with_econ_discounting_milestones.json
@@ -2180,7 +2180,7 @@
         [
             "connection__from_node__user_constraint",
             "coefficient_for_connection_flow",
-            0.0,
+            null,
             null,
             "Defines the user constraint coefficient on the connection flow variable in the from direction."
         ],
@@ -2344,21 +2344,21 @@
         [
             "connection__to_node__user_constraint",
             "coefficient_for_connection_flow",
-            0.0,
+            null,
             null,
             "Defines the user constraint coefficient on the connection flow variable in the to direction."
         ],
         [
             "connection__user_constraint",
             "coefficient_for_connections_invested",
-            0.0,
+            null,
             null,
             "Coefficient of `connections_invested` in the specific `user_constraint`"
         ],
         [
             "connection__user_constraint",
             "coefficient_for_connections_invested_available",
-            0.0,
+            null,
             null,
             "Coefficient of `connections_invested_available` in the specific `user_constraint`"
         ],
@@ -3319,28 +3319,28 @@
         [
             "node__user_constraint",
             "coefficient_for_demand",
-            0.0,
+            null,
             null,
             "Coefficient of the specified node's demand in the specified user constraint."
         ],
         [
             "node__user_constraint",
             "coefficient_for_node_state",
-            0.0,
+            null,
             null,
             "Coefficient of the specified node's state variable in the specified user constraint."
         ],
         [
             "node__user_constraint",
             "coefficient_for_storages_invested",
-            0.0,
+            null,
             null,
             "Coefficient of the specified node's storage investment variable in the specified user constraint."
         ],
         [
             "node__user_constraint",
             "coefficient_for_storages_invested_available",
-            0.0,
+            null,
             null,
             "Coefficient of the specified node's storages invested available variable in the specified user constraint."
         ],
@@ -3364,6 +3364,13 @@
             null,
             null,
             "Database url for SpineOpt output."
+        ],
+        [
+            "report__output",
+            "output_resolution",
+            null,
+            null,
+            "Temporal resolution of the output for this specific report. Overrides the output-level output_resolution if set."
         ],
         [
             "report__output",
@@ -3944,28 +3951,28 @@
         [
             "unit__user_constraint",
             "coefficient_for_units_invested",
-            0.0,
+            null,
             null,
             "Coefficient of the `units_invested` variable in the specified `user_constraint`."
         ],
         [
             "unit__user_constraint",
             "coefficient_for_units_invested_available",
-            0.0,
+            null,
             null,
             "Coefficient of the `units_invested_available` variable in the specified `user_constraint`."
         ],
         [
             "unit__user_constraint",
             "coefficient_for_units_on",
-            0.0,
+            null,
             null,
             "Coefficient of a `units_on` variable for a custom `user_constraint`."
         ],
         [
             "unit__user_constraint",
             "coefficient_for_units_started_up",
-            0.0,
+            null,
             null,
             "Coefficient of a `units_started_up` variable for a custom `user_constraint`."
         ],
@@ -4021,7 +4028,7 @@
         [
             "unit_flow__user_constraint",
             "coefficient_for_unit_flow",
-            0.0,
+            null,
             null,
             "Coefficient of a `unit_flow` variable for a custom `user_constraint`."
         ],

--- a/examples/multi-year_investment_without_econ_discounting.json
+++ b/examples/multi-year_investment_without_econ_discounting.json
@@ -2101,7 +2101,7 @@
         [
             "connection__from_node__user_constraint",
             "coefficient_for_connection_flow",
-            0.0,
+            null,
             null,
             "Defines the user constraint coefficient on the connection flow variable in the from direction."
         ],
@@ -2265,21 +2265,21 @@
         [
             "connection__to_node__user_constraint",
             "coefficient_for_connection_flow",
-            0.0,
+            null,
             null,
             "Defines the user constraint coefficient on the connection flow variable in the to direction."
         ],
         [
             "connection__user_constraint",
             "coefficient_for_connections_invested",
-            0.0,
+            null,
             null,
             "Coefficient of `connections_invested` in the specific `user_constraint`"
         ],
         [
             "connection__user_constraint",
             "coefficient_for_connections_invested_available",
-            0.0,
+            null,
             null,
             "Coefficient of `connections_invested_available` in the specific `user_constraint`"
         ],
@@ -3240,28 +3240,28 @@
         [
             "node__user_constraint",
             "coefficient_for_demand",
-            0.0,
+            null,
             null,
             "Coefficient of the specified node's demand in the specified user constraint."
         ],
         [
             "node__user_constraint",
             "coefficient_for_node_state",
-            0.0,
+            null,
             null,
             "Coefficient of the specified node's state variable in the specified user constraint."
         ],
         [
             "node__user_constraint",
             "coefficient_for_storages_invested",
-            0.0,
+            null,
             null,
             "Coefficient of the specified node's storage investment variable in the specified user constraint."
         ],
         [
             "node__user_constraint",
             "coefficient_for_storages_invested_available",
-            0.0,
+            null,
             null,
             "Coefficient of the specified node's storages invested available variable in the specified user constraint."
         ],
@@ -3285,6 +3285,13 @@
             null,
             null,
             "Database url for SpineOpt output."
+        ],
+        [
+            "report__output",
+            "output_resolution",
+            null,
+            null,
+            "Temporal resolution of the output for this specific report. Overrides the output-level output_resolution if set."
         ],
         [
             "report__output",
@@ -3865,28 +3872,28 @@
         [
             "unit__user_constraint",
             "coefficient_for_units_invested",
-            0.0,
+            null,
             null,
             "Coefficient of the `units_invested` variable in the specified `user_constraint`."
         ],
         [
             "unit__user_constraint",
             "coefficient_for_units_invested_available",
-            0.0,
+            null,
             null,
             "Coefficient of the `units_invested_available` variable in the specified `user_constraint`."
         ],
         [
             "unit__user_constraint",
             "coefficient_for_units_on",
-            0.0,
+            null,
             null,
             "Coefficient of a `units_on` variable for a custom `user_constraint`."
         ],
         [
             "unit__user_constraint",
             "coefficient_for_units_started_up",
-            0.0,
+            null,
             null,
             "Coefficient of a `units_started_up` variable for a custom `user_constraint`."
         ],
@@ -3942,7 +3949,7 @@
         [
             "unit_flow__user_constraint",
             "coefficient_for_unit_flow",
-            0.0,
+            null,
             null,
             "Coefficient of a `unit_flow` variable for a custom `user_constraint`."
         ],

--- a/examples/multi_stage_model_tutorial.json
+++ b/examples/multi_stage_model_tutorial.json
@@ -181,7 +181,7 @@
                                 ],
                                 [
                                     "threads",
-                                    0.0
+                                    0
                                 ]
                             ],
                             "type": "map",
@@ -28366,7 +28366,7 @@
         [
             "connection__from_node__user_constraint",
             "coefficient_for_connection_flow",
-            0.0,
+            null,
             null,
             "Defines the user constraint coefficient on the connection flow variable in the from direction."
         ],
@@ -28530,21 +28530,21 @@
         [
             "connection__to_node__user_constraint",
             "coefficient_for_connection_flow",
-            0.0,
+            null,
             null,
             "Defines the user constraint coefficient on the connection flow variable in the to direction."
         ],
         [
             "connection__user_constraint",
             "coefficient_for_connections_invested",
-            0.0,
+            null,
             null,
             "Coefficient of `connections_invested` in the specific `user_constraint`"
         ],
         [
             "connection__user_constraint",
             "coefficient_for_connections_invested_available",
-            0.0,
+            null,
             null,
             "Coefficient of `connections_invested_available` in the specific `user_constraint`"
         ],
@@ -29505,28 +29505,28 @@
         [
             "node__user_constraint",
             "coefficient_for_demand",
-            0.0,
+            null,
             null,
             "Coefficient of the specified node's demand in the specified user constraint."
         ],
         [
             "node__user_constraint",
             "coefficient_for_node_state",
-            0.0,
+            null,
             null,
             "Coefficient of the specified node's state variable in the specified user constraint."
         ],
         [
             "node__user_constraint",
             "coefficient_for_storages_invested",
-            0.0,
+            null,
             null,
             "Coefficient of the specified node's storage investment variable in the specified user constraint."
         ],
         [
             "node__user_constraint",
             "coefficient_for_storages_invested_available",
-            0.0,
+            null,
             null,
             "Coefficient of the specified node's storages invested available variable in the specified user constraint."
         ],
@@ -29550,6 +29550,13 @@
             null,
             null,
             "Database url for SpineOpt output."
+        ],
+        [
+            "report__output",
+            "output_resolution",
+            null,
+            null,
+            "Temporal resolution of the output for this specific report. Overrides the output-level output_resolution if set."
         ],
         [
             "report__output",
@@ -30130,28 +30137,28 @@
         [
             "unit__user_constraint",
             "coefficient_for_units_invested",
-            0.0,
+            null,
             null,
             "Coefficient of the `units_invested` variable in the specified `user_constraint`."
         ],
         [
             "unit__user_constraint",
             "coefficient_for_units_invested_available",
-            0.0,
+            null,
             null,
             "Coefficient of the `units_invested_available` variable in the specified `user_constraint`."
         ],
         [
             "unit__user_constraint",
             "coefficient_for_units_on",
-            0.0,
+            null,
             null,
             "Coefficient of a `units_on` variable for a custom `user_constraint`."
         ],
         [
             "unit__user_constraint",
             "coefficient_for_units_started_up",
-            0.0,
+            null,
             null,
             "Coefficient of a `units_started_up` variable for a custom `user_constraint`."
         ],
@@ -30207,7 +30214,7 @@
         [
             "unit_flow__user_constraint",
             "coefficient_for_unit_flow",
-            0.0,
+            null,
             null,
             "Coefficient of a `unit_flow` variable for a custom `user_constraint`."
         ],
@@ -31185,14 +31192,6 @@
             [
                 "h2_node_candidate",
                 "H2gen_candidate"
-            ],
-            null
-        ],
-        [
-            "report__output",
-            [
-                "my_report",
-                "LT_node_state"
             ],
             null
         ],

--- a/examples/representative_periods.json
+++ b/examples/representative_periods.json
@@ -2361,7 +2361,7 @@
         [
             "connection__from_node__user_constraint",
             "coefficient_for_connection_flow",
-            0.0,
+            null,
             null,
             "Defines the user constraint coefficient on the connection flow variable in the from direction."
         ],
@@ -2525,21 +2525,21 @@
         [
             "connection__to_node__user_constraint",
             "coefficient_for_connection_flow",
-            0.0,
+            null,
             null,
             "Defines the user constraint coefficient on the connection flow variable in the to direction."
         ],
         [
             "connection__user_constraint",
             "coefficient_for_connections_invested",
-            0.0,
+            null,
             null,
             "Coefficient of `connections_invested` in the specific `user_constraint`"
         ],
         [
             "connection__user_constraint",
             "coefficient_for_connections_invested_available",
-            0.0,
+            null,
             null,
             "Coefficient of `connections_invested_available` in the specific `user_constraint`"
         ],
@@ -3500,28 +3500,28 @@
         [
             "node__user_constraint",
             "coefficient_for_demand",
-            0.0,
+            null,
             null,
             "Coefficient of the specified node's demand in the specified user constraint."
         ],
         [
             "node__user_constraint",
             "coefficient_for_node_state",
-            0.0,
+            null,
             null,
             "Coefficient of the specified node's state variable in the specified user constraint."
         ],
         [
             "node__user_constraint",
             "coefficient_for_storages_invested",
-            0.0,
+            null,
             null,
             "Coefficient of the specified node's storage investment variable in the specified user constraint."
         ],
         [
             "node__user_constraint",
             "coefficient_for_storages_invested_available",
-            0.0,
+            null,
             null,
             "Coefficient of the specified node's storages invested available variable in the specified user constraint."
         ],
@@ -3545,6 +3545,13 @@
             null,
             null,
             "Database url for SpineOpt output."
+        ],
+        [
+            "report__output",
+            "output_resolution",
+            null,
+            null,
+            "Temporal resolution of the output for this specific report. Overrides the output-level output_resolution if set."
         ],
         [
             "report__output",
@@ -4125,28 +4132,28 @@
         [
             "unit__user_constraint",
             "coefficient_for_units_invested",
-            0.0,
+            null,
             null,
             "Coefficient of the `units_invested` variable in the specified `user_constraint`."
         ],
         [
             "unit__user_constraint",
             "coefficient_for_units_invested_available",
-            0.0,
+            null,
             null,
             "Coefficient of the `units_invested_available` variable in the specified `user_constraint`."
         ],
         [
             "unit__user_constraint",
             "coefficient_for_units_on",
-            0.0,
+            null,
             null,
             "Coefficient of a `units_on` variable for a custom `user_constraint`."
         ],
         [
             "unit__user_constraint",
             "coefficient_for_units_started_up",
-            0.0,
+            null,
             null,
             "Coefficient of a `units_started_up` variable for a custom `user_constraint`."
         ],
@@ -4202,7 +4209,7 @@
         [
             "unit_flow__user_constraint",
             "coefficient_for_unit_flow",
-            0.0,
+            null,
             null,
             "Coefficient of a `unit_flow` variable for a custom `user_constraint`."
         ],
@@ -5151,14 +5158,6 @@
             [
                 "report1",
                 "node_state"
-            ],
-            null
-        ],
-        [
-            "report__output",
-            [
-                "report1",
-                "node_state_longterm"
             ],
             null
         ],

--- a/examples/reserves.json
+++ b/examples/reserves.json
@@ -872,7 +872,7 @@
         [
             "connection__from_node__user_constraint",
             "coefficient_for_connection_flow",
-            0.0,
+            null,
             null,
             "Defines the user constraint coefficient on the connection flow variable in the from direction."
         ],
@@ -1036,21 +1036,21 @@
         [
             "connection__to_node__user_constraint",
             "coefficient_for_connection_flow",
-            0.0,
+            null,
             null,
             "Defines the user constraint coefficient on the connection flow variable in the to direction."
         ],
         [
             "connection__user_constraint",
             "coefficient_for_connections_invested",
-            0.0,
+            null,
             null,
             "Coefficient of `connections_invested` in the specific `user_constraint`"
         ],
         [
             "connection__user_constraint",
             "coefficient_for_connections_invested_available",
-            0.0,
+            null,
             null,
             "Coefficient of `connections_invested_available` in the specific `user_constraint`"
         ],
@@ -2011,28 +2011,28 @@
         [
             "node__user_constraint",
             "coefficient_for_demand",
-            0.0,
+            null,
             null,
             "Coefficient of the specified node's demand in the specified user constraint."
         ],
         [
             "node__user_constraint",
             "coefficient_for_node_state",
-            0.0,
+            null,
             null,
             "Coefficient of the specified node's state variable in the specified user constraint."
         ],
         [
             "node__user_constraint",
             "coefficient_for_storages_invested",
-            0.0,
+            null,
             null,
             "Coefficient of the specified node's storage investment variable in the specified user constraint."
         ],
         [
             "node__user_constraint",
             "coefficient_for_storages_invested_available",
-            0.0,
+            null,
             null,
             "Coefficient of the specified node's storages invested available variable in the specified user constraint."
         ],
@@ -2056,6 +2056,13 @@
             null,
             null,
             "Database url for SpineOpt output."
+        ],
+        [
+            "report__output",
+            "output_resolution",
+            null,
+            null,
+            "Temporal resolution of the output for this specific report. Overrides the output-level output_resolution if set."
         ],
         [
             "report__output",
@@ -2636,28 +2643,28 @@
         [
             "unit__user_constraint",
             "coefficient_for_units_invested",
-            0.0,
+            null,
             null,
             "Coefficient of the `units_invested` variable in the specified `user_constraint`."
         ],
         [
             "unit__user_constraint",
             "coefficient_for_units_invested_available",
-            0.0,
+            null,
             null,
             "Coefficient of the `units_invested_available` variable in the specified `user_constraint`."
         ],
         [
             "unit__user_constraint",
             "coefficient_for_units_on",
-            0.0,
+            null,
             null,
             "Coefficient of a `units_on` variable for a custom `user_constraint`."
         ],
         [
             "unit__user_constraint",
             "coefficient_for_units_started_up",
-            0.0,
+            null,
             null,
             "Coefficient of a `units_started_up` variable for a custom `user_constraint`."
         ],
@@ -2713,7 +2720,7 @@
         [
             "unit_flow__user_constraint",
             "coefficient_for_unit_flow",
-            0.0,
+            null,
             null,
             "Coefficient of a `unit_flow` variable for a custom `user_constraint`."
         ],

--- a/examples/rolling_horizon.json
+++ b/examples/rolling_horizon.json
@@ -872,7 +872,7 @@
         [
             "connection__from_node__user_constraint",
             "coefficient_for_connection_flow",
-            0.0,
+            null,
             null,
             "Defines the user constraint coefficient on the connection flow variable in the from direction."
         ],
@@ -1036,21 +1036,21 @@
         [
             "connection__to_node__user_constraint",
             "coefficient_for_connection_flow",
-            0.0,
+            null,
             null,
             "Defines the user constraint coefficient on the connection flow variable in the to direction."
         ],
         [
             "connection__user_constraint",
             "coefficient_for_connections_invested",
-            0.0,
+            null,
             null,
             "Coefficient of `connections_invested` in the specific `user_constraint`"
         ],
         [
             "connection__user_constraint",
             "coefficient_for_connections_invested_available",
-            0.0,
+            null,
             null,
             "Coefficient of `connections_invested_available` in the specific `user_constraint`"
         ],
@@ -2011,28 +2011,28 @@
         [
             "node__user_constraint",
             "coefficient_for_demand",
-            0.0,
+            null,
             null,
             "Coefficient of the specified node's demand in the specified user constraint."
         ],
         [
             "node__user_constraint",
             "coefficient_for_node_state",
-            0.0,
+            null,
             null,
             "Coefficient of the specified node's state variable in the specified user constraint."
         ],
         [
             "node__user_constraint",
             "coefficient_for_storages_invested",
-            0.0,
+            null,
             null,
             "Coefficient of the specified node's storage investment variable in the specified user constraint."
         ],
         [
             "node__user_constraint",
             "coefficient_for_storages_invested_available",
-            0.0,
+            null,
             null,
             "Coefficient of the specified node's storages invested available variable in the specified user constraint."
         ],
@@ -2056,6 +2056,13 @@
             null,
             null,
             "Database url for SpineOpt output."
+        ],
+        [
+            "report__output",
+            "output_resolution",
+            null,
+            null,
+            "Temporal resolution of the output for this specific report. Overrides the output-level output_resolution if set."
         ],
         [
             "report__output",
@@ -2636,28 +2643,28 @@
         [
             "unit__user_constraint",
             "coefficient_for_units_invested",
-            0.0,
+            null,
             null,
             "Coefficient of the `units_invested` variable in the specified `user_constraint`."
         ],
         [
             "unit__user_constraint",
             "coefficient_for_units_invested_available",
-            0.0,
+            null,
             null,
             "Coefficient of the `units_invested_available` variable in the specified `user_constraint`."
         ],
         [
             "unit__user_constraint",
             "coefficient_for_units_on",
-            0.0,
+            null,
             null,
             "Coefficient of a `units_on` variable for a custom `user_constraint`."
         ],
         [
             "unit__user_constraint",
             "coefficient_for_units_started_up",
-            0.0,
+            null,
             null,
             "Coefficient of a `units_started_up` variable for a custom `user_constraint`."
         ],
@@ -2713,7 +2720,7 @@
         [
             "unit_flow__user_constraint",
             "coefficient_for_unit_flow",
-            0.0,
+            null,
             null,
             "Coefficient of a `unit_flow` variable for a custom `user_constraint`."
         ],

--- a/examples/simple_system.json
+++ b/examples/simple_system.json
@@ -872,7 +872,7 @@
         [
             "connection__from_node__user_constraint",
             "coefficient_for_connection_flow",
-            0.0,
+            null,
             null,
             "Defines the user constraint coefficient on the connection flow variable in the from direction."
         ],
@@ -1036,21 +1036,21 @@
         [
             "connection__to_node__user_constraint",
             "coefficient_for_connection_flow",
-            0.0,
+            null,
             null,
             "Defines the user constraint coefficient on the connection flow variable in the to direction."
         ],
         [
             "connection__user_constraint",
             "coefficient_for_connections_invested",
-            0.0,
+            null,
             null,
             "Coefficient of `connections_invested` in the specific `user_constraint`"
         ],
         [
             "connection__user_constraint",
             "coefficient_for_connections_invested_available",
-            0.0,
+            null,
             null,
             "Coefficient of `connections_invested_available` in the specific `user_constraint`"
         ],
@@ -2011,28 +2011,28 @@
         [
             "node__user_constraint",
             "coefficient_for_demand",
-            0.0,
+            null,
             null,
             "Coefficient of the specified node's demand in the specified user constraint."
         ],
         [
             "node__user_constraint",
             "coefficient_for_node_state",
-            0.0,
+            null,
             null,
             "Coefficient of the specified node's state variable in the specified user constraint."
         ],
         [
             "node__user_constraint",
             "coefficient_for_storages_invested",
-            0.0,
+            null,
             null,
             "Coefficient of the specified node's storage investment variable in the specified user constraint."
         ],
         [
             "node__user_constraint",
             "coefficient_for_storages_invested_available",
-            0.0,
+            null,
             null,
             "Coefficient of the specified node's storages invested available variable in the specified user constraint."
         ],
@@ -2056,6 +2056,13 @@
             null,
             null,
             "Database url for SpineOpt output."
+        ],
+        [
+            "report__output",
+            "output_resolution",
+            null,
+            null,
+            "Temporal resolution of the output for this specific report. Overrides the output-level output_resolution if set."
         ],
         [
             "report__output",
@@ -2636,28 +2643,28 @@
         [
             "unit__user_constraint",
             "coefficient_for_units_invested",
-            0.0,
+            null,
             null,
             "Coefficient of the `units_invested` variable in the specified `user_constraint`."
         ],
         [
             "unit__user_constraint",
             "coefficient_for_units_invested_available",
-            0.0,
+            null,
             null,
             "Coefficient of the `units_invested_available` variable in the specified `user_constraint`."
         ],
         [
             "unit__user_constraint",
             "coefficient_for_units_on",
-            0.0,
+            null,
             null,
             "Coefficient of a `units_on` variable for a custom `user_constraint`."
         ],
         [
             "unit__user_constraint",
             "coefficient_for_units_started_up",
-            0.0,
+            null,
             null,
             "Coefficient of a `units_started_up` variable for a custom `user_constraint`."
         ],
@@ -2713,7 +2720,7 @@
         [
             "unit_flow__user_constraint",
             "coefficient_for_unit_flow",
-            0.0,
+            null,
             null,
             "Coefficient of a `unit_flow` variable for a custom `user_constraint`."
         ],

--- a/examples/stochastic.json
+++ b/examples/stochastic.json
@@ -2082,7 +2082,7 @@
         [
             "connection__from_node__user_constraint",
             "coefficient_for_connection_flow",
-            0.0,
+            null,
             null,
             "Defines the user constraint coefficient on the connection flow variable in the from direction."
         ],
@@ -2246,21 +2246,21 @@
         [
             "connection__to_node__user_constraint",
             "coefficient_for_connection_flow",
-            0.0,
+            null,
             null,
             "Defines the user constraint coefficient on the connection flow variable in the to direction."
         ],
         [
             "connection__user_constraint",
             "coefficient_for_connections_invested",
-            0.0,
+            null,
             null,
             "Coefficient of `connections_invested` in the specific `user_constraint`"
         ],
         [
             "connection__user_constraint",
             "coefficient_for_connections_invested_available",
-            0.0,
+            null,
             null,
             "Coefficient of `connections_invested_available` in the specific `user_constraint`"
         ],
@@ -3221,28 +3221,28 @@
         [
             "node__user_constraint",
             "coefficient_for_demand",
-            0.0,
+            null,
             null,
             "Coefficient of the specified node's demand in the specified user constraint."
         ],
         [
             "node__user_constraint",
             "coefficient_for_node_state",
-            0.0,
+            null,
             null,
             "Coefficient of the specified node's state variable in the specified user constraint."
         ],
         [
             "node__user_constraint",
             "coefficient_for_storages_invested",
-            0.0,
+            null,
             null,
             "Coefficient of the specified node's storage investment variable in the specified user constraint."
         ],
         [
             "node__user_constraint",
             "coefficient_for_storages_invested_available",
-            0.0,
+            null,
             null,
             "Coefficient of the specified node's storages invested available variable in the specified user constraint."
         ],
@@ -3266,6 +3266,13 @@
             null,
             null,
             "Database url for SpineOpt output."
+        ],
+        [
+            "report__output",
+            "output_resolution",
+            null,
+            null,
+            "Temporal resolution of the output for this specific report. Overrides the output-level output_resolution if set."
         ],
         [
             "report__output",
@@ -3846,28 +3853,28 @@
         [
             "unit__user_constraint",
             "coefficient_for_units_invested",
-            0.0,
+            null,
             null,
             "Coefficient of the `units_invested` variable in the specified `user_constraint`."
         ],
         [
             "unit__user_constraint",
             "coefficient_for_units_invested_available",
-            0.0,
+            null,
             null,
             "Coefficient of the `units_invested_available` variable in the specified `user_constraint`."
         ],
         [
             "unit__user_constraint",
             "coefficient_for_units_on",
-            0.0,
+            null,
             null,
             "Coefficient of a `units_on` variable for a custom `user_constraint`."
         ],
         [
             "unit__user_constraint",
             "coefficient_for_units_started_up",
-            0.0,
+            null,
             null,
             "Coefficient of a `units_started_up` variable for a custom `user_constraint`."
         ],
@@ -3923,7 +3930,7 @@
         [
             "unit_flow__user_constraint",
             "coefficient_for_unit_flow",
-            0.0,
+            null,
             null,
             "Coefficient of a `unit_flow` variable for a custom `user_constraint`."
         ],

--- a/examples/unit_commitment.json
+++ b/examples/unit_commitment.json
@@ -872,7 +872,7 @@
         [
             "connection__from_node__user_constraint",
             "coefficient_for_connection_flow",
-            0.0,
+            null,
             null,
             "Defines the user constraint coefficient on the connection flow variable in the from direction."
         ],
@@ -1036,21 +1036,21 @@
         [
             "connection__to_node__user_constraint",
             "coefficient_for_connection_flow",
-            0.0,
+            null,
             null,
             "Defines the user constraint coefficient on the connection flow variable in the to direction."
         ],
         [
             "connection__user_constraint",
             "coefficient_for_connections_invested",
-            0.0,
+            null,
             null,
             "Coefficient of `connections_invested` in the specific `user_constraint`"
         ],
         [
             "connection__user_constraint",
             "coefficient_for_connections_invested_available",
-            0.0,
+            null,
             null,
             "Coefficient of `connections_invested_available` in the specific `user_constraint`"
         ],
@@ -2011,28 +2011,28 @@
         [
             "node__user_constraint",
             "coefficient_for_demand",
-            0.0,
+            null,
             null,
             "Coefficient of the specified node's demand in the specified user constraint."
         ],
         [
             "node__user_constraint",
             "coefficient_for_node_state",
-            0.0,
+            null,
             null,
             "Coefficient of the specified node's state variable in the specified user constraint."
         ],
         [
             "node__user_constraint",
             "coefficient_for_storages_invested",
-            0.0,
+            null,
             null,
             "Coefficient of the specified node's storage investment variable in the specified user constraint."
         ],
         [
             "node__user_constraint",
             "coefficient_for_storages_invested_available",
-            0.0,
+            null,
             null,
             "Coefficient of the specified node's storages invested available variable in the specified user constraint."
         ],
@@ -2056,6 +2056,13 @@
             null,
             null,
             "Database url for SpineOpt output."
+        ],
+        [
+            "report__output",
+            "output_resolution",
+            null,
+            null,
+            "Temporal resolution of the output for this specific report. Overrides the output-level output_resolution if set."
         ],
         [
             "report__output",
@@ -2636,28 +2643,28 @@
         [
             "unit__user_constraint",
             "coefficient_for_units_invested",
-            0.0,
+            null,
             null,
             "Coefficient of the `units_invested` variable in the specified `user_constraint`."
         ],
         [
             "unit__user_constraint",
             "coefficient_for_units_invested_available",
-            0.0,
+            null,
             null,
             "Coefficient of the `units_invested_available` variable in the specified `user_constraint`."
         ],
         [
             "unit__user_constraint",
             "coefficient_for_units_on",
-            0.0,
+            null,
             null,
             "Coefficient of a `units_on` variable for a custom `user_constraint`."
         ],
         [
             "unit__user_constraint",
             "coefficient_for_units_started_up",
-            0.0,
+            null,
             null,
             "Coefficient of a `units_started_up` variable for a custom `user_constraint`."
         ],
@@ -2713,7 +2720,7 @@
         [
             "unit_flow__user_constraint",
             "coefficient_for_unit_flow",
-            0.0,
+            null,
             null,
             "Coefficient of a `unit_flow` variable for a custom `user_constraint`."
         ],

--- a/templates/spineopt_template.json
+++ b/templates/spineopt_template.json
@@ -3123,6 +3123,13 @@
         ],
         [
             "report__output",
+            "output_resolution",
+            null,
+            null,
+            "Temporal resolution of the output for this specific report. Overrides the output-level output_resolution if set."
+        ],
+        [
+            "report__output",
             "overwrite_results_on_rolling",
             true,
             "boolean_value_list",


### PR DESCRIPTION
Reintroduce the `report__output` `output_resolution` parameter that was accidentally removed in the input datastructure update.

## Checklist before merging
- [x] Documentation is up-to-date
- [x] Unit tests have been added/updated accordingly (unnecessary)
- [ ] improved [type stability](https://modernjuliaworkflows.org/optimizing/#type_stability) or, when outside the scope of the pull request, at least indicated where and how the code is not properly typed
- [x] Code has been formatted according to SpineOpt's style
- [ ] Unit tests pass
